### PR TITLE
fix(prod): expose Qdrant and API on localhost for host-run scripts

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,10 +20,9 @@ services:
   qdrant:
     image: qdrant/qdrant:latest
     container_name: qdrant
-    # Internal only - external access through Caddy HTTPS at /db/
-    # Port 6333 NOT exposed to host for security (API key over HTTP is insecure)
-    expose:
-      - "6333"
+    # Prod: 127.0.0.1 only — host access for admin/scripts; not on public interface
+    ports:
+      - "127.0.0.1:6333:6333"
     environment:
       - QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY}
     volumes:
@@ -131,9 +130,9 @@ services:
       target: runtime
     image: evidencelab-ai-python:latest
     container_name: api
-    # Not exposed to host; only visible to nginx (UI container)
-    expose:
-      - "8000"
+    # Prod: 127.0.0.1 only — host access for scripts (e.g. verify_search_performance); not public
+    ports:
+      - "127.0.0.1:8000:8000"
     volumes:
       - ${DATA_MOUNT_PATH:-./data}:/app/data
       - ${CACHE_MOUNT_PATH:-/mnt/data/cache}/huggingface:/root/.cache/huggingface
@@ -228,7 +227,7 @@ services:
     depends_on:
       - api
       - ui
-      - db
+      - qdrant
       - postgres
     deploy:
       resources:


### PR DESCRIPTION
## Description
Expose Qdrant (6333) and API (8000) on localhost only in production so performance scripts can run from the host. Add retries, fallbacks, and a short connect timeout to `verify_qdrant_performance.py` so it does not hang when Qdrant is slow or unreachable.

- **docker-compose.prod.yml**: Bind Qdrant to `127.0.0.1:6333` and API to `127.0.0.1:8000` (host-only; not on public interface).
- **verify_qdrant_performance.py**: When not in Docker, try primary host then fallback to `http://127.0.0.1:6333` and `http://localhost:6333`; use 15s connect timeout to avoid long hangs; retry on connection refused/reset/timeout; treat timeouts as retryable.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other: ___

## Testing
- [x] Pre-commit passes (including code-metrics)
- [x] Manual: `python scripts/performance/verify_qdrant_performance.py` and `verify_search_performance.py` reach Qdrant/API on localhost
- [ ] Unit tests (Docker build blocked by caddy_config permission in this env)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [ ] Documentation updated
- [x] No breaking changes (or clearly documented)

Made with [Cursor](https://cursor.com)