### PR TITLE
fix(deps): downgrade onnxruntime to 1.23.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       # Ignore major version updates (may have breaking changes)
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # Pin onnxruntime - v1.24+ has compatibility issues
+      - dependency-name: "onnxruntime"
 
   # NPM dependencies for frontend
   - package-ecosystem: "npm"

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ rapidocr-onnxruntime==1.4.4
 rapidocr==3.6.0
 
 # ONNX runtime for model inference
-onnxruntime==1.24.1
+onnxruntime==1.23.2
 
 # Embeddings and vector DB
 sentence-transformers==2.7.0


### PR DESCRIPTION
## Summary
- Downgrades onnxruntime from 1.24.1 to 1.23.2 due to compatibility issues with v1.24+
- Pins onnxruntime in dependabot config to prevent automatic upgrades

## Test plan
- [ ] CI passes with onnxruntime 1.23.2