### PR TITLE
ops(prod): increase API memory limit from 6G to 8G

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,7 +11,7 @@
 #
 # Memory limits prevent pipeline OOM from crashing UI/API:
 #   - Pipeline: NOT STARTED in production (disabled)
-#   - API: 6GB (1 worker)
+#   - API: 8GB (1 worker)
 #   - Qdrant: 15GB (vector DB)
 #   - UI/Caddy: minimal (static serving)
 
@@ -177,7 +177,7 @@ services:
     deploy:
       resources:
         limits:
-          memory: 6G
+          memory: 8G
         reservations:
           memory: 2G
 


### PR DESCRIPTION
## Description

Increase the production API container memory limit from 6GB to 8GB to accommodate heatmap queries that now return uncapped document counts.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other: ___

## Testing
- [x] Tests pass locally
- [x] Manual testing completed

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] No breaking changes (or clearly documented)