### PR TITLE
fix(sanitization): add NFD normalization for unicode filenames

### DIFF
--- a/pipeline/utilities/sanitization.py
+++ b/pipeline/utilities/sanitization.py
@@ -1,6 +1,7 @@
 """Filename sanitization helpers."""
 
 import re
+import unicodedata
 
 
 def sanitize_filename(filename: str) -> str:
@@ -20,11 +21,14 @@ def sanitize_filename(filename: str) -> str:
     # Lowercase
     clean = filename.lower()
 
+    # Decompose unicode so accented chars become base letter + combining mark
+    clean = unicodedata.normalize("NFD", clean)
+
     # Replace spaces with underscores
     clean = clean.replace(" ", "_")
 
     # Keep only alphanumeric, underscores, hyphens, and dots
-    # This also effectively removes other special chars
+    # Combining marks from NFD decomposition are stripped, base letters kept
     clean = re.sub(r"[^a-z0-9_.-]", "", clean)
 
     # Collapse multiple underscores


### PR DESCRIPTION
## Summary
- Adds `unicodedata.normalize("NFD", ...)` before the regex strip in `sanitize_filename()`
- Without NFD, NFC-composed characters like `é` (single codepoint) are stripped entirely, losing the base letter
- With NFD, `é` decomposes into `e` + combining accent → regex strips only the accent, preserves `e`
- Fixes file-not-found errors for documents with accented characters in titles (e.g. Chad évaluation)

## Test plan
- [ ] Verify `sanitize_filename("évaluation")` returns `evaluation` (not `valuation`)
- [ ] Verify `sanitize_filename("naïve café")` returns `naive_cafe`
- [ ] Confirm existing ASCII-only filenames are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)