### PR TITLE
fix(parser): set download_error when PDF file not found

### DIFF
--- a/pipeline/processors/parsing/parser.py
+++ b/pipeline/processors/parsing/parser.py
@@ -497,9 +497,18 @@ class ParseProcessor(BaseProcessor):
         filepath = self._resolve_data_filepath(filepath)
 
         if not os.path.exists(filepath):
-            return self._build_parse_failure(
-                doc, "File not found", error_detail=f"File not found: {filepath}"
+            stage_updates = self.build_stage_updates(
+                doc, success=False, error="File not found"
             )
+            return {
+                "success": False,
+                "updates": {
+                    "sys_status": "download_error",
+                    "sys_error_message": f"File not found: {filepath}",
+                    **stage_updates,
+                },
+                "error": f"File not found: {filepath}",
+            }
 
         # Convert DOC/DOCX to PDF (Linux) or proper DOCX (Mac) if needed
         original_filepath = filepath


### PR DESCRIPTION
## Summary
- When the parser can't find a PDF on disk, it now returns `download_error` status instead of `parse_failed`
- This correctly distinguishes missing files (download/storage issue) from actual parsing failures
- Prevents the orchestrator from retrying parses on files that were never downloaded

## Test plan
- [ ] Verify a doc with a missing PDF file gets `sys_status = 'download_error'`
- [ ] Verify actual parse failures (corrupt PDF, timeout) still get `parse_failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)