### PR TITLE
fix(indexer): reject chunks exceeding embedding model token limit

### DIFF
--- a/pipeline/db/config.py
+++ b/pipeline/db/config.py
@@ -80,67 +80,71 @@ DENSE_VECTOR_SIZE = 1024
 SPARSE_VECTOR_NAME = "bm25"  # Just in case
 
 
+def _load_embedding_models(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Build DB_VECTORS dict from supported_embedding_models config."""
+    result: Dict[str, Dict[str, Any]] = {}
+    for model_name, model_info in config.get("supported_embedding_models", {}).items():
+        if model_info.get("type") != "dense":
+            continue
+        vec_entry: Dict[str, Any] = {
+            "size": model_info["size"],
+            "enabled": True,
+            "model_id": model_info["model_id"],
+            "source": model_info.get("source", "huggingface"),
+        }
+        if "max_tokens" in model_info:
+            vec_entry["max_tokens"] = model_info["max_tokens"]
+        result[model_name] = vec_entry
+    return result
+
+
+def _load_llms(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Build SUPPORTED_LLMS dict from supported_llms config."""
+    result: Dict[str, Dict[str, Any]] = {}
+    for model_name, model_info in config.get("supported_llms", {}).items():
+        llm_config: Dict[str, Any] = {
+            "model": model_info.get("model"),
+            "provider": model_info.get("provider", "huggingface"),
+        }
+        if "inference_provider" in model_info:
+            llm_config["inference_provider"] = model_info.get("inference_provider")
+        result[model_name] = llm_config
+    return result
+
+
+def _load_rerank_models(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Build SUPPORTED_RERANK_MODELS dict from supported_rerank_models config."""
+    result: Dict[str, Dict[str, Any]] = {}
+    for model_name, model_info in config.get("supported_rerank_models", {}).items():
+        result[model_name] = {
+            "api_version": model_info.get("api_version"),
+            "endpoint": model_info.get("endpoint"),
+            "endpoint_url": model_info.get("endpoint_url"),
+            "model_id": model_info.get("model_id", model_name),
+            "source": model_info.get("source", "huggingface"),
+            "provider": model_info.get("provider"),
+        }
+    return result
+
+
 def refresh_config() -> None:
     """Reload config-driven settings for vectors and LLMs."""
     global _config, _app_config, _search_config, _datasources_config
-    global DB_VECTORS
-    global SUPPORTED_LLMS
-    global SUPPORTED_RERANK_MODELS
-    global UI_MODEL_COMBOS
-    global DENSE_VECTOR_NAME
-    global DENSE_VECTOR_SIZE
+    global DB_VECTORS, SUPPORTED_LLMS, SUPPORTED_RERANK_MODELS, UI_MODEL_COMBOS
+    global DENSE_VECTOR_NAME, DENSE_VECTOR_SIZE
 
     _datasources_config = {}
     _config = load_datasources_config()
 
-    DB_VECTORS = {}
-    if "supported_embedding_models" in _config:
-        for model_name, model_info in _config["supported_embedding_models"].items():
-            if model_info.get("type") == "dense":
-                vec_entry: Dict[str, Any] = {
-                    "size": model_info["size"],
-                    "enabled": True,  # Default to enabled
-                    "model_id": model_info["model_id"],
-                    "source": model_info.get("source", "huggingface"),
-                }
-                if "max_tokens" in model_info:
-                    vec_entry["max_tokens"] = model_info["max_tokens"]
-                DB_VECTORS[model_name] = vec_entry
-
-    SUPPORTED_LLMS = {}
-    if "supported_llms" in _config:
-        for model_name, model_info in _config["supported_llms"].items():
-            llm_config: Dict[str, Any] = {
-                "model": model_info.get("model"),
-                "provider": model_info.get("provider", "huggingface"),
-            }
-            # Add inference_provider if present
-            if "inference_provider" in model_info:
-                llm_config["inference_provider"] = model_info.get("inference_provider")
-            SUPPORTED_LLMS[model_name] = llm_config
-
-    SUPPORTED_RERANK_MODELS = {}
-    if "supported_rerank_models" in _config:
-        for model_name, model_info in _config["supported_rerank_models"].items():
-            SUPPORTED_RERANK_MODELS[model_name] = {
-                "api_version": model_info.get("api_version"),
-                "endpoint": model_info.get("endpoint"),
-                "endpoint_url": model_info.get("endpoint_url"),
-                "model_id": model_info.get("model_id", model_name),
-                "source": model_info.get("source", "huggingface"),
-                "provider": model_info.get("provider"),
-            }
-
-    UI_MODEL_COMBOS = {}
-    if "ui_model_combos" in _config:
-        UI_MODEL_COMBOS = _config.get("ui_model_combos", {})
+    DB_VECTORS = _load_embedding_models(_config)
+    SUPPORTED_LLMS = _load_llms(_config)
+    SUPPORTED_RERANK_MODELS = _load_rerank_models(_config)
+    UI_MODEL_COMBOS = _config.get("ui_model_combos", {})
 
     _app_config = _config.get("application", {})
     _search_config = _app_config.get("search", {})
     DENSE_VECTOR_NAME = _search_config.get("default_dense_model", "e5_large")
-    DENSE_VECTOR_SIZE = 1024
-    if DENSE_VECTOR_NAME in DB_VECTORS:
-        DENSE_VECTOR_SIZE = DB_VECTORS[DENSE_VECTOR_NAME]["size"]
+    DENSE_VECTOR_SIZE = DB_VECTORS.get(DENSE_VECTOR_NAME, {}).get("size", 1024)
 
     if "ui_model_combos" in _config:
         from utils.config_validator import validate_ui_model_combos  # noqa: PLC0415

--- a/pipeline/processors/indexing/indexer.py
+++ b/pipeline/processors/indexing/indexer.py
@@ -335,16 +335,16 @@ class IndexProcessor(BaseProcessor):
         max_chars = getattr(
             self, "_max_embed_chars", _DEFAULT_MAX_EMBED_TOKENS * _CHARS_PER_TOKEN
         )
+        oversized = []
         for i, chunk in enumerate(valid_chunks):
             text = chunk.get("text", "")
             if len(text) > max_chars:
-                logger.warning(
-                    "Chunk %d truncated from %d to %d chars (embedding model limit)",
-                    i,
-                    len(text),
-                    max_chars,
-                )
-                chunk["text"] = text[:max_chars]
+                oversized.append(f"Chunk {i}: {len(text)} chars (limit {max_chars})")
+        if oversized:
+            details = "; ".join(oversized)
+            raise ValueError(
+                f"{len(oversized)} chunk(s) exceed embedding model limit: {details}"
+            )
         return valid_chunks
 
     def _build_batches(

--- a/tests/unit/test_indexer_truncation.py
+++ b/tests/unit/test_indexer_truncation.py
@@ -1,12 +1,14 @@
 """
-Unit tests for IndexProcessor chunk truncation and max_embed_chars computation.
+Unit tests for IndexProcessor chunk validation and max_embed_chars computation.
 
 Tests cover:
 - _compute_max_embed_chars: config-driven character limit derivation
-- _filter_valid_chunks: empty-chunk filtering and oversized-chunk truncation
+- _filter_valid_chunks: empty-chunk filtering and oversized-chunk rejection
 """
 
 from unittest.mock import patch
+
+import pytest
 
 from pipeline.processors.indexing.indexer import (
     _CHARS_PER_TOKEN,
@@ -83,7 +85,7 @@ class TestComputeMaxEmbedChars:
 
 
 class TestFilterValidChunks:
-    """Test _filter_valid_chunks removes empty chunks and truncates oversized ones."""
+    """Test _filter_valid_chunks removes empty chunks and rejects oversized ones."""
 
     def _make_processor(self, max_embed_chars=None):
         with patch("pipeline.processors.indexing.indexer.get_db"), patch(
@@ -108,17 +110,16 @@ class TestFilterValidChunks:
         assert result[0]["text"] == "valid text"
         assert result[1]["text"] == "also valid"
 
-    def test_truncates_oversized_chunks(self):
-        """Chunks exceeding max_embed_chars are truncated."""
+    def test_rejects_oversized_chunks(self):
+        """Chunks exceeding max_embed_chars raise ValueError."""
         max_chars = 100
         proc = self._make_processor(max_embed_chars=max_chars)
         long_text = "x" * 500
         chunks = [{"text": long_text}]
-        result = proc._filter_valid_chunks(chunks)
-        assert len(result) == 1
-        assert len(result[0]["text"]) == max_chars
+        with pytest.raises(ValueError, match="exceed embedding model limit"):
+            proc._filter_valid_chunks(chunks)
 
-    def test_does_not_truncate_short_chunks(self):
+    def test_does_not_reject_short_chunks(self):
         """Chunks within the limit are left unchanged."""
         proc = self._make_processor(max_embed_chars=1000)
         text = "short chunk"
@@ -126,8 +127,8 @@ class TestFilterValidChunks:
         result = proc._filter_valid_chunks(chunks)
         assert result[0]["text"] == text
 
-    def test_truncation_at_exact_boundary(self):
-        """A chunk exactly at the limit is not truncated."""
+    def test_exact_boundary_passes(self):
+        """A chunk exactly at the limit is not rejected."""
         max_chars = 50
         proc = self._make_processor(max_embed_chars=max_chars)
         text = "a" * max_chars
@@ -135,8 +136,8 @@ class TestFilterValidChunks:
         result = proc._filter_valid_chunks(chunks)
         assert len(result[0]["text"]) == max_chars
 
-    def test_mixed_chunks_only_oversized_truncated(self):
-        """Only oversized chunks are truncated; short ones are untouched."""
+    def test_mixed_chunks_oversized_causes_failure(self):
+        """Any oversized chunk causes the entire batch to fail."""
         max_chars = 100
         proc = self._make_processor(max_embed_chars=max_chars)
         chunks = [
@@ -145,19 +146,14 @@ class TestFilterValidChunks:
             {"text": "normal length text here"},
             {"text": "z" * 300},
         ]
-        result = proc._filter_valid_chunks(chunks)
-        assert len(result) == 4
-        assert result[0]["text"] == "short"
-        assert len(result[1]["text"]) == max_chars
-        assert result[2]["text"] == "normal length text here"
-        assert len(result[3]["text"]) == max_chars
+        with pytest.raises(ValueError, match="2 chunk\\(s\\) exceed"):
+            proc._filter_valid_chunks(chunks)
 
     def test_uses_default_when_no_max_embed_chars_attr(self):
         """Falls back to _DEFAULT_MAX_EMBED_TOKENS * _CHARS_PER_TOKEN."""
         proc = self._make_processor()
-        # Don't set _max_embed_chars — should use default
         default_limit = _DEFAULT_MAX_EMBED_TOKENS * _CHARS_PER_TOKEN
         text = "a" * (default_limit + 100)
         chunks = [{"text": text}]
-        result = proc._filter_valid_chunks(chunks)
-        assert len(result[0]["text"]) == default_limit
+        with pytest.raises(ValueError, match="exceed embedding model limit"):
+            proc._filter_valid_chunks(chunks)


### PR DESCRIPTION
## Summary
- Chunks exceeding the embedding model's token limit now raise `ValueError` instead of being silently truncated, preventing data loss
- Derives max character limit from the smallest `max_tokens` across configured embedding models
- Propagates `max_tokens` from `config.json` embedding model entries through `DB_VECTORS` registry
- Adds `max_tokens: 8192` to Azure text-embedding-3-small/large in config.json
- Refactors `config.py` `refresh_config()` to reduce cognitive complexity

## Root Cause
Docling's HybridChunker targets 450 E5-tokens but some content (large tables, raw GLYPH artifacts from bad PDF parsing) produces chunks of 11,000+ E5-tokens (~20,000 chars). These exceed Azure's text-embedding-3-small 8,192 token hard limit, causing 422 errors and `index_failed` status.

## Test plan
- [x] 12 unit tests in `tests/unit/test_indexer_truncation.py` (6 for `_compute_max_embed_chars`, 6 for `_filter_valid_chunks`)
- [x] All pre-commit hooks pass including code-metrics
- [x] Oversized chunks now cause a clear `ValueError` failure instead of silent data loss

🤖 Generated with [Claude Code](https://claude.com/claude-code)