### PR TITLE
fix(pipeline): use config timeout for workers, raise summarizer chunk limit

### DIFF
--- a/pipeline/db/config.py
+++ b/pipeline/db/config.py
@@ -80,67 +80,71 @@ DENSE_VECTOR_SIZE = 1024
 SPARSE_VECTOR_NAME = "bm25"  # Just in case
 
 
+def _load_embedding_models(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Build DB_VECTORS dict from supported_embedding_models config."""
+    result: Dict[str, Dict[str, Any]] = {}
+    for model_name, model_info in config.get("supported_embedding_models", {}).items():
+        if model_info.get("type") != "dense":
+            continue
+        vec_entry: Dict[str, Any] = {
+            "size": model_info["size"],
+            "enabled": True,
+            "model_id": model_info["model_id"],
+            "source": model_info.get("source", "huggingface"),
+        }
+        if "max_tokens" in model_info:
+            vec_entry["max_tokens"] = model_info["max_tokens"]
+        result[model_name] = vec_entry
+    return result
+
+
+def _load_llms(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Build SUPPORTED_LLMS dict from supported_llms config."""
+    result: Dict[str, Dict[str, Any]] = {}
+    for model_name, model_info in config.get("supported_llms", {}).items():
+        llm_config: Dict[str, Any] = {
+            "model": model_info.get("model"),
+            "provider": model_info.get("provider", "huggingface"),
+        }
+        if "inference_provider" in model_info:
+            llm_config["inference_provider"] = model_info.get("inference_provider")
+        result[model_name] = llm_config
+    return result
+
+
+def _load_rerank_models(config: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Build SUPPORTED_RERANK_MODELS dict from supported_rerank_models config."""
+    result: Dict[str, Dict[str, Any]] = {}
+    for model_name, model_info in config.get("supported_rerank_models", {}).items():
+        result[model_name] = {
+            "api_version": model_info.get("api_version"),
+            "endpoint": model_info.get("endpoint"),
+            "endpoint_url": model_info.get("endpoint_url"),
+            "model_id": model_info.get("model_id", model_name),
+            "source": model_info.get("source", "huggingface"),
+            "provider": model_info.get("provider"),
+        }
+    return result
+
+
 def refresh_config() -> None:
     """Reload config-driven settings for vectors and LLMs."""
     global _config, _app_config, _search_config, _datasources_config
-    global DB_VECTORS
-    global SUPPORTED_LLMS
-    global SUPPORTED_RERANK_MODELS
-    global UI_MODEL_COMBOS
-    global DENSE_VECTOR_NAME
-    global DENSE_VECTOR_SIZE
+    global DB_VECTORS, SUPPORTED_LLMS, SUPPORTED_RERANK_MODELS, UI_MODEL_COMBOS
+    global DENSE_VECTOR_NAME, DENSE_VECTOR_SIZE
 
     _datasources_config = {}
     _config = load_datasources_config()
 
-    DB_VECTORS = {}
-    if "supported_embedding_models" in _config:
-        for model_name, model_info in _config["supported_embedding_models"].items():
-            if model_info.get("type") == "dense":
-                vec_entry: Dict[str, Any] = {
-                    "size": model_info["size"],
-                    "enabled": True,  # Default to enabled
-                    "model_id": model_info["model_id"],
-                    "source": model_info.get("source", "huggingface"),
-                }
-                if "max_tokens" in model_info:
-                    vec_entry["max_tokens"] = model_info["max_tokens"]
-                DB_VECTORS[model_name] = vec_entry
-
-    SUPPORTED_LLMS = {}
-    if "supported_llms" in _config:
-        for model_name, model_info in _config["supported_llms"].items():
-            llm_config: Dict[str, Any] = {
-                "model": model_info.get("model"),
-                "provider": model_info.get("provider", "huggingface"),
-            }
-            # Add inference_provider if present
-            if "inference_provider" in model_info:
-                llm_config["inference_provider"] = model_info.get("inference_provider")
-            SUPPORTED_LLMS[model_name] = llm_config
-
-    SUPPORTED_RERANK_MODELS = {}
-    if "supported_rerank_models" in _config:
-        for model_name, model_info in _config["supported_rerank_models"].items():
-            SUPPORTED_RERANK_MODELS[model_name] = {
-                "api_version": model_info.get("api_version"),
-                "endpoint": model_info.get("endpoint"),
-                "endpoint_url": model_info.get("endpoint_url"),
-                "model_id": model_info.get("model_id", model_name),
-                "source": model_info.get("source", "huggingface"),
-                "provider": model_info.get("provider"),
-            }
-
-    UI_MODEL_COMBOS = {}
-    if "ui_model_combos" in _config:
-        UI_MODEL_COMBOS = _config.get("ui_model_combos", {})
+    DB_VECTORS = _load_embedding_models(_config)
+    SUPPORTED_LLMS = _load_llms(_config)
+    SUPPORTED_RERANK_MODELS = _load_rerank_models(_config)
+    UI_MODEL_COMBOS = _config.get("ui_model_combos", {})
 
     _app_config = _config.get("application", {})
     _search_config = _app_config.get("search", {})
     DENSE_VECTOR_NAME = _search_config.get("default_dense_model", "e5_large")
-    DENSE_VECTOR_SIZE = 1024
-    if DENSE_VECTOR_NAME in DB_VECTORS:
-        DENSE_VECTOR_SIZE = DB_VECTORS[DENSE_VECTOR_NAME]["size"]
+    DENSE_VECTOR_SIZE = DB_VECTORS.get(DENSE_VECTOR_NAME, {}).get("size", 1024)
 
     if "ui_model_combos" in _config:
         from utils.config_validator import validate_ui_model_combos  # noqa: PLC0415

--- a/pipeline/orchestrator/core_processing.py
+++ b/pipeline/orchestrator/core_processing.py
@@ -164,9 +164,11 @@ def _process_docs_parallel(orchestrator, docs_to_process: list, stats: Dict[str,
 
         logger.info("Submitted %s tasks to pool...", len(pending_results))
 
+        worker_timeout = orchestrator.pipeline_config.get("processing_timeout", 7200)
+
         for doc_id, (res, doc) in pending_results.items():
             try:
-                result = res.get(timeout=600)
+                result = res.get(timeout=worker_timeout)
 
                 stats["processed"] += 1
 

--- a/pipeline/orchestrator/worker.py
+++ b/pipeline/orchestrator/worker.py
@@ -42,7 +42,7 @@ def _wait_for_available_memory() -> Optional[str]:
         mem = psutil.virtual_memory()
         if mem.available > 2 * 1024 * 1024 * 1024:  # 2GB
             return None
-        if time.time() - start_wait > 600:  # 10 min timeout
+        if time.time() - start_wait > 3600:  # 1 hour timeout
             return "OOM Protection: Timeout waiting for memory"
         time.sleep(random.uniform(5, 15))
 

--- a/pipeline/processors/summarization/summarizer.py
+++ b/pipeline/processors/summarization/summarizer.py
@@ -519,7 +519,7 @@ class SummarizeProcessor(BaseProcessor):
         # prevent infinite recursion if we can't split it further meaningfuly.
         # But here _split_chunks uses strict sizing, so it should always split.
 
-        if len(chunks) > 50:  # Increased safety limit
+        if len(chunks) > 200:  # Safety limit for extremely large documents
             logger.warning("  Too many chunks (%s) - will use centroid", len(chunks))
             return "USE_CENTROID", None
 


### PR DESCRIPTION
## Summary
- Worker pool timeout was hardcoded at 600s, now reads `processing_timeout` from pipeline config (default 7200s)
- Memory wait timeout increased from 600s to 3600s to handle large documents without false OOM timeouts
- Map-reduce summarizer chunk limit raised from 50 to 200 to support large documents without falling back to centroid

## Root Cause
- Large documents (e.g., 200+ page PDFs) could take over 10 minutes to process, hitting the hardcoded 600s timeout even though config specified 7200s
- Memory wait timeout of 10 minutes was too short for systems processing multiple large documents
- Summarizer's 50-chunk limit caused unnecessary fallback to centroid method for documents with 50-200 chunks

## Test plan
- [x] All pre-commit hooks pass including code-metrics
- [x] Verified large documents process successfully with config-driven timeout
- [x] Verified 93-chunk document summarizes via map-reduce instead of centroid fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)