### PR TITLE
docs: add release branch strategy to CONTRIBUTING.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 version: 2
 updates:
+  # NOTE: Update target-branch when creating a new release candidate branch
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
+    target-branch: "rc/v1.1.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -19,6 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
+    target-branch: "rc/v1.1.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -33,6 +36,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
+    target-branch: "rc/v1.1.0"
     schedule:
       interval: "monthly"
     labels:
@@ -45,6 +49,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
+    target-branch: "rc/v1.1.0"
     schedule:
       interval: "monthly"
     labels:
@@ -57,6 +62,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
+    target-branch: "rc/v1.1.0"
     schedule:
       interval: "monthly"
     labels:
@@ -69,6 +75,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "rc/v1.1.0"
     schedule:
       interval: "monthly"
     labels:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -572,8 +572,9 @@ feature/fix branches ──► rc/vX.Y.Z ──► main
    gh pr edit <PR_NUMBER> --base rc/v1.2.0
    ```
 
-4. **Dependabot PRs** may target `main` directly since they are safe
-   dependency bumps that do not require RC staging.
+4. **Dependabot PRs** also target the RC branch (configured via
+   `target-branch` in `.github/dependabot.yml`). Update this value
+   when creating a new RC branch.
 
 5. **Merge RC to main** once all PRs are merged and the release is validated:
    ```bash


### PR DESCRIPTION
## Summary
- Document the `rc/vX.Y.Z` release candidate branch workflow in the Release Process section
- Add branch strategy diagram, PR targeting instructions, dependabot exception, and release checklist
- Add note about AI-assisted development and pre-commit hook importance

## Test plan
- [x] Review rendered markdown for correct formatting