### PR TITLE
fix(tests): align OOM timeout test with 3600s worker timeout

### DIFF
--- a/tests/unit/test_orchestrator_utils.py
+++ b/tests/unit/test_orchestrator_utils.py
@@ -29,7 +29,7 @@ def test_process_document_wrapper_times_out_on_low_memory(monkeypatch):
     monkeypatch.setattr(orchestrator.random, "uniform", lambda *_: 0)
     monkeypatch.setattr(orchestrator.time, "sleep", lambda *_: None)
 
-    times = iter([0, 601])
+    times = iter([0, 3601])
     monkeypatch.setattr(orchestrator.time, "time", lambda: next(times))
 
     result = orchestrator.process_document_wrapper({"id": "doc-2", "title": "Title"})


### PR DESCRIPTION
## Summary
- The memory wait timeout in `_wait_for_available_memory` is 3600s but the test iterator only provided `[0, 601]`, causing `StopIteration` on the third `time.time()` call
- Updated test to use `[0, 3601]` to correctly exceed the timeout threshold

## Test plan
- [ ] CI `tests` job passes (this is the fix for the failing test)