### PR TITLE
fix(tagger): add retry with backoff for transient LLM API errors

### DIFF
--- a/pipeline/processors/tagging/tagger_llm.py
+++ b/pipeline/processors/tagging/tagger_llm.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import math
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -210,7 +211,27 @@ def invoke_and_parse_toc(
         messages.append(SystemMessage(content=additional_instruction))
     messages.append(HumanMessage(content=user_prompt))
 
-    response = llm.invoke(messages)
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            response = llm.invoke(messages)
+            break
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            if attempt < max_retries - 1:
+                wait = 2**attempt
+                logger.warning(
+                    "LLM invoke failed (attempt %d/%d), retrying in %ds: %s",
+                    attempt + 1,
+                    max_retries,
+                    wait,
+                    exc,
+                )
+                time.sleep(wait)
+            else:
+                logger.error(
+                    "LLM invoke failed after %d attempts: %s", max_retries, exc
+                )
+                return None
     response_text = str(response.content).strip()
 
     try:


### PR DESCRIPTION
## Summary
- Add retry loop (3 attempts, exponential backoff) around `llm.invoke()` in `invoke_and_parse_toc`
- Handles transient HTTP errors (e.g. HuggingFace 500) that were causing CI test failures
- Returns `None` after exhausting retries, allowing the existing retry-on-failure logic to kick in

## Test plan
- [ ] Unit tests pass (no more flaky failures from transient API errors)
- [ ] TOC classification test passes reliably in CI