### PR TITLE
fix(parser): pypdf fallback for glyph-contaminated PDFs

### DIFF
--- a/pipeline/processors/parsing/parser.py
+++ b/pipeline/processors/parsing/parser.py
@@ -15,6 +15,7 @@ import logging
 import multiprocessing
 import os
 import platform
+import re
 import shutil
 import subprocess
 import tempfile
@@ -36,6 +37,7 @@ from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
 from docling_core.types.doc import DoclingDocument, ImageRefMode
 from langdetect import detect_langs
+from pypdf import PdfReader
 
 from pipeline.processors.base import BaseProcessor
 from pipeline.processors.parsing.parser_chunking import (
@@ -978,6 +980,8 @@ class ParseProcessor(BaseProcessor):
     ) -> Tuple[str, int]:
         """Finalize parsing artifacts and return toc/word_count."""
         self._clean_markdown_file(markdown_path)
+        if Path(filepath).suffix.lower() == ".pdf":
+            self._fix_glyph_contamination(markdown_path, filepath)
 
         json_path = Path(output_folder) / f"{markdown_path.stem}.json"
         result.document.save_as_json(json_path)
@@ -1034,6 +1038,57 @@ class ParseProcessor(BaseProcessor):
 
         except Exception as e:
             logger.warning("  ⚠ Failed to clean markdown file: %s", e)
+
+    _GLYPH_PATTERN = re.compile(r"/gid\d{5}")
+    _GLYPH_THRESHOLD = 0.30  # 30% glyph content triggers fallback
+
+    def _fix_glyph_contamination(self, markdown_path: Path, pdf_path: str) -> bool:
+        """Detect glyph-ID contamination and rebuild markdown from pypdf if needed.
+
+        Returns True if fallback was applied.
+        """
+        try:
+            with open(markdown_path, "r", encoding="utf-8") as f:
+                content = f.read()
+        except OSError:
+            return False
+
+        total = len(content)
+        if total < 200:
+            return False
+
+        glyph_chars = len(self._GLYPH_PATTERN.findall(content)) * 9
+        ratio = glyph_chars / total
+        if ratio < self._GLYPH_THRESHOLD:
+            return False
+
+        logger.warning(
+            "  ⚠ Glyph contamination %.0f%% in %s — rebuilding with pypdf",
+            ratio * 100,
+            markdown_path.name,
+        )
+
+        try:
+            reader = PdfReader(pdf_path)
+            pages = []
+            for page in reader.pages:
+                text = page.extract_text() or ""
+                if text.strip():
+                    pages.append(text)
+            if not pages:
+                logger.warning("  ⚠ pypdf extracted no text, keeping original")
+                return False
+
+            rebuilt = PAGE_SEPARATOR.join(pages)
+            with open(markdown_path, "w", encoding="utf-8") as f:
+                f.write(rebuilt)
+            logger.info(
+                "  ✓ Rebuilt markdown via pypdf fallback (%d pages)", len(pages)
+            )
+            return True
+        except Exception as exc:
+            logger.warning("  ⚠ pypdf fallback failed: %s", exc)
+            return False
 
     def _add_page_numbers_to_breaks(self, markdown_path: Path, document) -> None:
         """Add page numbers to page break placeholders."""

--- a/tests/unit/test_parser_glyph_fallback.py
+++ b/tests/unit/test_parser_glyph_fallback.py
@@ -1,0 +1,137 @@
+"""
+Unit tests for ParseProcessor glyph contamination detection and pypdf fallback.
+
+Tests cover:
+- _fix_glyph_contamination: glyph detection threshold and pypdf rebuild
+"""
+
+from unittest.mock import MagicMock, patch
+
+from pipeline.processors.parsing.parser import ParseProcessor
+from pipeline.processors.parsing.parser_constants import PAGE_SEPARATOR
+
+
+def _make_parser():
+    """Create a ParseProcessor without initialising Docling converter."""
+    with patch.object(ParseProcessor, "setup"):
+        p = ParseProcessor.__new__(ParseProcessor)
+        p.name = "ParseProcessor"
+        return p
+
+
+class TestGlyphDetection:
+    """Test _fix_glyph_contamination detects and fixes glyph content."""
+
+    def test_no_glyphs_unchanged(self, tmp_path):
+        """Clean markdown should not be modified."""
+        md = tmp_path / "doc.md"
+        original = "This is a perfectly clean document with real text content."
+        md.write_text(original)
+
+        parser = _make_parser()
+        result = parser._fix_glyph_contamination(md, str(tmp_path / "doc.pdf"))
+
+        assert result is False
+        assert md.read_text() == original
+
+    def test_below_threshold_unchanged(self, tmp_path):
+        """Markdown with glyphs below 30% threshold should not trigger fallback."""
+        md = tmp_path / "doc.md"
+        real_text = "A" * 800
+        glyph_text = "/gid00028/gid01154" * 10  # 180 chars = ~18% of 980
+        original = real_text + glyph_text
+        md.write_text(original)
+
+        parser = _make_parser()
+        result = parser._fix_glyph_contamination(md, str(tmp_path / "doc.pdf"))
+
+        assert result is False
+        assert md.read_text() == original
+
+    @patch("pipeline.processors.parsing.parser.PdfReader")
+    def test_glyph_contamination_triggers_fallback(self, mock_reader_cls, tmp_path):
+        """Markdown with >30% glyphs should be rebuilt from pypdf."""
+        md = tmp_path / "doc.md"
+        # 90% glyphs
+        glyph_text = "/gid00028" * 100  # 900 chars
+        real_text = "X" * 100
+        md.write_text(glyph_text + real_text)
+
+        # Mock pypdf
+        mock_page1 = MagicMock()
+        mock_page1.extract_text.return_value = "Page one content here."
+        mock_page2 = MagicMock()
+        mock_page2.extract_text.return_value = "Page two content here."
+        mock_reader = MagicMock()
+        mock_reader.pages = [mock_page1, mock_page2]
+        mock_reader_cls.return_value = mock_reader
+
+        pdf_path = str(tmp_path / "doc.pdf")
+        parser = _make_parser()
+        result = parser._fix_glyph_contamination(md, pdf_path)
+
+        assert result is True
+        rebuilt = md.read_text()
+        assert "Page one content here." in rebuilt
+        assert "Page two content here." in rebuilt
+        assert PAGE_SEPARATOR in rebuilt
+        assert "/gid00028" not in rebuilt
+        mock_reader_cls.assert_called_once_with(pdf_path)
+
+    def test_non_pdf_not_called(self, tmp_path):
+        """The method itself works on any file, but the caller gates on .pdf.
+
+        Verify the method returns False for content without glyphs (simulating
+        a non-PDF that would never have glyph contamination).
+        """
+        md = tmp_path / "doc.md"
+        md.write_text("Normal DOCX content without any glyph patterns.")
+
+        parser = _make_parser()
+        result = parser._fix_glyph_contamination(md, str(tmp_path / "doc.docx"))
+
+        assert result is False
+
+    @patch("pipeline.processors.parsing.parser.PdfReader")
+    def test_pypdf_empty_keeps_original(self, mock_reader_cls, tmp_path):
+        """If pypdf extracts no text, keep the original markdown."""
+        md = tmp_path / "doc.md"
+        original = "/gid00028" * 200  # heavy glyphs
+        md.write_text(original)
+
+        mock_reader = MagicMock()
+        mock_page = MagicMock()
+        mock_page.extract_text.return_value = ""
+        mock_reader.pages = [mock_page]
+        mock_reader_cls.return_value = mock_reader
+
+        parser = _make_parser()
+        result = parser._fix_glyph_contamination(md, str(tmp_path / "doc.pdf"))
+
+        assert result is False
+        assert md.read_text() == original
+
+    @patch("pipeline.processors.parsing.parser.PdfReader")
+    def test_pypdf_exception_keeps_original(self, mock_reader_cls, tmp_path):
+        """If pypdf raises, keep the original markdown."""
+        md = tmp_path / "doc.md"
+        original = "/gid00028" * 200
+        md.write_text(original)
+
+        mock_reader_cls.side_effect = Exception("corrupt pdf")
+
+        parser = _make_parser()
+        result = parser._fix_glyph_contamination(md, str(tmp_path / "doc.pdf"))
+
+        assert result is False
+        assert md.read_text() == original
+
+    def test_short_content_skipped(self, tmp_path):
+        """Very short markdown files should be skipped."""
+        md = tmp_path / "doc.md"
+        md.write_text("/gid00028" * 5)  # 45 chars, below 200 min
+
+        parser = _make_parser()
+        result = parser._fix_glyph_contamination(md, str(tmp_path / "doc.pdf"))
+
+        assert result is False


### PR DESCRIPTION
## Summary
- Detects `/gidXXXXX` glyph contamination in parsed markdown (a known docling-parse bug, [docling#2334](https://github.com/docling-project/docling/issues/2334))
- When >30% of content is glyph IDs, re-extracts text page-by-page using pypdf and rebuilds the markdown
- Core docling processing is untouched — fallback only fires when contamination is detected
- Includes 7 unit tests covering detection threshold, pypdf rebuild, error handling, and edge cases

## Context
One WFP document (`interagency_humanitarian_evaluation_on_gender_equality_...`) parsed as 91% glyph IDs. The PDF is valid — pypdf extracts 62/69 pages perfectly. The fonts (`SourceSansVariable-Roman`) have proper ToUnicode CMaps but docling-parse can't resolve them. Unfixed even in docling-parse 5.4.0.

The glyph contamination caused downstream failures in summarization (LLM API 500 errors on garbage tokens) and would produce meaningless embeddings in indexing.

## Test plan
- [x] 7 unit tests pass (`pytest tests/unit/test_parser_glyph_fallback.py`)
- [x] All 366 existing unit tests still pass
- [ ] Re-parse affected document to verify glyph-free output
- [ ] Verify clean documents are unaffected (no fallback triggered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)