### PR TITLE
fix(indexer): add oversize_chunks_strategy config setting

### DIFF
--- a/config.json
+++ b/config.json
@@ -388,6 +388,7 @@
         "index": {
           "batch_size": 10,
           "embedding_workers": 1,
+          "oversize_chunks_strategy": "truncate",
           "dense_models": [
             "azure_small",
             "e5_large"

--- a/pipeline/processors/indexing/indexer.py
+++ b/pipeline/processors/indexing/indexer.py
@@ -128,6 +128,14 @@ class IndexProcessor(BaseProcessor):
 
         self.batch_size = self.index_config.get("batch_size", 10)
         self.embedding_workers = self.index_config.get("embedding_workers", 4)
+        # "stop" = raise on oversized chunks; "truncate" = trim to fit.
+        # Truncation mainly affects small-context models (e.g. e5_large 512
+        # tokens) where post-processing (heading prefix, footnotes) pushes
+        # chunks past the embedding limit.  Longer-context models are
+        # generally unaffected.
+        self.oversize_chunks_strategy = self.index_config.get(
+            "oversize_chunks_strategy", "truncate"
+        )
 
         self._dense_model = None
         self._sparse_model = None
@@ -343,17 +351,51 @@ class IndexProcessor(BaseProcessor):
                 "Ensure all embedding models have 'max_tokens' in config.json."
             )
         tokenizer = getattr(self, "_tokenizer", None)
+        strategy = self.oversize_chunks_strategy
         oversized = []
+        truncated_count = 0
         for i, chunk in enumerate(valid_chunks):
             text = chunk.get("text", "")
             if tokenizer is not None:
-                n_tokens = len(tokenizer.encode(text, add_special_tokens=False))
+                token_ids = tokenizer.encode(text, add_special_tokens=False)
+                n_tokens = len(token_ids)
             else:
                 n_tokens = len(text) // 4  # rough fallback
+                token_ids = None
             if n_tokens > max_tokens:
-                oversized.append(f"Chunk {i}: {n_tokens} tokens (limit {max_tokens})")
+                if strategy == "truncate":
+                    if tokenizer is not None and token_ids is not None:
+                        chunk["text"] = tokenizer.decode(
+                            token_ids[:max_tokens], skip_special_tokens=True
+                        )
+                    else:
+                        chunk["text"] = text[: max_tokens * 4]
+                    truncated_count += 1
+                    logger.warning(
+                        "Chunk %d truncated from %d to %d tokens.",
+                        i,
+                        n_tokens,
+                        max_tokens,
+                    )
+                else:
+                    oversized.append(
+                        f"Chunk {i}: {n_tokens} tokens (limit {max_tokens})"
+                    )
+        if truncated_count:
+            logger.warning(
+                "oversize_chunks_strategy=truncate: truncated %d chunk(s) "
+                "to fit embedding model limit (%d tokens).",
+                truncated_count,
+                max_tokens,
+            )
         if oversized:
             details = "; ".join(oversized)
+            logger.error(
+                "oversize_chunks_strategy=stop: %d chunk(s) exceed "
+                "embedding model limit (%d tokens).",
+                len(oversized),
+                max_tokens,
+            )
             raise ValueError(
                 f"{len(oversized)} chunk(s) exceed embedding model limit: {details}"
             )

--- a/scripts/pipeline/run_pipeline_host.sh
+++ b/scripts/pipeline/run_pipeline_host.sh
@@ -154,6 +154,14 @@ if [[ "$QDRANT_HOST" == *"//qdrant"* ]] || [[ "$QDRANT_HOST" == "qdrant" ]]; the
 fi
 
 export QDRANT_HOST=${QDRANT_HOST:-localhost}
+
+# Override Postgres host for local execution if it points to the docker service name
+if [[ "${POSTGRES_HOST:-}" == "postgres" ]]; then
+    echo "⚠️  Detected Docker service name 'postgres' in POSTGRES_HOST. Switching to 'localhost' for host execution."
+    export POSTGRES_HOST="localhost"
+fi
+export POSTGRES_HOST=${POSTGRES_HOST:-localhost}
+
 QDRANT_CURL_AUTH=()
 if [ -n "${QDRANT_API_KEY:-}" ]; then
     QDRANT_CURL_AUTH=(-H "api-key: ${QDRANT_API_KEY}")

--- a/tests/unit/test_indexer_truncation.py
+++ b/tests/unit/test_indexer_truncation.py
@@ -3,7 +3,9 @@ Unit tests for IndexProcessor chunk validation and max_embed_tokens computation.
 
 Tests cover:
 - _compute_max_embed_tokens: config-driven token limit derivation
-- _filter_valid_chunks: empty-chunk filtering and oversized-chunk rejection
+- _filter_valid_chunks: empty-chunk filtering, oversized-chunk rejection (stop)
+  and truncation (truncate)
+- oversize_chunks_strategy config setting
 """
 
 from unittest.mock import MagicMock, patch
@@ -67,20 +69,22 @@ class TestComputeMaxEmbedTokens:
 
 
 class TestFilterValidChunks:
-    """Test _filter_valid_chunks removes empty chunks and rejects oversized ones."""
+    """Test _filter_valid_chunks removes empty chunks and handles oversized ones."""
 
-    def _make_processor(self, max_embed_tokens=None):
+    def _make_processor(self, max_embed_tokens=None, strategy="truncate"):
         chunk_config = {
             "dense_model": "intfloat/multilingual-e5-large",
             "max_tokens": 450,
         }
+        index_config = {"oversize_chunks_strategy": strategy}
         with patch("pipeline.processors.indexing.indexer.get_db"), patch(
             "pipeline.processors.indexing.indexer.PostgresClient"
         ):
-            proc = IndexProcessor(chunk_config=chunk_config)
+            proc = IndexProcessor(chunk_config=chunk_config, index_config=index_config)
         # Mock tokenizer: each word = 1 token (split on whitespace)
         mock_tok = MagicMock()
         mock_tok.encode.side_effect = lambda text, **kw: text.split()
+        mock_tok.decode.side_effect = lambda ids, **kw: " ".join(ids)
         proc._tokenizer = mock_tok
         if max_embed_tokens is not None:
             proc._max_embed_tokens = max_embed_tokens
@@ -100,47 +104,105 @@ class TestFilterValidChunks:
         assert result[0]["text"] == "valid text"
         assert result[1]["text"] == "also valid"
 
-    def test_rejects_oversized_chunks(self):
-        """Chunks exceeding max_embed_tokens raise ValueError."""
-        proc = self._make_processor(max_embed_tokens=5)
-        # 10 words = 10 tokens (mock tokenizer splits on whitespace)
+    # --- strategy=stop tests ---
+
+    def test_stop_rejects_oversized_chunks(self):
+        """strategy=stop raises ValueError on oversized chunks."""
+        proc = self._make_processor(max_embed_tokens=5, strategy="stop")
         long_text = " ".join(["word"] * 10)
         chunks = [{"text": long_text}]
         with pytest.raises(ValueError, match="exceed embedding model limit"):
             proc._filter_valid_chunks(chunks)
 
-    def test_does_not_reject_short_chunks(self):
-        """Chunks within the limit are left unchanged."""
-        proc = self._make_processor(max_embed_tokens=100)
+    def test_stop_does_not_reject_short_chunks(self):
+        """strategy=stop leaves chunks within the limit unchanged."""
+        proc = self._make_processor(max_embed_tokens=100, strategy="stop")
         text = "short chunk"
         chunks = [{"text": text}]
         result = proc._filter_valid_chunks(chunks)
         assert result[0]["text"] == text
 
-    def test_exact_boundary_passes(self):
+    def test_stop_exact_boundary_passes(self):
         """A chunk exactly at the limit is not rejected."""
-        proc = self._make_processor(max_embed_tokens=5)
-        text = " ".join(["word"] * 5)  # 5 tokens
+        proc = self._make_processor(max_embed_tokens=5, strategy="stop")
+        text = " ".join(["word"] * 5)
         chunks = [{"text": text}]
         result = proc._filter_valid_chunks(chunks)
         assert result[0]["text"] == text
 
-    def test_mixed_chunks_oversized_causes_failure(self):
-        """Any oversized chunk causes the entire batch to fail."""
-        proc = self._make_processor(max_embed_tokens=5)
+    def test_stop_mixed_chunks_oversized_causes_failure(self):
+        """Any oversized chunk causes the entire batch to fail with stop."""
+        proc = self._make_processor(max_embed_tokens=5, strategy="stop")
         chunks = [
             {"text": "short"},
-            {"text": " ".join(["word"] * 10)},  # 10 tokens > 5
+            {"text": " ".join(["word"] * 10)},
             {"text": "normal length text here"},
-            {"text": " ".join(["word"] * 8)},  # 8 tokens > 5
+            {"text": " ".join(["word"] * 8)},
         ]
         with pytest.raises(ValueError, match="2 chunk\\(s\\) exceed"):
             proc._filter_valid_chunks(chunks)
 
+    # --- strategy=truncate tests ---
+
+    def test_truncate_trims_oversized_chunks(self):
+        """strategy=truncate trims oversized chunks to max_tokens."""
+        proc = self._make_processor(max_embed_tokens=5, strategy="truncate")
+        long_text = " ".join(["word"] * 10)
+        chunks = [{"text": long_text}]
+        result = proc._filter_valid_chunks(chunks)
+        assert len(result) == 1
+        # Mock decode joins the first 5 token IDs (words)
+        assert result[0]["text"] == " ".join(["word"] * 5)
+
+    def test_truncate_leaves_short_chunks_unchanged(self):
+        """strategy=truncate does not modify chunks within the limit."""
+        proc = self._make_processor(max_embed_tokens=100, strategy="truncate")
+        text = "short chunk"
+        chunks = [{"text": text}]
+        result = proc._filter_valid_chunks(chunks)
+        assert result[0]["text"] == text
+
+    def test_truncate_mixed_chunks(self):
+        """strategy=truncate only trims oversized chunks, leaves others intact."""
+        proc = self._make_processor(max_embed_tokens=5, strategy="truncate")
+        chunks = [
+            {"text": "ok"},
+            {"text": " ".join(["word"] * 10)},
+            {"text": "fine"},
+        ]
+        result = proc._filter_valid_chunks(chunks)
+        assert len(result) == 3
+        assert result[0]["text"] == "ok"
+        assert result[1]["text"] == " ".join(["word"] * 5)
+        assert result[2]["text"] == "fine"
+
+    def test_truncate_exact_boundary_untouched(self):
+        """A chunk exactly at the limit is not truncated."""
+        proc = self._make_processor(max_embed_tokens=5, strategy="truncate")
+        text = " ".join(["word"] * 5)
+        chunks = [{"text": text}]
+        result = proc._filter_valid_chunks(chunks)
+        assert result[0]["text"] == text
+
+    # --- default strategy ---
+
+    def test_default_strategy_is_truncate(self):
+        """When index_config omits oversize_chunks_strategy, defaults to truncate."""
+        chunk_config = {
+            "dense_model": "intfloat/multilingual-e5-large",
+            "max_tokens": 450,
+        }
+        with patch("pipeline.processors.indexing.indexer.get_db"), patch(
+            "pipeline.processors.indexing.indexer.PostgresClient"
+        ):
+            proc = IndexProcessor(chunk_config=chunk_config)
+        assert proc.oversize_chunks_strategy == "truncate"
+
+    # --- guard: _max_embed_tokens not set ---
+
     def test_aborts_when_max_embed_tokens_not_set(self):
         """Raises ValueError when _max_embed_tokens is not set."""
         proc = self._make_processor()
-        # Remove _max_embed_tokens to test abort
         if hasattr(proc, "_max_embed_tokens"):
             delattr(proc, "_max_embed_tokens")
         chunks = [{"text": "any text"}]


### PR DESCRIPTION
## Summary
- Add `oversize_chunks_strategy` setting to pipeline index config (`"stop"` or `"truncate"`, default `"truncate"`)
- `"stop"` preserves the existing behaviour (raise `ValueError` on oversized chunks)
- `"truncate"` trims oversized chunks to the embedding model token limit using the actual tokenizer
- Truncation primarily affects small-context embedding models (e.g. `e5_large` at 512 tokens) where post-processing — heading hierarchy prefixes and footnote redistribution — inflates chunks past the limit. Longer-context models like `azure_small` (8192 tokens) are generally unaffected
- Fix `POSTGRES_HOST` override in `run_pipeline_host.sh` so local integration tests resolve the database when `.env` contains the Docker service name `postgres`

## Test plan
- [x] 15 unit tests covering both strategies, default behaviour, boundary cases, and mixed chunks
- [ ] Run local integration pipeline to verify truncation allows indexing to complete
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)