### PR TITLE
feat(auth): add DISABLE_EMAIL_CONFIRMATION setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,6 +208,10 @@ AUTH_LOCKOUT_DURATION_MINUTES=15
 # Only set if you need to customise CSP for your deployment.
 # CSP_POLICY=default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
 
+# Skip email verification — accounts are auto-approved on registration.
+# WARNING: For testing/development ONLY. Never enable in production.
+DISABLE_EMAIL_CONFIRMATION=false
+
 # SMTP settings for email verification and password reset
 # For local development, use Mailpit (see README for setup):
 #   SMTP_HOST=mailpit  SMTP_PORT=1025  SMTP_USE_TLS=false

--- a/ui/backend/auth/users.py
+++ b/ui/backend/auth/users.py
@@ -254,6 +254,21 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         await write_audit_event(
             "register", user_id=user.id, user_email=user.email, ip_address=ip
         )
+
+        # When email confirmation is disabled, auto-verify the account so the
+        # user can log in immediately without an SMTP server.
+        if os.environ.get("DISABLE_EMAIL_CONFIRMATION", "").lower() == "true":
+            logger.warning(
+                "DISABLE_EMAIL_CONFIRMATION=true — auto-verifying %s",
+                user.email,
+            )
+            async for session in get_async_session():
+                await session.execute(
+                    update(User).where(User.id == user.id).values(is_verified=True)
+                )
+                await session.commit()
+            return
+
         await self.request_verify(user, request)
 
     async def on_after_request_verify(


### PR DESCRIPTION
## Summary
- Add `DISABLE_EMAIL_CONFIRMATION` env var (default `false`)
- When `true`, accounts are auto-verified on registration — no SMTP server needed
- Logs a warning when auto-verification is used so it's visible in server output
- Added to `.env.example` (set to `false`) with a clear warning against production use
- Set to `true` in `.env` for local development convenience

## Test plan
- [x] All 69 existing auth/user tests pass (no regressions)
- [ ] Register a new user with `DISABLE_EMAIL_CONFIRMATION=true` — should be able to log in immediately
- [ ] Register with `DISABLE_EMAIL_CONFIRMATION=false` — should require email verification as before
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)