### PR TITLE
fix(frontend): add CSRF token to fetch POST calls

### DIFF
--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -48,6 +48,11 @@ import {
 
 const AI_SUMMARY_ERROR = 'Uh oh. Something went wrong asking the AI.';
 
+const getCsrfToken = (): string | null => {
+  const match = document.cookie.match(/(?:^|;\s*)evidencelab_csrf=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
 // Configure API key header for all axios requests
 const API_KEY = process.env.REACT_APP_API_KEY;
 if (API_KEY) {
@@ -135,9 +140,10 @@ const buildSearchErrorMessage = (error: any): string => {
 
 const translateViaApi = async (text: string, targetLanguage: string, sourceLanguage?: string): Promise<string | null> => {
   try {
+    const csrfToken = getCsrfToken();
     const resp = await fetch(`${API_BASE_URL}/translate`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...(API_KEY ? { 'X-API-Key': API_KEY } : {}) },
+      headers: { 'Content-Type': 'application/json', ...(API_KEY ? { 'X-API-Key': API_KEY } : {}), ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
       body: JSON.stringify({ text, target_language: targetLanguage, source_language: sourceLanguage })
     });
     if (resp.ok) {

--- a/ui/frontend/src/components/app/HeatmapTabContent.tsx
+++ b/ui/frontend/src/components/app/HeatmapTabContent.tsx
@@ -26,6 +26,11 @@ import { useCarouselScroll } from '../../hooks/useCarouselScroll';
 
 const API_KEY = process.env.REACT_APP_API_KEY;
 
+const getCsrfToken = (): string | null => {
+  const match = document.cookie.match(/(?:^|;\s*)evidencelab_csrf=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
 // Top N% of score range to display (0.2 = show only top 20%)
 const HEATMAP_SCORE_PERCENTILE = 0.2;
 
@@ -993,9 +998,10 @@ const HeatmapGridContent = ({
 
 const translateWithFallback = async (text: string, newLang: string, label: string) => {
   try {
+    const csrfToken = getCsrfToken();
     const resp = await fetch(`${API_BASE_URL}/translate`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...(API_KEY ? { 'X-API-Key': API_KEY } : {}) },
+      headers: { 'Content-Type': 'application/json', ...(API_KEY ? { 'X-API-Key': API_KEY } : {}), ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
       body: JSON.stringify({ text, target_language: newLang }),
     });
     if (resp.ok) {

--- a/ui/frontend/src/utils/textHighlighting.tsx
+++ b/ui/frontend/src/utils/textHighlighting.tsx
@@ -5,6 +5,11 @@ import { SearchResult, SummaryModelConfig } from '../types/api';
 
 const API_KEY = process.env.REACT_APP_API_KEY;
 
+const getCsrfToken = (): string | null => {
+  const match = document.cookie.match(/(?:^|;\s*)evidencelab_csrf=([^;]*)/);
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
 export interface TextMatch {
   start: number;
   end: number;
@@ -186,11 +191,13 @@ export const highlightTextWithAPI = async (
   if (!query.trim() || !text.trim()) return { highlighted_text: text, matches: [] };
 
   try {
+    const csrfToken = getCsrfToken();
     const response = await fetch(`${API_BASE_URL}/highlight`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        ...(API_KEY ? { 'X-API-Key': API_KEY } : {})
+        ...(API_KEY ? { 'X-API-Key': API_KEY } : {}),
+        ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {})
       },
       body: JSON.stringify({
         query: query.trim(),


### PR DESCRIPTION
## Summary
- Adds `X-CSRF-Token` header to all raw `fetch` POST calls that were missing it
- Fixes 403 Forbidden on `/api/highlight` (semantic highlighting) and `/api/translate` endpoints
- The CSRF middleware added during security hardening blocks POST requests without the token, but only axios-based auth calls and the AI summary stream included it — raw `fetch` calls for highlight and translate did not

## Files changed
- `ui/frontend/src/utils/textHighlighting.tsx` — highlight endpoint
- `ui/frontend/src/App.tsx` — translate endpoint
- `ui/frontend/src/components/app/HeatmapTabContent.tsx` — heatmap translate endpoint

## Test plan
- [x] All 126 frontend tests pass (25 suites)
- [ ] Browser smoke test: semantic highlighting works on search results
- [ ] Browser smoke test: translation works on heatmap and search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)