### PR TITLE
fix(alembic): commit implicit transaction before running migrations

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -77,6 +77,7 @@ def run_migrations_online() -> None:
 
     with connectable.connect() as connection:
         _widen_version_column(connection)
+        connection.commit()
         context.configure(
             connection=connection,
             target_metadata=target_metadata,


### PR DESCRIPTION
## Summary
- `_widen_version_column()` in `alembic/env.py` executes a SELECT that auto-begins a transaction in SQLAlchemy 2.0
- When the `alembic_version` table doesn't exist (fresh install), the function returns without committing, leaving a dangling implicit transaction
- `context.begin_transaction()` then can't properly own the transaction lifecycle — migrations appear to run but are never committed
- Fix: add explicit `connection.commit()` after `_widen_version_column()` to clear the connection state

## Test plan
- [ ] Drop all user tables and `alembic_version`, re-run `alembic upgrade head` — all tables should be created
- [ ] Run `alembic current` — should show `0009_add_langsmith_trace_url (head)`
- [ ] Restart API with `USER_MODULE=true` — should start without "relation users does not exist" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)