### PR TITLE
feat: add PDF export and global summary to AI Summary Tree

### DIFF
--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -2379,6 +2379,8 @@ function App() {
       findOutMoreLoading={findOutMoreLoading}
       findOutMoreActiveFact={findOutMoreActiveFact}
       requestShowGraph={findOutMoreDone}
+      dataSource={dataSource}
+      summaryModelConfig={summaryModelConfig}
     />
   );
 

--- a/ui/frontend/src/components/AiSummaryPanel.tsx
+++ b/ui/frontend/src/components/AiSummaryPanel.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { SearchResult, DrilldownNode } from '../types/api';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import { SearchResult, DrilldownNode, SummaryModelConfig } from '../types/api';
+import API_BASE_URL from '../config';
 import { LANGUAGES } from '../constants';
 import { RainbowText } from './RainbowText';
 import { AiSummaryWithCitations } from './AiSummaryWithCitations';
@@ -7,6 +9,7 @@ import { AiSummaryReferences } from './AiSummaryReferences';
 import { DigDeeperPopover } from './DigDeeperPopover';
 import { DrilldownBreadcrumb } from './DrilldownBreadcrumb';
 import { DrilldownGraphView } from './DrilldownGraphView';
+import { exportResearchToPdf } from '../utils/exportResearch';
 import StarRating from './ratings/StarRating';
 
 interface AiSummaryPanelProps {
@@ -46,6 +49,10 @@ interface AiSummaryPanelProps {
   ratingScore?: number;
   /** Callback when user clicks a star to open the rating modal */
   onRequestRatingModal?: (selectedScore: number) => void;
+  /** Data source for the global summary API call */
+  dataSource?: string;
+  /** Summary model config for the global summary API call */
+  summaryModelConfig?: SummaryModelConfig | null;
 }
 
 const GeneratingText = () => (
@@ -284,24 +291,175 @@ const DocumentIcon = () => (
   </svg>
 );
 
-const GraphToggleButton = ({
-  showGraph,
-  onToggle,
-}: {
-  showGraph: boolean;
-  onToggle: () => void;
-}) => (
-  <button
-    className={`drilldown-graph-toggle ${showGraph ? 'active' : ''}`}
-    onClick={(e) => {
-      e.stopPropagation();
-      onToggle();
-    }}
-    type="button"
+const GlobeIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
   >
-    {showGraph ? <DocumentIcon /> : <NetworkIcon />}
-    {showGraph ? 'Show summary' : 'Show tree'}
-  </button>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="2" y1="12" x2="22" y2="12" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+  </svg>
+);
+
+const DownloadIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
+interface NodeSummary {
+  label: string;
+  summary: string;
+}
+
+const collectNodeSummaries = (node: DrilldownNode): NodeSummary[] => {
+  const entries: NodeSummary[] = [];
+  if (node.summary) {
+    entries.push({ label: node.label, summary: node.summary });
+  }
+  for (const child of node.children) {
+    entries.push(...collectNodeSummaries(child));
+  }
+  return entries;
+};
+
+/** Collect all unique search results from every node in the tree, deduped by chunk_id */
+const collectAllResults = (node: DrilldownNode): SearchResult[] => {
+  const seen = new Set<string>();
+  const all: SearchResult[] = [];
+  const walk = (n: DrilldownNode) => {
+    for (const r of n.results) {
+      if (!seen.has(r.chunk_id)) {
+        seen.add(r.chunk_id);
+        all.push(r);
+      }
+    }
+    for (const child of n.children) walk(child);
+  };
+  walk(node);
+  return all;
+};
+
+/** Return a deep copy of the tree with one node's summary/results patched in */
+const patchNodeInTree = (
+  node: DrilldownNode,
+  targetId: string,
+  summary: string,
+  nodeResults: SearchResult[]
+): DrilldownNode => {
+  if (node.id === targetId) {
+    return { ...node, summary, results: nodeResults, children: node.children.map((c) => ({ ...c })) };
+  }
+  return {
+    ...node,
+    children: node.children.map((c) => patchNodeInTree(c, targetId, summary, nodeResults)),
+  };
+};
+
+const DrilldownNavRow = ({
+  viewMode,
+  hasGraph,
+  globalSummaryLoading,
+  drilldownStackDepth,
+  drilldownHighlight,
+  onSetViewMode,
+  onGenerateGlobalSummary,
+  onExportResearch,
+  onDrilldownBack,
+}: {
+  viewMode: 'summary' | 'tree' | 'global';
+  hasGraph: boolean;
+  globalSummaryLoading: boolean;
+  drilldownStackDepth: number;
+  drilldownHighlight?: string;
+  onSetViewMode: (mode: 'summary' | 'tree' | 'global') => void;
+  onGenerateGlobalSummary: () => void;
+  onExportResearch: () => void;
+  onDrilldownBack: () => void;
+}) => (
+  <div className="ai-drilldown-nav-row">
+    {viewMode === 'summary' && hasGraph && (
+      <button
+        className="drilldown-graph-toggle"
+        onClick={() => onSetViewMode('tree')}
+        type="button"
+      >
+        <NetworkIcon />
+        Show tree
+      </button>
+    )}
+    {viewMode === 'tree' && (
+      <>
+        <button
+          className="drilldown-graph-toggle"
+          onClick={() => onSetViewMode('summary')}
+          type="button"
+        >
+          <DocumentIcon />
+          Show summary
+        </button>
+        {!globalSummaryLoading && (
+          <button
+            className="drilldown-graph-toggle"
+            onClick={onGenerateGlobalSummary}
+            type="button"
+          >
+            <GlobeIcon />
+            Generate Global Summary
+          </button>
+        )}
+        {globalSummaryLoading && (
+          <span className="global-summary-loading">
+            <RainbowText text="Generating global summary..." />
+          </span>
+        )}
+        <button
+          className="drilldown-graph-toggle"
+          onClick={onExportResearch}
+          type="button"
+          style={{ marginLeft: 'auto' }}
+        >
+          <DownloadIcon />
+          Export research
+        </button>
+      </>
+    )}
+    {viewMode === 'global' && (
+      <button
+        className="drilldown-graph-toggle"
+        onClick={() => onSetViewMode('tree')}
+        type="button"
+      >
+        <NetworkIcon />
+        Show tree
+      </button>
+    )}
+    {viewMode === 'summary' && (
+      <DrilldownBreadcrumb
+        stackDepth={drilldownStackDepth}
+        onBack={onDrilldownBack}
+        currentHighlight={drilldownHighlight}
+      />
+    )}
+  </div>
 );
 
 const LanguageSelector = ({
@@ -442,13 +600,69 @@ export const AiSummaryPanel = ({
   isAuthenticated,
   ratingScore = 0,
   onRequestRatingModal,
+  dataSource,
+  summaryModelConfig,
 }: AiSummaryPanelProps) => {
   const summaryContentRef = useRef<HTMLDivElement>(null);
-  const [showGraph, setShowGraph] = useState(false);
+  // viewMode: 'summary' = node summary, 'tree' = graph, 'global' = global summary
+  const [viewMode, setViewMode] = useState<'summary' | 'tree' | 'global'>('summary');
+  const [globalSummary, setGlobalSummary] = useState('');
+  const [globalSummaryResults, setGlobalSummaryResults] = useState<SearchResult[]>([]);
+  const [globalSummaryLoading, setGlobalSummaryLoading] = useState(false);
 
   useEffect(() => {
-    if (requestShowGraph) setShowGraph(true);
+    if (requestShowGraph) setViewMode('tree');
   }, [requestShowGraph]);
+
+  // Reset global summary when tree changes
+  useEffect(() => {
+    setGlobalSummary('');
+    setGlobalSummaryResults([]);
+  }, [drilldownTree]);
+
+  const handleGenerateGlobalSummary = useCallback(async () => {
+    if (!drilldownTree || globalSummaryLoading) return;
+    const summaries = collectNodeSummaries(drilldownTree);
+    if (summaries.length === 0) return;
+
+    const allResults = collectAllResults(drilldownTree);
+    if (allResults.length === 0) return;
+
+    setGlobalSummaryLoading(true);
+    try {
+      const rootLabel = drilldownTree.label || 'research';
+      const summaryContext = summaries
+        .map((s) => `- ${s.label}: ${s.summary}`)
+        .join('\n');
+      const q = `Synthesise a comprehensive global summary from the following research topics, in the context of: "${rootLabel}". Use the search results below to cite sources.\n\nResearch summaries so far:\n${summaryContext}`;
+      const resp = await axios.post<{ summary: string }>(
+        `${API_BASE_URL}/ai-summary?data_source=${dataSource || 'default'}`,
+        {
+          query: q,
+          results: allResults.map((r) => ({
+            chunk_id: r.chunk_id,
+            doc_id: r.doc_id,
+            text: r.text,
+            title: r.title,
+            page_num: r.page_num,
+            headings: r.headings || [],
+            score: r.score,
+            organization: r.organization,
+            year: r.year,
+          })),
+          max_results: allResults.length,
+          ...(summaryModelConfig ? { summary_model_config: summaryModelConfig } : {}),
+        }
+      );
+      setGlobalSummary(resp.data.summary);
+      setGlobalSummaryResults(allResults);
+      setViewMode('global');
+    } catch (err) {
+      console.error('Failed to generate global summary:', err);
+    } finally {
+      setGlobalSummaryLoading(false);
+    }
+  }, [drilldownTree, globalSummaryLoading, dataSource, summaryModelConfig]);
 
   if (!enabled) return null;
 
@@ -457,7 +671,8 @@ export const AiSummaryPanel = ({
   const selectedLang = translatedLang || 'en';
   const isDrilldown = (drilldownStackDepth || 0) > 0;
   const hasGraph = drilldownTree && drilldownTree.children.length > 0;
-  const showGraphView = showGraph && hasGraph && onDrilldownNavigate;
+  const showGraphView = viewMode === 'tree' && hasGraph && onDrilldownNavigate;
+  const showGlobalView = viewMode === 'global' && globalSummary;
 
   return (
     <>
@@ -465,7 +680,7 @@ export const AiSummaryPanel = ({
         <AiSummaryHeader
           isDrilldown={isDrilldown}
           collapsed={aiSummaryCollapsed}
-          showGraph={showGraph}
+          showGraph={viewMode !== 'summary'}
           aiSummary={aiSummary}
           loading={aiSummaryLoading}
           selectedLang={selectedLang}
@@ -474,22 +689,32 @@ export const AiSummaryPanel = ({
           onLanguageChange={onLanguageChange}
           onToggleCollapsed={onToggleCollapsed}
         />
-        {!aiSummaryCollapsed && aiSummary && !aiSummaryLoading && !showGraphView && (
+        {!aiSummaryCollapsed && aiSummary && !aiSummaryLoading && viewMode === 'summary' && (
           <p className="ai-summary-hint">Highlight text below to find out more.</p>
         )}
         {!aiSummaryCollapsed && onDrilldownBack && (
-          <div className="ai-drilldown-nav-row">
-            {hasGraph && (
-              <GraphToggleButton showGraph={showGraph} onToggle={() => setShowGraph((prev) => !prev)} />
-            )}
-            {!showGraph && (
-              <DrilldownBreadcrumb
-                stackDepth={drilldownStackDepth || 0}
-                onBack={onDrilldownBack}
-                currentHighlight={drilldownHighlight}
-              />
-            )}
-          </div>
+          <DrilldownNavRow
+            viewMode={viewMode}
+            hasGraph={!!hasGraph}
+            globalSummaryLoading={globalSummaryLoading}
+            drilldownStackDepth={drilldownStackDepth || 0}
+            drilldownHighlight={drilldownHighlight}
+            onSetViewMode={setViewMode}
+            onGenerateGlobalSummary={handleGenerateGlobalSummary}
+            onExportResearch={() => {
+              if (drilldownTree) {
+                // Patch the currently-viewed node's live state into the tree before exporting
+                const currentId = drilldownCurrentNodeId || drilldownTree.id;
+                const patchedTree = patchNodeInTree(drilldownTree, currentId, aiSummary, results);
+                exportResearchToPdf(
+                  patchedTree,
+                  globalSummary || undefined,
+                  globalSummaryResults
+                );
+              }
+            }}
+            onDrilldownBack={onDrilldownBack}
+          />
         )}
         {showGraphView ? (
           <DrilldownGraphView
@@ -497,9 +722,24 @@ export const AiSummaryPanel = ({
             activeNodeId={drilldownCurrentNodeId || 'root'}
             onNodeClick={(nodeId) => {
               onDrilldownNavigate!(nodeId);
-              setShowGraph(false);
+              setViewMode('summary');
             }}
           />
+        ) : showGlobalView ? (
+          <div className="ai-summary-content expanded global-summary-content">
+            <div className="ai-summary-markdown">
+              <AiSummaryWithCitations
+                summaryText={globalSummary}
+                searchResults={globalSummaryResults}
+                onResultClick={onResultClick}
+              />
+            </div>
+            <AiSummaryReferences
+              summaryText={globalSummary}
+              results={globalSummaryResults}
+              onResultClick={onResultClick}
+            />
+          </div>
         ) : (
           <>
             <AiSummaryContent

--- a/ui/frontend/src/components/AiSummaryReferences.tsx
+++ b/ui/frontend/src/components/AiSummaryReferences.tsx
@@ -29,14 +29,14 @@ interface CitedRef {
   result: SearchResult;
 }
 
-interface DocumentGroup {
+export interface DocumentGroup {
   title: string;
   organization?: string;
   year?: string;
   refs: CitedRef[];
 }
 
-const buildGroupedReferences = (
+export const buildGroupedReferences = (
   summaryText: string,
   results: SearchResult[]
 ): DocumentGroup[] => {

--- a/ui/frontend/src/components/app/SearchTabContent.tsx
+++ b/ui/frontend/src/components/app/SearchTabContent.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState, useEffect, useRef } from 'react';
-import { Facets, FacetValue, SearchResult, DrilldownNode } from '../../types/api';
+import { Facets, FacetValue, SearchResult, DrilldownNode, SummaryModelConfig } from '../../types/api';
 import API_BASE_URL from '../../config';
 import { AiSummaryPanel } from '../AiSummaryPanel';
 import { FiltersPanel } from '../filters/FiltersPanel';
@@ -95,6 +95,8 @@ interface SearchTabContentProps {
   findOutMoreLoading?: boolean;
   findOutMoreActiveFact?: string | null;
   requestShowGraph?: boolean;
+  dataSource?: string;
+  summaryModelConfig?: SummaryModelConfig | null;
 }
 
 const DOT_SIZES = [12, 12, 12, 12, 12];
@@ -429,6 +431,8 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
   findOutMoreLoading,
   findOutMoreActiveFact,
   requestShowGraph,
+  dataSource,
+  summaryModelConfig,
 }) => {
   const [filteredOrgs, setFilteredOrgs] = useState<string[]>(() => {
     const params = new URLSearchParams(window.location.search);
@@ -748,6 +752,8 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
             findOutMoreLoading={findOutMoreLoading}
             findOutMoreActiveFact={findOutMoreActiveFact}
             requestShowGraph={requestShowGraph}
+            dataSource={dataSource}
+            summaryModelConfig={summaryModelConfig}
             isAuthenticated={isAuthenticated}
             ratingScore={aiRating?.score || 0}
             onRequestRatingModal={(selectedScore) => {

--- a/ui/frontend/src/utils/exportResearch.ts
+++ b/ui/frontend/src/utils/exportResearch.ts
@@ -1,0 +1,360 @@
+import { DrilldownNode, SearchResult } from '../types/api';
+import { buildGroupedReferences, DocumentGroup } from '../components/AiSummaryReferences';
+
+/** Escape HTML special characters */
+const esc = (text: string): string =>
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+/** Convert a label to a URL-safe anchor id */
+const toAnchorId = (label: string, index: number): string =>
+  `section-${index}-${label.replace(/[^a-zA-Z0-9]+/g, '-').toLowerCase()}`;
+
+/** Resolve a SearchResult to its external source document URL */
+const resolveSourceUrl = (result: SearchResult): string =>
+  result.report_url ||
+  result.metadata?.report_url ||
+  result.metadata?.map_report_url ||
+  result.metadata?.src_doc_raw_metadata?.report_url ||
+  result.pdf_url ||
+  result.metadata?.pdf_url ||
+  result.metadata?.map_pdf_url ||
+  result.metadata?.src_doc_raw_metadata?.pdf_url ||
+  '';
+
+/** Build a map from original citation number to { url, sequential } */
+const buildCitationLinks = (
+  summary: string,
+  results: SearchResult[]
+): Map<number, { url: string; seq: number }> => {
+  const cited = new Set<number>();
+  const regex = /\[(\d+(?:,\s*\d+)*)\]/g;
+  let match;
+  while ((match = regex.exec(summary)) !== null) {
+    match[1].split(',').forEach((n) => {
+      const num = parseInt(n.trim(), 10);
+      if (num >= 1 && num <= results.length) cited.add(num);
+    });
+  }
+  const sorted = Array.from(cited).sort((a, b) => a - b);
+  const map = new Map<number, { url: string; seq: number }>();
+  sorted.forEach((origNum, idx) => {
+    const r = results[origNum - 1];
+    let url = resolveSourceUrl(r);
+    if (url && r.page_num) url += `#page=${r.page_num}`;
+    map.set(origNum, { url, seq: idx + 1 });
+  });
+  return map;
+};
+
+/** Parse inline markdown (bold, italic, citations) to HTML */
+const parseInlineMarkdown = (
+  line: string,
+  linkMap?: Map<number, { url: string; seq: number }>
+): string =>
+  esc(line)
+    .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+    .replace(/\*(.+?)\*/g, '<em>$1</em>')
+    .replace(
+      /\[(\d+(?:,\s*\d+)*)\]/g,
+      (_, nums: string) => {
+        if (!linkMap) {
+          return `<sup class="citation">[${nums}]</sup>`;
+        }
+        const parts = nums.split(/,\s*/).map((n) => {
+          const orig = parseInt(n, 10);
+          const entry = linkMap.get(orig);
+          if (!entry) return n;
+          if (entry.url) {
+            return `<a href="${entry.url}" target="_blank" class="citation-link">${entry.seq}</a>`;
+          }
+          return `${entry.seq}`;
+        });
+        return `<sup class="citation">[${parts.join(', ')}]</sup>`;
+      }
+    );
+
+/** Wrap consecutive <li> elements in <ul> tags */
+const wrapListItems = (htmlLines: string[]): string => {
+  const result: string[] = [];
+  let inList = false;
+
+  for (const line of htmlLines) {
+    if (line.startsWith('<li>')) {
+      if (!inList) {
+        result.push('<ul>');
+        inList = true;
+      }
+      result.push(line);
+    } else {
+      if (inList) {
+        result.push('</ul>');
+        inList = false;
+      }
+      result.push(line);
+    }
+  }
+  if (inList) result.push('</ul>');
+
+  return result.join('\n');
+};
+
+/** Parse a single line of markdown into an HTML string */
+const parseMarkdownLine = (
+  trimmed: string,
+  linkMap?: Map<number, { url: string; seq: number }>
+): string | null => {
+  if (!trimmed) return null;
+
+  const headingMatch = trimmed.match(/^(#{1,4})\s+(.+)$/);
+  if (headingMatch) {
+    const level = Math.min(headingMatch[1].length + 2, 6);
+    return `<h${level}>${parseInlineMarkdown(headingMatch[2], linkMap)}</h${level}>`;
+  }
+
+  const boldHeadingMatch = trimmed.match(/^\*\*(.+?)\*\*:?\s*$/);
+  if (boldHeadingMatch) {
+    return `<p><strong>${esc(boldHeadingMatch[1])}</strong></p>`;
+  }
+
+  if (/^[-*]\s/.test(trimmed)) {
+    return `<li>${parseInlineMarkdown(trimmed.replace(/^[-*]\s/, ''), linkMap)}</li>`;
+  }
+
+  if (/^\d+[.)]\s/.test(trimmed)) {
+    return `<li>${parseInlineMarkdown(trimmed.replace(/^\d+[.)]\s/, ''), linkMap)}</li>`;
+  }
+
+  return `<p>${parseInlineMarkdown(trimmed, linkMap)}</p>`;
+};
+
+/** Parse a full markdown summary into HTML paragraphs */
+const parseSummaryToHtml = (
+  summary: string,
+  results?: SearchResult[]
+): string => {
+  const linkMap = results
+    ? buildCitationLinks(summary, results)
+    : undefined;
+
+  const blocks = summary.split(/\n\n+/);
+  const parts: string[] = [];
+
+  for (const block of blocks) {
+    const lines = block.split('\n');
+    const htmlLines: string[] = [];
+    for (const line of lines) {
+      const parsed = parseMarkdownLine(line.trim(), linkMap);
+      if (parsed) htmlLines.push(parsed);
+    }
+    parts.push(wrapListItems(htmlLines));
+  }
+
+  return parts.join('\n');
+};
+
+/** Build HTML for a references section */
+const buildReferencesHtml = (groups: DocumentGroup[]): string => {
+  if (groups.length === 0) return '';
+
+  const items = groups.map((group) => {
+    const meta = [group.title, group.organization, group.year]
+      .filter(Boolean)
+      .join(', ');
+    const citations = group.refs
+      .map(({ sequential, result }) => {
+        const page = result.page_num ? ` p.${result.page_num}` : '';
+        let url = resolveSourceUrl(result);
+        if (url && result.page_num) url += `#page=${result.page_num}`;
+        if (url) {
+          return `<a href="${url}" target="_blank" class="citation-link">[${sequential}]${page}</a>`;
+        }
+        return `<span>[${sequential}]${page}</span>`;
+      })
+      .join(' ');
+    return `<li class="ref-item">${esc(meta)} | ${citations}</li>`;
+  });
+
+  return `<div class="references"><h4>References</h4><ul>${items.join('\n')}</ul></div>`;
+};
+
+interface TocEntry {
+  id: string;
+  label: string;
+  depth: number;
+}
+
+/** Build a visual tree graph from the drilldown nodes */
+const buildNodeGraphHtml = (
+  node: DrilldownNode,
+  isRoot: boolean
+): string => {
+  const label = `<span class="graph-label">${esc(node.label)}</span>`;
+  if (node.children.length === 0) {
+    return isRoot
+      ? `<div class="tree-graph"><ul><li>${label}</li></ul></div>`
+      : `<li>${label}</li>`;
+  }
+  const kids = node.children.map((c) => buildNodeGraphHtml(c, false)).join('\n');
+  const inner = `${label}<ul>${kids}</ul>`;
+  return isRoot
+    ? `<div class="tree-graph"><ul><li>${inner}</li></ul></div>`
+    : `<li>${inner}</li>`;
+};
+
+const buildGraphHtml = (
+  tree: DrilldownNode,
+  hasGlobal: boolean
+): string => {
+  if (!hasGlobal) return buildNodeGraphHtml(tree, true);
+  const globalLabel = '<span class="graph-label">Global Summary</span>';
+  const treeHtml = buildNodeGraphHtml(tree, false);
+  return `<div class="tree-graph"><ul><li>${globalLabel}<ul>${treeHtml}</ul></li></ul></div>`;
+};
+
+/** Collect TOC entries and section HTML from the tree recursively */
+const buildTreeSections = (
+  node: DrilldownNode,
+  depth: number,
+  toc: TocEntry[],
+  counter: { value: number }
+): string => {
+  let html = '';
+
+  if (node.summary) {
+    const idx = counter.value++;
+    const id = toAnchorId(node.label, idx);
+    const hLevel = Math.min(depth + 2, 6);
+    toc.push({ id, label: node.label, depth });
+
+    const heading = `<h${hLevel} id="${id}">${esc(node.label)}</h${hLevel}>`;
+    const content = parseSummaryToHtml(node.summary, node.results);
+    const refs = buildReferencesHtml(
+      buildGroupedReferences(node.summary, node.results)
+    );
+
+    html += `${heading}\n${content}\n${refs}\n`;
+  }
+
+  for (const child of node.children) {
+    html += buildTreeSections(child, depth + 1, toc, counter);
+  }
+
+  return html;
+};
+
+/** Build the TOC HTML from collected entries */
+const buildTocHtml = (entries: TocEntry[]): string => {
+  const items = entries.map((entry) => {
+    const indent = entry.depth * 20;
+    return `<li style="margin-left:${indent}px"><a href="#${entry.id}">${esc(entry.label)}</a></li>`;
+  });
+  return `<nav class="toc"><h2>Table of Contents</h2><ul>${items.join('\n')}</ul></nav>`;
+};
+
+const PRINT_CSS = `
+  * { box-sizing: border-box; }
+  body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; max-width: 800px; margin: 0 auto; padding: 40px 30px; color: #1a1a1a; line-height: 1.6; }
+  h1 { font-size: 1.6rem; border-bottom: 2px solid #5B8FA8; padding-bottom: 6px; margin-top: 0; }
+  .report-header { display: flex; align-items: center; gap: 12px; border-bottom: 2px solid #5B8FA8; padding-bottom: 8px; margin-bottom: 24px; }
+  .report-header img { height: 36px; width: auto; }
+  .report-header h1 { border-bottom: none; padding-bottom: 0; margin-bottom: 0; }
+  h2 { font-size: 1.3rem; border-bottom: 1px solid #ddd; padding-bottom: 4px; margin-top: 28px; }
+  h3 { font-size: 1.1rem; margin-top: 20px; }
+  h4 { font-size: 1rem; margin-top: 14px; color: #444; }
+  h5, h6 { font-size: 0.95rem; margin-top: 10px; }
+  p { margin: 6px 0; font-size: 0.95rem; }
+  ul { padding-left: 20px; }
+  li { margin: 3px 0; font-size: 0.95rem; }
+  .citation { color: #5B8FA8; font-size: 0.7em; }
+  .citation-link { color: #5B8FA8; text-decoration: none; }
+  .citation-link:hover { text-decoration: underline; }
+  .references { background: #f8f9fa; border-left: 3px solid #5B8FA8; padding: 10px 14px; margin: 14px 0; }
+  .references h4 { margin-top: 0; color: #5B8FA8; }
+  .references ul { list-style: none; padding-left: 0; }
+  .ref-item { font-size: 0.85rem; margin: 4px 0; color: #555; }
+  .tree-graph { margin: 16px 0 28px; }
+  .tree-graph ul { list-style: none; padding-left: 24px; position: relative; }
+  .tree-graph > ul { padding-left: 0; }
+  .tree-graph li { position: relative; padding: 4px 0 4px 16px; }
+  .tree-graph li::before { content: ''; position: absolute; left: -8px; top: 14px; width: 16px; border-top: 2px solid #5B8FA8; }
+  .tree-graph li::after { content: ''; position: absolute; left: -8px; top: 0; bottom: 0; border-left: 2px solid #5B8FA8; }
+  .tree-graph li:last-child::after { bottom: calc(100% - 14px); }
+  .tree-graph > ul > li::before, .tree-graph > ul > li::after { display: none; }
+  .graph-label { display: inline-block; padding: 3px 10px; border: 1px solid #5B8FA8; border-radius: 4px; background: #f8f9fa; font-size: 0.85rem; color: #1a1a1a; }
+  .toc { margin-bottom: 28px; }
+  .toc ul { list-style: none; padding-left: 0; }
+  .toc li { margin: 3px 0; font-size: 0.95rem; }
+  .toc a { color: #5B8FA8; text-decoration: none; }
+  .toc a:hover { text-decoration: underline; }
+  @media print {
+    body { padding: 20px; max-width: none; }
+    .toc a { color: #333; }
+    .references { break-inside: avoid; }
+    h2, h3, h4 { break-after: avoid; }
+  }
+`;
+
+/** Export the drilldown tree as a print-ready PDF document */
+export const exportResearchToPdf = (
+  tree: DrilldownNode,
+  globalSummary?: string,
+  globalSummaryResults?: SearchResult[]
+): void => {
+  const toc: TocEntry[] = [];
+  const counter = { value: 0 };
+  let bodyHtml = '';
+
+  // Global summary section
+  if (globalSummary) {
+    const globalResults = globalSummaryResults || [];
+    const globalId = toAnchorId('Global Summary', counter.value++);
+    toc.push({ id: globalId, label: 'Global Summary', depth: 0 });
+    bodyHtml += `<h1 id="${globalId}">Global Summary</h1>\n`;
+    bodyHtml += parseSummaryToHtml(globalSummary, globalResults);
+    bodyHtml += buildReferencesHtml(
+      buildGroupedReferences(globalSummary, globalResults)
+    );
+  }
+
+  // Tree sections
+  bodyHtml += buildTreeSections(tree, 0, toc, counter);
+
+  const tocHtml = buildTocHtml(toc);
+  const graphHtml = buildGraphHtml(tree, !!globalSummary);
+  const docTitle = 'Evidence Lab - AI Summary Tree';
+  const querySlug = tree.label
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+    .slice(0, 60);
+  const fileTitle = `${docTitle} - ${querySlug}`;
+
+  const fullHtml = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>${esc(fileTitle)}</title>
+<style>${PRINT_CSS}</style>
+</head>
+<body>
+<div class="report-header">
+<img src="/logo.png" alt="Evidence Lab" />
+<h1>${docTitle}</h1>
+</div>
+${graphHtml}
+${tocHtml}
+${bodyHtml}
+<script>window.onload = function() { window.print(); }<\/script>
+</body>
+</html>`;
+
+  const printWindow = window.open('', '_blank');
+  if (printWindow) {
+    printWindow.document.write(fullHtml);
+    printWindow.document.close();
+  }
+};


### PR DESCRIPTION
## Summary
- Adds "Export research" (PDF via `window.print()`) and "Generate Global Summary" buttons to the AI Summary Tree graph view
- PDF export includes: report header, visual tree graph, table of contents, clickable citation links to source documents, and grouped references
- Fixes bug where the currently-viewed node's summary was missing from the export
- Zero new dependencies — uses `window.open` + `window.print()` with embedded print CSS

## Changes
| File | Change |
|------|--------|
| `ui/frontend/src/utils/exportResearch.ts` | **NEW** — PDF export utility with citation links, tree graph, TOC |
| `ui/frontend/src/components/AiSummaryPanel.tsx` | Add download/global summary buttons, tri-state viewMode, export handler with live-state patching |
| `ui/frontend/src/components/AiSummaryReferences.tsx` | Export `buildGroupedReferences` and `DocumentGroup` |
| `ui/frontend/src/components/app/SearchTabContent.tsx` | Thread `dataSource` and `summaryModelConfig` props |
| `ui/frontend/src/App.tsx` | Pass `dataSource` and `summaryModelConfig` to SearchTabContent |

## Test plan
- [ ] Build in Docker: `docker compose up -d --build -V ui`
- [ ] Navigate to AI Summary Tree → drill into 2+ sub-nodes
- [ ] Click "Show tree" → verify "Export research" and "Generate Global Summary" buttons appear
- [ ] Click "Export research" → verify PDF opens with all nodes including the last-viewed one
- [ ] Click "Generate Global Summary" → verify global summary renders with citations
- [ ] Export after generating global summary → verify it appears in the PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)