### PR TITLE
Fix duplicate scrollbar on document column filters

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -1507,8 +1507,6 @@ h6,
 
 .filter-popover-content {
   padding: 12px;
-  overflow-y: auto;
-  max-height: 340px;
 }
 
 /* Text filter input */


### PR DESCRIPTION
## Summary
- Remove `overflow-y: auto` and `max-height` from `.filter-popover-content` which was creating a second scrollbar alongside `.filter-multiselect-options`
- The inner options list already handles scrolling correctly

## Test plan
- [ ] Open Documents tab, click a column filter with many options (e.g. Agency)
- [ ] Verify only one scrollbar appears in the filter dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)