### PR TITLE
Show all organizations in stats bar chart

### DIFF
--- a/ui/frontend/src/components/documents/DocumentsChart.tsx
+++ b/ui/frontend/src/components/documents/DocumentsChart.tsx
@@ -131,7 +131,7 @@ const getChartEntries = (
   if (chartView === 'year') {
     return [...entries].sort((a, b) => b[0].localeCompare(a[0]));
   }
-  if (chartView === 'country') {
+  if (chartView === 'country' || chartView === 'agency') {
     return entries;
   }
   return entries.slice(0, 10);


### PR DESCRIPTION
## Summary
- Remove the top-10 limit on the organization/agency bar chart in the stats page
- All organizations are now displayed, matching the behavior of country and year views

## Test plan
- [ ] Open stats page, switch to Organization view
- [ ] Verify all organizations appear in the bar chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)