### PR TITLE
fix: handle brotli-compressed Qdrant snapshots in dump/restore

### DIFF
--- a/scripts/sync/db/dump_qdrant.py
+++ b/scripts/sync/db/dump_qdrant.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -186,8 +185,13 @@ def dump_qdrant(
 
             with requests.get(download_url, headers=headers, stream=True) as r:
                 r.raise_for_status()
+                # Use iter_content instead of r.raw so that
+                # content-encoding (brotli, gzip) is decoded
+                # automatically by the requests/urllib3 stack.
                 with open(target_file, "wb") as f:
-                    shutil.copyfileobj(r.raw, f)
+                    for chunk in r.iter_content(chunk_size=8 * 1024 * 1024):
+                        if chunk:
+                            f.write(chunk)
 
             if target_file.stat().st_size == 0:
                 logger.error(

--- a/scripts/sync/db/restore_qdrant.py
+++ b/scripts/sync/db/restore_qdrant.py
@@ -12,6 +12,13 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 from qdrant_client import QdrantClient
+
+try:
+    import brotli as _brotli
+
+    _HAS_BROTLI = True
+except ImportError:
+    _HAS_BROTLI = False
 from qdrant_client.http import models as qmodels
 
 # This python script is executed INSIDE the restore worker container
@@ -383,6 +390,44 @@ def restore_qdrant(*, source: Path, use_dev: bool, skip_wait: bool) -> None:
         snapshots = list(extract_dir.rglob("*.snapshot"))
         if not snapshots:
             raise RuntimeError("No .snapshot files found in source.")
+
+        # Decompress brotli-encoded snapshots if needed.
+        # Qdrant's HTTP API may serve snapshots with brotli
+        # content-encoding; the dump script historically saved
+        # the raw (compressed) bytes.  Valid snapshots are tar
+        # archives whose first bytes are a POSIX path; brotli
+        # data never starts that way.
+        for snap in snapshots:
+            with open(snap, "rb") as fh:
+                magic = fh.read(6)
+            is_tar = magic[:2] in (b"0/", b"./", b"co")  # common tar path starts
+            if not is_tar and _HAS_BROTLI:
+                logger.info("Decompressing brotli snapshot: %s", snap.name)
+                with open(snap, "rb") as fh:
+                    raw = fh.read()
+                try:
+                    decompressed = _brotli.decompress(raw)
+                except _brotli.error:
+                    logger.warning(
+                        "Snapshot %s is not tar and not brotli — skipping decompression",
+                        snap.name,
+                    )
+                    continue
+                with open(snap, "wb") as fh:
+                    fh.write(decompressed)
+                logger.info(
+                    "  Decompressed %s: %d -> %d bytes",
+                    snap.name,
+                    len(raw),
+                    len(decompressed),
+                )
+            elif not is_tar and not _HAS_BROTLI:
+                logger.warning(
+                    "Snapshot %s does not appear to be a tar archive and "
+                    "brotli is not installed (pip install brotli). "
+                    "Restore may fail.",
+                    snap.name,
+                )
 
         logger.info("Found snapshots: %s", [s.name for s in snapshots])
 


### PR DESCRIPTION
## Summary
- **dump_qdrant.py**: Switch from `shutil.copyfileobj(r.raw)` to `r.iter_content()` so content-encoding (brotli, gzip) is decoded automatically during snapshot download
- **restore_qdrant.py**: Detect non-tar snapshots and decompress with brotli before cold restore, as a safety net for existing compressed dumps

Plain tar snapshots (docker-to-docker same host) continue to work unchanged.

## Context
Qdrant's HTTP API may serve snapshot downloads with brotli content-encoding. The dump script was saving the raw compressed bytes, producing `.snapshot` files that were not valid tar archives. This caused restore failures when transferring dumps between environments (e.g. Mac Docker → Azure prod).

## Test plan
- [ ] Dump from Docker Qdrant on Mac, restore on prod server
- [ ] Dump and restore within same Docker environment (no brotli)
- [ ] Restore an existing brotli-compressed snapshot with the updated restore script

🤖 Generated with [Claude Code](https://claude.com/claude-code)