### PR TITLE
Add Docker Hub auth to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,12 @@ jobs:
           docker system prune -af
           df -h /
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
         with:
@@ -342,6 +348,12 @@ jobs:
         run: |
           test -f .env || touch .env
         working-directory: ${{ github.workspace }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build shared Python image
         run: |


### PR DESCRIPTION
## Summary
- Add `docker/login-action` to both container-scan and integration-tests CI jobs
- Uses `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repo secrets (already configured)
- Fixes `429 Too Many Requests` errors from Docker Hub rate limiting on shared GitHub Actions runners

## Test plan
- [ ] CI pipeline passes without Docker Hub rate limit errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)