### PR TITLE
docs: add UN Mandates Registry data source

### DIFF
--- a/docs/overview/data.md
+++ b/docs/overview/data.md
@@ -4,6 +4,7 @@ In order to test a document ingestion pipeline and AI tools, and to confirm it's
 
 - About 19,000 United Nations humanitarian evaluation reports (1985–2025) from 30+ agencies sourced from the [United Nations Evaluation Group (UNEG)](https://www.un.org/evaluations). The UNEG site is evolving rapidly as it's developed and so data formats are changing. The snapshot in Evidence Lab was created in Dec 2025, and will be refreshed as the site evolves.
 - About 10,500 reports related to Fraud and Program Integrity (2020–2026) sourced from [The World Bank](https://www.worldbank.org/ext/en/home) via the [World Bank Documents & Reports API](https://documents.worldbank.org). The snapshot in Evidence Lab was created in Mar 2026.
+- About 4,000 United Nations resolutions and decisions sourced from the [UN Mandates Registry](https://www.un.org/securitycouncil/content/mandates-registry) covering the General Assembly, Security Council, and other UN organs. The snapshot in Evidence Lab was created in Mar 2026.
 
 ## No Affiliation or Endorsement
 

--- a/docs/overview/data_and_attribution.md
+++ b/docs/overview/data_and_attribution.md
@@ -5,12 +5,14 @@ Evidence Lab includes publicly available documents sourced from third parties fo
 The current online instance at [evidencelab.ai](https://evidencelab.ai) includes:
 
 - Approximately 20,000 United Nations humanitarian evaluation reports sourced from the United Nations Evaluation Group (UNEG).
+- Approximately 10,500 reports related to Fraud and Program Integrity sourced from The World Bank via the World Bank Documents & Reports API.
+- Approximately 4,000 United Nations resolutions and decisions sourced from the UN Mandates Registry covering the General Assembly, Security Council, and other UN organs.
 
-Links to source document UNEG hosting pages and agency PDFs are provided throughout Evidence Lab.
+Links to source document hosting pages and PDFs are provided throughout Evidence Lab.
 
 ## No Affiliation or Endorsement
 
-Evidence Lab is not affiliated with, endorsed by, or associated with the United Nations, the United Nations Evaluation Group, or any of its agencies or programs.
+Evidence Lab is not affiliated with, endorsed by, or associated with the United Nations, the United Nations Evaluation Group, the World Bank, the UN Mandates Registry, or any of their agencies or programs.
 
 The inclusion of these documents is solely for research, testing, and demonstration purposes.
 


### PR DESCRIPTION
## Summary
- Add ~4,000 UN Mandates Registry resolutions/decisions to data source documentation
- Update `data_and_attribution.md` to list all three data sources (was missing World Bank and UN Mandates)
- Update no-affiliation disclaimer to cover all three sources

## Test plan
- [ ] Verify data.md renders correctly in the docs viewer
- [ ] Verify data_and_attribution.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)