### PR TITLE
Fix translate, highlight and assistant 401 auth errors

### DIFF
--- a/tests/unit/test_fetch_credentials.py
+++ b/tests/unit/test_fetch_credentials.py
@@ -1,0 +1,86 @@
+"""Ensure every fetch(API_BASE_URL/...) call includes credentials: 'include'.
+
+Without credentials, requests to authenticated endpoints fail with 401
+when ActiveAuthMiddleware is enabled. This test scans all frontend
+source files and flags fetch calls that are missing the credential.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+SRC_DIR = Path("ui/frontend/src")
+
+# Paths that are exempt from auth (match EXEMPT_PATH_PREFIXES in active_auth.py)
+EXEMPT_PATHS = (
+    "/auth/",
+    "/config/",
+    "/health",
+    "/users/",
+    "/groups/",
+    "/ratings/",
+    "/activity/",
+    "/api-keys",
+)
+
+
+def _find_fetch_calls_missing_credentials():
+    """Return list of (file, line_number, line) for fetch calls without credentials."""
+    issues = []
+    for ts_file in SRC_DIR.rglob("*.ts*"):
+        if "node_modules" in str(ts_file) or ".test." in str(ts_file):
+            continue
+        lines = ts_file.read_text().splitlines()
+        for i, line in enumerate(lines):
+            # Match fetch(`${API_BASE_URL}/...
+            if re.search(r"fetch\(\`\$\{API_BASE_URL\}", line):
+                # Check if the URL is an exempt path
+                exempt = any(f'/{p.strip("/")}' in line for p in EXEMPT_PATHS)
+                if exempt:
+                    continue
+                # Look in the next 5 lines for credentials: 'include'
+                block = "\n".join(lines[i : i + 6])
+                if "credentials" not in block:
+                    issues.append((str(ts_file), i + 1, line.strip()))
+    return issues
+
+
+def _find_fetch_calls_missing_api_key():
+    """Return list of (file, line_number, line) for fetch calls without X-API-Key."""
+    issues = []
+    for ts_file in SRC_DIR.rglob("*.ts*"):
+        if "node_modules" in str(ts_file) or ".test." in str(ts_file):
+            continue
+        lines = ts_file.read_text().splitlines()
+        for i, line in enumerate(lines):
+            if re.search(r"fetch\(\`\$\{API_BASE_URL\}", line):
+                exempt = any(f'/{p.strip("/")}' in line for p in EXEMPT_PATHS)
+                if exempt:
+                    continue
+                # Look in surrounding context (headers may be built above)
+                start = max(0, i - 10)
+                block = "\n".join(lines[start : i + 8])
+                if "X-API-Key" not in block:
+                    issues.append((str(ts_file), i + 1, line.strip()))
+    return issues
+
+
+def test_all_api_fetch_calls_include_credentials():
+    """Every fetch to API_BASE_URL must include credentials: 'include'."""
+    issues = _find_fetch_calls_missing_credentials()
+    if issues:
+        msg = "fetch() calls missing credentials: 'include':\n"
+        for path, lineno, line in issues:
+            msg += f"  {path}:{lineno}: {line}\n"
+        pytest.fail(msg)
+
+
+def test_all_api_fetch_calls_include_api_key():
+    """Every fetch to API_BASE_URL must include X-API-Key header."""
+    issues = _find_fetch_calls_missing_api_key()
+    if issues:
+        msg = "fetch() calls missing X-API-Key header:\n"
+        for path, lineno, line in issues:
+            msg += f"  {path}:{lineno}: {line}\n"
+        pytest.fail(msg)

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import './App.css';
 import API_BASE_URL, {
   AI_SUMMARY_ON,
+  API_KEY,
   SEARCH_SEMANTIC_HIGHLIGHTS,
   SEMANTIC_HIGHLIGHT_THRESHOLD,
   SEARCH_RESULTS_PAGE_SIZE,
@@ -145,7 +146,8 @@ const translateViaApi = async (text: string, targetLanguage: string, sourceLangu
     const csrfToken = getCsrfToken();
     const resp = await fetch(`${API_BASE_URL}/translate`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', ...(API_KEY ? { 'X-API-Key': API_KEY } : {}), ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
       body: JSON.stringify({ text, target_language: targetLanguage, source_language: sourceLanguage })
     });
     if (resp.ok) {

--- a/ui/frontend/src/components/app/HeatmapTabContent.tsx
+++ b/ui/frontend/src/components/app/HeatmapTabContent.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import axios from 'axios';
 import * as XLSX from 'xlsx-js-style';
 import API_BASE_URL, {
+  API_KEY,
   HEATMAP_CELL_LIMIT,
   SEARCH_SEMANTIC_HIGHLIGHTS,
   SEMANTIC_HIGHLIGHT_THRESHOLD,
@@ -1004,7 +1005,8 @@ const translateWithFallback = async (text: string, newLang: string, label: strin
     const csrfToken = getCsrfToken();
     const resp = await fetch(`${API_BASE_URL}/translate`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json', ...(API_KEY ? { 'X-API-Key': API_KEY } : {}), ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
       body: JSON.stringify({ text, target_language: newLang }),
     });
     if (resp.ok) {

--- a/ui/frontend/src/components/assistant/AssistantTab.tsx
+++ b/ui/frontend/src/components/assistant/AssistantTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
-import API_BASE_URL, { USER_MODULE } from '../../config';
+import API_BASE_URL, { API_KEY, USER_MODULE } from '../../config';
 import { useAuth } from '../../hooks/useAuth';
 import { useRatings, Rating } from '../../hooks/useRatings';
 import { ChatMessage, SearchResult, SearchToolCall, SourceReference, SummaryModelConfig, ThreadListItem } from '../../types/api';
@@ -107,6 +107,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
     try {
       const response = await fetch(`${API_BASE_URL}/assistant/threads`, {
         credentials: 'include',
+        headers: { ...(API_KEY ? { 'X-API-Key': API_KEY } : {}) },
       });
       if (response.ok) {
         const data = await response.json();
@@ -121,6 +122,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
     try {
       const response = await fetch(`${API_BASE_URL}/assistant/threads/${threadId}`, {
         credentials: 'include',
+        headers: { ...(API_KEY ? { 'X-API-Key': API_KEY } : {}) },
       });
       if (response.ok) {
         const data = await response.json();
@@ -150,6 +152,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
     try {
       const csrfMatch = document.cookie.match(/(?:^|;\s*)evidencelab_csrf=([^;]*)/);
       const headers: Record<string, string> = {};
+      if (API_KEY) headers['X-API-Key'] = API_KEY;
       if (csrfMatch) {
         headers['X-CSRF-Token'] = decodeURIComponent(csrfMatch[1]);
       }
@@ -174,6 +177,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
     try {
       const csrfMatch = document.cookie.match(/(?:^|;\s*)evidencelab_csrf=([^;]*)/);
       const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (API_KEY) headers['X-API-Key'] = API_KEY;
       if (csrfMatch) {
         headers['X-CSRF-Token'] = decodeURIComponent(csrfMatch[1]);
       }

--- a/ui/frontend/src/utils/textHighlighting.tsx
+++ b/ui/frontend/src/utils/textHighlighting.tsx
@@ -1,6 +1,6 @@
 // Shared text highlighting and rendering utilities used by App, PDFViewer, and SearchResultCard
 import React from 'react';
-import API_BASE_URL, { SEARCH_SEMANTIC_HIGHLIGHTS } from '../config';
+import API_BASE_URL, { API_KEY, SEARCH_SEMANTIC_HIGHLIGHTS } from '../config';
 import { SearchResult, SummaryModelConfig } from '../types/api';
 
 const getCsrfToken = (): string | null => {
@@ -192,8 +192,10 @@ export const highlightTextWithAPI = async (
     const csrfToken = getCsrfToken();
     const response = await fetch(`${API_BASE_URL}/highlight`, {
       method: 'POST',
+      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
+        ...(API_KEY ? { 'X-API-Key': API_KEY } : {}),
         ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {})
       },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Add `credentials: 'include'` and `X-API-Key` header to all frontend fetch calls that were missing them
- Affected: translate (search + heatmap), semantic highlight, assistant thread CRUD
- Add unit test scanning all fetch calls for both credentials and API key to prevent regressions

## Test plan
- [ ] Search, verify translate dropdown works on results
- [ ] Verify semantic highlighting appears on search results
- [ ] Verify heatmap translate works
- [ ] Verify assistant thread list/load/delete/rename work
- [ ] `pytest tests/unit/test_fetch_credentials.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)