### PR TITLE
fix(docs): add MCP docs to root docs/ so they survive the build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,11 @@
 
 ## Git Commits
 - **NEVER use `--no-verify` when committing.** If a pre-commit hook fails, ALWAYS fix the underlying issue (lint errors, formatting, complexity, etc.) before committing again. No exceptions.
+- **NEVER commit directly to `main`, `rc/v*`, or any release branch.** All changes go on a feature branch and in via PR. No exceptions.
+
+## Documentation
+- **All docs MUST go in `docs/` at the repo root.** The directory `ui/frontend/public/docs/` is wiped and regenerated from `docs/` at every build by `copy-docs.js`. Anything written there will be lost on the next build.
+- **`docs/docs.json` is the source of truth** for the docs sidebar. Add new pages here.
 
 ## Code Quality
 - **NEVER use `noqa`, `type: ignore`, or similar suppressions to bypass pre-commit hooks or linters.** Fix the actual issue instead. Only use suppressions if explicitly requested by the user.

--- a/docs/admin/mcp-server.md
+++ b/docs/admin/mcp-server.md
@@ -1,0 +1,154 @@
+# MCP Server Administration
+
+The MCP server runs as a separate Docker service that exposes Evidence Lab's search and assistant capabilities via the [Model Context Protocol](https://modelcontextprotocol.io/).
+
+## Architecture
+
+The MCP server is a standalone Python service (`mcp_server/`) that imports Evidence Lab's search and assistant services directly. It runs alongside the API server but on its own port (default 8001), with nginx proxying `/mcp` to it.
+
+```
+Client (Claude/ChatGPT)
+  |
+  v
+nginx (/mcp -> http://mcp:8001/mcp)
+  |
+  v
+MCP Server (Streamable HTTP transport)
+  |
+  v
+Evidence Lab Services (search, assistant, document retrieval)
+  |
+  v
+Qdrant + PostgreSQL
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MCP_PORT` | `8001` | Port the MCP server listens on |
+| `API_SECRET_KEY` | *required* | Shared secret for API key authentication |
+| `AUTH_SECRET_KEY` | *required* | Secret for JWT token verification |
+| `APP_BASE_URL` | `https://evidencelab.ai` | Base URL for OAuth redirects and citation links |
+| `OAUTH_CALLBACK_BASE_URL` | `http://localhost:8000` | Base URL for OAuth callbacks |
+| `RATE_LIMIT_MCP_SEARCH` | `30/minute` | Rate limit for search and get_document tools |
+| `RATE_LIMIT_MCP_AI` | `10/minute` | Rate limit for ask_assistant tool |
+
+### Docker Compose
+
+The MCP server is defined as the `mcp` service in `docker-compose.yml`. It shares the same base image as the API server and mounts the same data, config, and model cache volumes.
+
+### Nginx Proxy
+
+Add the following to your nginx configuration to proxy MCP requests:
+
+```nginx
+location /mcp {
+    proxy_pass http://mcp:8001/mcp;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 120s;
+}
+```
+
+## Authentication
+
+The MCP server supports three authentication methods:
+
+### 1. API Key
+
+Clients can authenticate by passing an API key in the `X-API-Key` header. This matches either:
+- The `API_SECRET_KEY` environment variable (master key)
+- An admin-generated API key stored in the database
+
+### 2. OAuth 2.0 (for Claude and ChatGPT)
+
+The MCP server implements OAuth 2.0 Authorization Server Metadata (RFC 8414) for browser-based login flows used by Claude Desktop and ChatGPT.
+
+**Flow:**
+
+1. Client discovers OAuth endpoints via `GET /mcp/.well-known/oauth-authorization-server`
+2. Client redirects user to `/mcp/authorize` with PKCE parameters
+3. User sees the Evidence Lab login page (email/password, Microsoft, or Google)
+4. After login, Evidence Lab redirects back to `/mcp/complete` with the auth session
+5. MCP server generates an authorization code and redirects to the client's callback
+6. Client exchanges the code for an access token via `/mcp/token`
+7. Client uses the access token as a Bearer token in subsequent MCP requests
+
+**OAuth endpoints:**
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /mcp/.well-known/oauth-authorization-server` | OAuth metadata discovery |
+| `GET /mcp/authorize` | Authorization endpoint (redirects to login) |
+| `GET /mcp/complete` | Post-login completion (generates auth code) |
+| `POST /mcp/token` | Token exchange endpoint |
+| `POST /mcp/register` | Dynamic client registration (RFC 7591) |
+
+### 3. Bearer JWT
+
+Clients can pass a JWT token in the `Authorization: Bearer <token>` header. The token is verified using the `AUTH_SECRET_KEY`.
+
+## Tools
+
+The MCP server exposes three tools, all read-only:
+
+| Tool | Description | Rate Limit |
+|------|-------------|------------|
+| `search` | Hybrid semantic + keyword search across document chunks | 30/min |
+| `get_document` | Retrieve full document metadata by ID | 30/min |
+| `ask_assistant` | AI research assistant with citation synthesis | 10/min |
+
+Tool parameters, descriptions, and available data sources are driven by `config.json`. When data sources are added or removed, the MCP tool descriptions update automatically.
+
+## Monitoring
+
+### Audit Logging
+
+All MCP tool calls are logged with:
+- Tool name and input parameters
+- Authentication method and user identity
+- Response time and status
+- Client IP address
+
+Logs are written to the standard application log and can be viewed via `docker compose logs mcp`.
+
+### Health Check
+
+```bash
+curl https://your-instance.example.com/mcp/health
+```
+
+Returns `{"status": "ok", "service": "mcp"}` when the server is running.
+
+## Troubleshooting
+
+### Connection Refused
+
+Ensure the MCP container is running: `docker compose ps mcp`
+
+If the container is not starting, check logs: `docker compose logs mcp`
+
+### OAuth Login Not Working
+
+- Verify `APP_BASE_URL` is set correctly (must be the externally-accessible URL)
+- Ensure the nginx proxy is configured for `/mcp`
+- Check that at least one OAuth provider (Microsoft or Google) is configured
+
+### Rate Limiting
+
+If users are hitting rate limits, adjust via environment variables:
+
+```bash
+RATE_LIMIT_MCP_SEARCH=60/minute
+RATE_LIMIT_MCP_AI=20/minute
+```
+
+### Model Errors
+
+If `ask_assistant` returns model errors, verify the configured model combo is available. The default is "Azure Foundry" which requires Azure OpenAI credentials. Check that `AZURE_FOUNDRY_API_KEY` and `AZURE_FOUNDRY_ENDPOINT` are set.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -7,7 +7,8 @@
         { "title": "About Evidence Lab", "path": "overview/about.md" },
         { "title": "Getting Started", "path": "overview/getting-started.md" },
         { "title": "Technical Info", "path": "overview/tech.md" },
-        { "title": "Data Sources", "path": "overview/data.md" }
+        { "title": "Data Sources", "path": "overview/data.md" },
+        { "title": "Using in AI Platforms", "path": "overview/mcp.md" }
       ]
     },
     {
@@ -27,7 +28,8 @@
         { "title": "Pipeline Configuration", "path": "admin/pipeline-configuration.md" },
         { "title": "User Administration", "path": "admin/user-administration.md" },
         { "title": "API", "path": "admin/api-keys.md" },
-        { "title": "System Monitoring", "path": "admin/system-monitoring.md" }
+        { "title": "System Monitoring", "path": "admin/system-monitoring.md" },
+        { "title": "MCP Server", "path": "admin/mcp-server.md" }
       ]
     }
   ]


### PR DESCRIPTION
## Summary

- `copy-docs.js` **wipes** `public/docs/` at every build and replaces it from the root `docs/` folder. The MCP admin page and `docs.json` entries were only committed to `ui/frontend/public/docs/`, so they were deleted on every build — which is why the MCP docs never appeared in the deployed UI.
- Adds `docs/admin/mcp-server.md` (copied from `ui/frontend/public/docs/admin/mcp-server.md`)
- Adds MCP entries to `docs/docs.json`: "Using in AI Platforms" under Overview, "MCP Server" under Admin

## Important note for all future docs work

**All documentation must go in `docs/` at the repo root.** Do not add docs to `ui/frontend/public/docs/` — that directory is wiped and regenerated at every build.

## Test plan

- [ ] Rebuild UI container
- [ ] Confirm "Using in AI Platforms" appears under Overview in the docs sidebar
- [ ] Confirm "MCP Server" appears under Admin in the docs sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)