### PR TITLE
fix(tls): explicitly enforce TLS 1.2+ minimum in Caddyfile

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -8,6 +8,14 @@
 # Protected by API key in X-API-Key header
 
 evidencelab.ai, www.evidencelab.ai {
+	# Enforce TLS 1.2+ — disables TLS 1.0/1.1 and their weak cipher suites
+	# (RC4, 3DES, etc.). Satisfies NIST SP 800-131A key-length requirements
+	# through 2030. Caddy defaults to this, but explicit config prevents
+	# regression on future Caddy upgrades.
+	tls {
+		protocols tls1.2 tls1.3
+	}
+
 	# Redirect www to bare domain
 	@www host www.evidencelab.ai
 	redir @www https://evidencelab.ai{uri} permanent


### PR DESCRIPTION
## Summary

- Adds `tls { protocols tls1.2 tls1.3 }` to the Caddyfile, explicitly disabling TLS 1.0 and 1.1 (and their associated weak cipher suites: RC4, 3DES, export-grade ciphers)
- Caddy already defaults to TLS 1.2+, but without an explicit directive a future Caddy upgrade could silently change the default

## Why

Satisfies two OpenSSF Best Practices criteria:

1. **Key lengths** — *"security mechanisms MUST use default key lengths that at least meet NIST SP 800-131A minimums through 2030"*. TLS 1.2+ with AES-128-GCM/AES-256-GCM/ChaCha20 meets this. TLS 1.0/1.1 with RC4 or 3DES does not.

2. **Configurability** — *"it MUST be possible to configure the software so that smaller key lengths are completely disabled"*. This directive makes that explicit and machine-verifiable.

## Test plan

- [ ] `curl -I --tls-max 1.1 https://evidencelab.ai` → connection refused
- [ ] `curl -I https://evidencelab.ai` (TLS 1.2+) → 200
- [ ] Verify with `nmap --script ssl-enum-ciphers -p 443 evidencelab.ai` — no TLS 1.0/1.1 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)