### PR TITLE
docs: add OAUTH_CALLBACK_BASE_URL to .env.example and auth docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,11 @@ AUTH_SECRET_KEY=
 # Base URL for email links (verification, password reset)
 APP_BASE_URL=http://localhost:3000
 
+# Base URL for OAuth callback endpoints (must match redirect URIs registered
+# in the OAuth provider). In production behind a reverse proxy, this should be
+# the public URL including any path prefix, e.g. https://example.com/api
+OAUTH_CALLBACK_BASE_URL=http://localhost:8000
+
 # Registration controls — restrict who can sign up
 # Comma-separated list of allowed email domains (e.g. "example.com,corp.org").
 # Leave empty for open registration (anyone can register).

--- a/docs/admin/user-administration.md
+++ b/docs/admin/user-administration.md
@@ -51,6 +51,14 @@ OAUTH_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 OAUTH_GOOGLE_CLIENT_SECRET=your-client-secret
 ```
 
+5. Set `OAUTH_CALLBACK_BASE_URL` to the public base URL that the browser uses to reach the API. In production behind a reverse proxy this includes the path prefix:
+
+```env
+OAUTH_CALLBACK_BASE_URL=https://yourdomain.com/api
+```
+
+   The redirect URI registered in Google must match: `{OAUTH_CALLBACK_BASE_URL}/auth/google/callback`. For local development the default (`http://localhost:8000`) is used when this variable is unset.
+
 Evidence Lab requests the `openid`, `email`, and `profile` scopes. If a user registers with email/password first and then signs in with Google using the same email, the accounts are automatically linked.
 
 #### 3. Setting Up Microsoft / Azure OAuth
@@ -61,7 +69,7 @@ To enable "Sign in with Microsoft":
 2. Register a new application
 3. Under **Authentication**, add a **Web** redirect URI:
    - Local development: `http://localhost:8000/auth/microsoft/callback`
-   - Production: `https://yourdomain.com/api/auth/microsoft/callback`
+   - Production: `{OAUTH_CALLBACK_BASE_URL}/auth/microsoft/callback` (e.g. `https://yourdomain.com/api/auth/microsoft/callback`)
 4. Under **Certificates & secrets**, create a new client secret
 5. Copy the values into your `.env`:
 


### PR DESCRIPTION
## Summary
- Added `OAUTH_CALLBACK_BASE_URL` to `.env.example` with a comment explaining its purpose
- Updated OAuth setup instructions in `docs/admin/user-administration.md` to reference the variable for both Google and Microsoft providers
- Without this variable, OAuth redirects default to `http://localhost:8000`, which breaks production deployments behind a reverse proxy

## Test plan
- [ ] Verify `.env.example` renders correctly
- [ ] Verify docs build includes the updated user-administration page

🤖 Generated with [Claude Code](https://claude.com/claude-code)