### PR TITLE
ci: update dependabot target-branch to rc/v1.4.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -21,7 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -36,7 +36,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:
@@ -49,7 +49,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:
@@ -62,7 +62,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:
@@ -75,7 +75,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
## Summary
- Updated all 6 `target-branch` entries in `.github/dependabot.yml` from `rc/v1.2.0` to `rc/v1.4.0`
- Root cause of all 10 failing dependabot PRs: branches were created from stale `rc/v1.2.0` which lacks the `container-scan` skip fix (`c18ab32`)
- After merge, dependabot will create new PRs against `rc/v1.4.0` where CI correctly skips `container-scan` and `integration-tests` for dependabot actors

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, confirm dependabot closes stale PRs and opens new ones against `rc/v1.4.0`
- [ ] Verify new dependabot PRs pass CI (container-scan skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)