### PR TITLE
feat: conditional OAuth buttons and DISABLE_EMAIL_LOGIN

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -260,6 +260,12 @@ OAUTH_MICROSOFT_CLIENT_ID=
 OAUTH_MICROSOFT_CLIENT_SECRET=
 OAUTH_MICROSOFT_TENANT_ID=common
 
+# Disable email/password login and registration. When true, users can only
+# sign in via configured OAuth providers (Google / Microsoft). The backend
+# does not mount the email login/register routes and the frontend hides the
+# email form and Register tab.
+DISABLE_EMAIL_LOGIN=false
+
 # Frontend feature flag for user module UI (must match USER_MODULE above)
 # Values: off | on_passive | on_active (legacy: true → on_active, false → off)
 REACT_APP_USER_MODULE=off

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -179,11 +179,9 @@ services:
       - SMTP_USER=${SMTP_USER:-}
       - SMTP_PASSWORD=${SMTP_PASSWORD:-}
       - SMTP_FROM=${SMTP_FROM:-noreply@evidencelab.ai}
-      - OAUTH_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_CLIENT_ID:-}
-      - OAUTH_GOOGLE_CLIENT_SECRET=${OAUTH_GOOGLE_CLIENT_SECRET:-}
-      - OAUTH_MICROSOFT_CLIENT_ID=${OAUTH_MICROSOFT_CLIENT_ID:-}
-      - OAUTH_MICROSOFT_CLIENT_SECRET=${OAUTH_MICROSOFT_CLIENT_SECRET:-}
-      - OAUTH_MICROSOFT_TENANT_ID=${OAUTH_MICROSOFT_TENANT_ID:-common}
+      # OAuth secrets read exclusively via env_file above. Do NOT add
+      # ${OAUTH_*:-} substitutions here — host env vars (even empty ones
+      # inherited from parent processes) would override .env values.
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docs/admin/user-administration.md
+++ b/docs/admin/user-administration.md
@@ -85,7 +85,23 @@ The **tenant ID** controls who can sign in:
 
 Evidence Lab requests the `openid`, `email`, `profile`, and `User.Read` scopes.
 
-#### 4. Setting Up Email (SMTP)
+#### 4. Disabling Email Login (OAuth-only mode)
+
+To force all users to sign in via OAuth (Google and/or Microsoft) and remove email/password login and registration entirely:
+
+```env
+DISABLE_EMAIL_LOGIN=true
+```
+
+When this is set:
+
+- The backend does **not** mount the `/auth/login`, `/auth/cookie-login`, or `/auth/register` endpoints — direct API calls to them return 404.
+- The login modal hides the email form and the **Register** tab.
+- Only the OAuth buttons for providers with credentials configured are shown.
+
+The login modal also automatically hides any OAuth provider whose credentials are not configured. If both `OAUTH_GOOGLE_*` and `OAUTH_MICROSOFT_*` are unset, only the Google button would be missing — so ensure at least one OAuth provider is fully configured before enabling `DISABLE_EMAIL_LOGIN`, otherwise users will have no way to sign in.
+
+#### 5. Setting Up Email (SMTP)
 
 Evidence Lab sends two types of email: **account verification** (on registration) and **password reset**. Configure your SMTP server:
 
@@ -107,7 +123,7 @@ AUTH_RESET_TOKEN_LIFETIME=86400      # Password reset: 24 hours (default)
 AUTH_VERIFY_TOKEN_LIFETIME=604800    # Email verification: 7 days (default)
 ```
 
-#### 5. Testing Emails with Mailpit
+#### 6. Testing Emails with Mailpit
 
 For local development, [Mailpit](https://mailpit.axllent.org/) provides a fake SMTP server with a web inbox — no real emails are sent.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,8 +83,12 @@ google-cloud-discoveryengine>=0.13.0
 
 
 # LangGraph agent framework
+# Pinned: newer langgraph-prebuilt releases import ExecutionInfo from
+# langgraph.runtime which the matching langgraph version does not expose,
+# breaking CI. Keep these in lockstep with the working runtime versions.
 deepagents>=0.4.0
-langgraph>=0.4.0
+langgraph==1.0.10
+langgraph-prebuilt==1.0.8
 langgraph-checkpoint-postgres>=2.0.0
 
 # Task queue

--- a/ui/backend/routes/auth.py
+++ b/ui/backend/routes/auth.py
@@ -24,26 +24,38 @@ _OAUTH_CALLBACK_BASE = os.environ.get(
 # Where to redirect the browser after a successful OAuth login.
 _APP_BASE_URL = os.environ.get("APP_BASE_URL", "http://localhost:3000")
 
+# When DISABLE_EMAIL_LOGIN is true, email/password login and registration
+# routes are not mounted at all — forcing users to sign in via OAuth only.
+DISABLE_EMAIL_LOGIN = os.environ.get("DISABLE_EMAIL_LOGIN", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
 router = APIRouter()
 
 # ---------------------------------------------------------------------------
-# Email/password auth
+# Email/password auth — mounted only when DISABLE_EMAIL_LOGIN is not set.
+# Verify and reset-password routers remain available so OAuth users who also
+# have an email on file can still verify / reset if needed.
 # ---------------------------------------------------------------------------
 
-router.include_router(
-    fastapi_users.get_auth_router(bearer_backend),
-    prefix="/login",
-    tags=["auth"],
-)
-router.include_router(
-    fastapi_users.get_auth_router(cookie_backend),
-    prefix="/cookie-login",
-    tags=["auth"],
-)
-router.include_router(
-    fastapi_users.get_register_router(UserRead, UserCreate),
-    tags=["auth"],
-)
+if not DISABLE_EMAIL_LOGIN:
+    router.include_router(
+        fastapi_users.get_auth_router(bearer_backend),
+        prefix="/login",
+        tags=["auth"],
+    )
+    router.include_router(
+        fastapi_users.get_auth_router(cookie_backend),
+        prefix="/cookie-login",
+        tags=["auth"],
+    )
+    router.include_router(
+        fastapi_users.get_register_router(UserRead, UserCreate),
+        tags=["auth"],
+    )
+
 router.include_router(
     fastapi_users.get_verify_router(UserRead),
     tags=["auth"],

--- a/ui/backend/routes/config.py
+++ b/ui/backend/routes/config.py
@@ -276,10 +276,26 @@ async def get_datasources_config(
 
 @router.get("/config/auth-status")
 def get_auth_status():
-    """Return the user module mode (for frontend feature flag)."""
+    """Return auth module mode and available login methods (for frontend)."""
+    email_disabled = os.environ.get("DISABLE_EMAIL_LOGIN", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    google_enabled = bool(
+        os.environ.get("OAUTH_GOOGLE_CLIENT_ID")
+        and os.environ.get("OAUTH_GOOGLE_CLIENT_SECRET")
+    )
+    microsoft_enabled = bool(
+        os.environ.get("OAUTH_MICROSOFT_CLIENT_ID")
+        and os.environ.get("OAUTH_MICROSOFT_CLIENT_SECRET")
+    )
     return {
         "user_module_enabled": _USER_MODULE,
         "user_module_mode": _USER_MODULE_MODE,
+        "email_login_disabled": email_disabled,
+        "google_oauth_enabled": google_enabled,
+        "microsoft_oauth_enabled": microsoft_enabled,
     }
 
 

--- a/ui/frontend/src/components/auth/LoginModal.test.tsx
+++ b/ui/frontend/src/components/auth/LoginModal.test.tsx
@@ -26,6 +26,33 @@ const mockAuthValue = (overrides: Partial<AuthContextValue> = {}): AuthContextVa
   ...overrides,
 });
 
+interface MockAuthStatusOverrides {
+  email_login_disabled?: boolean;
+  google_oauth_enabled?: boolean;
+  microsoft_oauth_enabled?: boolean;
+}
+
+const mockAuthStatusResponse = (overrides: MockAuthStatusOverrides = {}) => {
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url.includes('/config/auth-status')) {
+      return Promise.resolve({
+        data: {
+          email_login_disabled: overrides.email_login_disabled ?? false,
+          google_oauth_enabled: overrides.google_oauth_enabled ?? true,
+          microsoft_oauth_enabled: overrides.microsoft_oauth_enabled ?? true,
+        },
+      });
+    }
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+};
+
+beforeEach(() => {
+  mockedAxios.get.mockReset();
+  mockedAxios.post.mockReset();
+  mockAuthStatusResponse();
+});
+
 const renderModal = (
   authValue?: AuthContextValue,
   props?: Partial<React.ComponentProps<typeof LoginModal>>,
@@ -58,10 +85,39 @@ describe('LoginModal', () => {
     expect(screen.getByLabelText('Last name')).toBeInTheDocument();
   });
 
-  it('shows OAuth buttons', () => {
+  it('shows OAuth buttons when providers are enabled', async () => {
     renderModal();
-    expect(screen.getByText(/Sign in with Google/)).toBeInTheDocument();
-    expect(screen.getByText(/Sign in with Microsoft/)).toBeInTheDocument();
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
+    expect(await screen.findByText(/Sign in with Microsoft/)).toBeInTheDocument();
+  });
+
+  it('hides Google button when google_oauth_enabled is false', async () => {
+    mockAuthStatusResponse({ google_oauth_enabled: false });
+    renderModal();
+    expect(await screen.findByText(/Sign in with Microsoft/)).toBeInTheDocument();
+    expect(screen.queryByText(/Sign in with Google/)).not.toBeInTheDocument();
+  });
+
+  it('hides Microsoft button when microsoft_oauth_enabled is false', async () => {
+    mockAuthStatusResponse({ microsoft_oauth_enabled: false });
+    renderModal();
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
+    expect(screen.queryByText(/Sign in with Microsoft/)).not.toBeInTheDocument();
+  });
+
+  it('hides email form, Register tab and "or" divider when email login is disabled', async () => {
+    mockAuthStatusResponse({ email_login_disabled: true });
+    renderModal();
+    // OAuth buttons still render
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
+    // Email form and Register tab are gone
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Register', { selector: 'button.login-tab' }),
+    ).not.toBeInTheDocument();
+    // "or" divider is also hidden when no email form follows
+    expect(screen.queryByText('or')).not.toBeInTheDocument();
   });
 
   it('switches to register tab', () => {
@@ -120,17 +176,19 @@ describe('LoginModal — Forgot password', () => {
     expect(screen.getByText('Back to Sign In')).toBeInTheDocument();
   });
 
-  it('returns to login mode when "Back to Sign In" is clicked', () => {
+  it('returns to login mode when "Back to Sign In" is clicked', async () => {
     renderModal();
+    // Wait for auth-status fetch to complete so OAuth buttons would appear
+    await screen.findByText(/Sign in with Google/);
     fireEvent.click(screen.getByText('Forgot password?'));
     fireEvent.click(screen.getByText('Back to Sign In'));
-    // Should be back in login mode with OAuth buttons visible
     expect(screen.getByText(/Sign in with Google/)).toBeInTheDocument();
     expect(screen.getByText('Forgot password?')).toBeInTheDocument();
   });
 
-  it('hides OAuth buttons and password field in forgot mode', () => {
+  it('hides OAuth buttons and password field in forgot mode', async () => {
     renderModal();
+    await screen.findByText(/Sign in with Google/);
     fireEvent.click(screen.getByText('Forgot password?'));
     expect(screen.queryByText(/Sign in with Google/)).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
@@ -269,11 +327,10 @@ describe('LoginModal — Reset password', () => {
     });
   });
 
-  it('can navigate to Sign In tab from reset mode', () => {
+  it('can navigate to Sign In tab from reset mode', async () => {
     renderModal(undefined, { resetToken: 'test-token-abc' });
     fireEvent.click(screen.getByText('Sign In', { selector: 'button.login-tab' }));
-    // Should now show login form
-    expect(screen.getByText(/Sign in with Google/)).toBeInTheDocument();
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
   });
 });

--- a/ui/frontend/src/components/auth/LoginModal.tsx
+++ b/ui/frontend/src/components/auth/LoginModal.tsx
@@ -1,8 +1,20 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import API_BASE_URL from '../../config';
 import { useAuth } from '../../hooks/useAuth';
 import OAuthButtons from './OAuthButtons';
+
+interface AuthStatus {
+  email_login_disabled: boolean;
+  google_oauth_enabled: boolean;
+  microsoft_oauth_enabled: boolean;
+}
+
+const DEFAULT_AUTH_STATUS: AuthStatus = {
+  email_login_disabled: false,
+  google_oauth_enabled: false,
+  microsoft_oauth_enabled: false,
+};
 
 interface LoginModalProps {
   onClose: () => void;
@@ -151,6 +163,7 @@ interface MainAuthFormProps {
   setLastName: (v: string) => void;
   loading: boolean;
   displaySuccess: string | null;
+  authStatus: AuthStatus;
   onSubmit: (e: React.FormEvent) => void;
   onForgot: () => void;
 }
@@ -158,9 +171,12 @@ interface MainAuthFormProps {
 const MainAuthForm: React.FC<MainAuthFormProps> = ({
   mode, email, setEmail, password, setPassword,
   firstName, setFirstName, lastName, setLastName,
-  loading, displaySuccess,
+  loading, displaySuccess, authStatus,
   onSubmit, onForgot,
-}) => (
+}) => {
+  const showOAuth = authStatus.google_oauth_enabled || authStatus.microsoft_oauth_enabled;
+  const showEmail = !authStatus.email_login_disabled;
+  return (
   <>
     {mode === 'register' && !displaySuccess && (
       <p className="auth-callout">
@@ -168,10 +184,19 @@ const MainAuthForm: React.FC<MainAuthFormProps> = ({
       </p>
     )}
 
-    <OAuthButtons action={mode === 'login' ? 'Sign in' : 'Sign up'} />
+    {showOAuth && (
+      <OAuthButtons
+        action={mode === 'login' ? 'Sign in' : 'Sign up'}
+        googleEnabled={authStatus.google_oauth_enabled}
+        microsoftEnabled={authStatus.microsoft_oauth_enabled}
+      />
+    )}
 
-    <div className="auth-divider"><span>or</span></div>
+    {showOAuth && showEmail && (
+      <div className="auth-divider"><span>or</span></div>
+    )}
 
+    {showEmail && (
     <form onSubmit={onSubmit}>
       {mode === 'register' && (
         <div className="form-group-row">
@@ -246,8 +271,10 @@ const MainAuthForm: React.FC<MainAuthFormProps> = ({
         {loading ? 'Please wait...' : mode === 'login' ? 'Sign In' : 'Create Account'}
       </button>
     </form>
+    )}
   </>
-);
+  );
+};
 
 /* ------------------------------------------------------------------ */
 /*  Main modal                                                        */
@@ -264,6 +291,28 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [loading, setLoading] = useState(false);
+  const [authStatus, setAuthStatus] = useState<AuthStatus>(DEFAULT_AUTH_STATUS);
+
+  useEffect(() => {
+    let cancelled = false;
+    axios.get(`${API_BASE_URL}/config/auth-status`)
+      .then((res) => {
+        if (cancelled) return;
+        setAuthStatus({
+          email_login_disabled: !!res.data.email_login_disabled,
+          google_oauth_enabled: !!res.data.google_oauth_enabled,
+          microsoft_oauth_enabled: !!res.data.microsoft_oauth_enabled,
+        });
+      })
+      .catch(() => { /* keep defaults on failure */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (authStatus.email_login_disabled && mode === 'register') {
+      setMode('login');
+    }
+  }, [authStatus.email_login_disabled, mode]);
 
   const handleClose = () => {
     clearVerificationMessage();
@@ -371,12 +420,14 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
             >
               Sign In
             </button>
-            <button
-              className={`login-tab ${mode === 'register' ? 'login-tab-active' : ''}`}
-              onClick={() => switchMode('register')}
-            >
-              Register
-            </button>
+            {!authStatus.email_login_disabled && (
+              <button
+                className={`login-tab ${mode === 'register' ? 'login-tab-active' : ''}`}
+                onClick={() => switchMode('register')}
+              >
+                Register
+              </button>
+            )}
           </div>
           {!required && <button className="modal-close" onClick={handleClose}>&times;</button>}
         </div>
@@ -422,6 +473,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
               setLastName={setLastName}
               loading={loading}
               displaySuccess={displaySuccess}
+              authStatus={authStatus}
               onSubmit={mode === 'login' ? handleLogin : handleRegister}
               onForgot={() => switchMode('forgot')}
             />

--- a/ui/frontend/src/components/auth/LoginModal.tsx
+++ b/ui/frontend/src/components/auth/LoginModal.tsx
@@ -295,7 +295,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
 
   useEffect(() => {
     let cancelled = false;
-    axios.get(`${API_BASE_URL}/config/auth-status`)
+    axios.get<Partial<AuthStatus>>(`${API_BASE_URL}/config/auth-status`)
       .then((res) => {
         if (cancelled) return;
         setAuthStatus({

--- a/ui/frontend/src/components/auth/OAuthButtons.tsx
+++ b/ui/frontend/src/components/auth/OAuthButtons.tsx
@@ -4,9 +4,21 @@ import API_BASE_URL from '../../config';
 interface OAuthButtonsProps {
   /** Label prefix, e.g. "Sign in" or "Sign up" */
   action?: string;
+  /** Whether the Google OAuth button should be rendered. */
+  googleEnabled?: boolean;
+  /** Whether the Microsoft OAuth button should be rendered. */
+  microsoftEnabled?: boolean;
 }
 
-const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
+const OAuthButtons: React.FC<OAuthButtonsProps> = ({
+  action = 'Sign in',
+  googleEnabled = true,
+  microsoftEnabled = true,
+}) => {
+  if (!googleEnabled && !microsoftEnabled) {
+    return null;
+  }
+
   const handleOAuth = async (provider: string) => {
     try {
       const res = await fetch(`${API_BASE_URL}/auth/${provider}/authorize`, {
@@ -27,6 +39,7 @@ const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
 
   return (
     <div className="oauth-buttons">
+      {googleEnabled && (
       <button type="button" className="oauth-button oauth-google" onClick={handleGoogle}>
         <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
           <path
@@ -48,6 +61,8 @@ const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
         </svg>
         {action} with Google
       </button>
+      )}
+      {microsoftEnabled && (
       <button type="button" className="oauth-button oauth-microsoft" onClick={handleMicrosoft}>
         <svg width="18" height="18" viewBox="0 0 21 21" aria-hidden="true">
           <rect x="1" y="1" width="9" height="9" fill="#f25022" />
@@ -57,6 +72,7 @@ const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
         </svg>
         {action} with Microsoft
       </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- `/config/auth-status` now reports which login methods are available (email, Google, Microsoft) based on backend env vars
- `LoginModal` fetches the status on mount and only renders OAuth buttons for providers whose credentials are configured
- New `DISABLE_EMAIL_LOGIN` env var: when true, backend does not mount `/auth/login`, `/auth/cookie-login`, or `/auth/register` routes; frontend hides the email form, Register tab, and "or" divider
- `.env.example` and `docs/admin/user-administration.md` updated

## Behavior matrix
| `DISABLE_EMAIL_LOGIN` | Google creds | MS creds | Result |
|---|---|---|---|
| false | ✓ | ✓ | Email + both OAuth buttons (current default) |
| false | ✗ | ✓ | Email + MS button only |
| true | ✓ | ✓ | Both OAuth buttons only, no Register tab, no email form |
| true | ✗ | ✗ | ⚠️ No way to sign in — misconfiguration, documented in admin docs |

## Test plan
- [ ] Frontend unit tests pass (`LoginModal.test.tsx` updated with new coverage)
- [ ] Manual: verify Register tab hidden when `DISABLE_EMAIL_LOGIN=true`
- [ ] Manual: verify `/auth/register` returns 404 when `DISABLE_EMAIL_LOGIN=true`
- [ ] Manual: unset `OAUTH_GOOGLE_*` and confirm Google button disappears
- [ ] Manual: smoke test Microsoft OAuth login still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)