### PR TITLE
fix: prevent SQL injection via sort_by and taxonomy filter parameters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Follow `SECURITY.md` protocols. Key rules:
 - **Path traversal protection** on file-serving endpoints: double URL decoding, null byte rejection, `Path.resolve()` canonicalization, `relative_to()` containment, explicit extension whitelist.
 - **Data source validation**: always validate `data_source` against the whitelist from `config.json`. Never trust user input directly.
 - **Request body size limits**: enforced at middleware (`MAX_REQUEST_BODY_BYTES`, default 2 MB). POST/PUT/PATCH only.
-- **SQL**: always use parameterized queries. Never concatenate user input into SQL strings.
+- **SQL**: always use parameterized queries (`%s` placeholders). Never interpolate user input into SQL strings via f-strings, `.format()`, or `%`. For dynamic SQL fragments that cannot be parameterized (e.g., `ORDER BY` columns, JSONB path expressions), use **whitelist dictionary lookups** that map user input to hardcoded SQL — never interpolate the input itself. See `_get_paginated_documents_impl()` for the canonical pattern.
 
 ### Secrets & Credentials
 - **Never hardcode secrets.** Use environment variables exclusively.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -136,6 +136,17 @@ The `/file/{file_path}` endpoint implements comprehensive path traversal protect
 - Directory containment verification using `relative_to()`
 - Explicit file extension whitelist
 
+#### SQL Injection Prevention
+
+All SQL queries use parameterized queries (`%s` placeholders) for user-supplied values. Dynamic SQL fragments that cannot be parameterized (e.g., `ORDER BY` column names, JSONB path expressions) use **whitelist dictionaries** that map user input to hardcoded SQL strings — user input is never interpolated into SQL.
+
+Specific controls:
+
+- **Sort columns**: `sort_by` API parameter is resolved via a `dict.get()` lookup against a hardcoded map; unrecognised values fall back to a safe default
+- **Sort direction**: `sort_order` is normalised to a binary `"ASC"` / `"DESC"` choice
+- **Taxonomy filters**: JSONB path expressions use `jsonb_path_exists` with the `vars` argument so taxonomy codes are bound as query parameters; the taxonomy key is validated against `_ALLOWED_TAXONOMY_KEYS`
+- **Table names**: derived from `config.json` (operator-controlled), never from user input
+
 #### Data Source Validation
 
 API endpoints validate `data_source` parameters against a whitelist loaded from `config.json`, preventing:
@@ -368,6 +379,8 @@ Before submitting a PR, ensure:
 
 - [ ] No hardcoded secrets or credentials
 - [ ] Input validation for user-provided data
+- [ ] All SQL uses parameterized queries — no f-string/format interpolation of user input
+- [ ] Dynamic SQL fragments (ORDER BY, JSONB paths) use whitelist lookups, not interpolation
 - [ ] Pre-commit hooks pass (including Bandit, Gitleaks)
 - [ ] No new security warnings in CI
 - [ ] Sensitive operations are properly authenticated
@@ -414,6 +427,12 @@ MD4, MD5 (for security purposes), RC4, single DES, 3DES, SHA-1 (for security pur
 
 ## Changelog
 
+- **2026-04-12**: Fix SQL injection via `sort_by` and taxonomy filter parameters (#264)
+  - Replaced f-string interpolation of `sort_by` in `ORDER BY` clause with a whitelist dictionary lookup (hardcoded SQL fragments only)
+  - Replaced f-string interpolation of taxonomy codes in `jsonb_path_exists` with parameterized `vars` argument (`jsonb_build_object('v', %s::text)`)
+  - Added `_ALLOWED_TAXONOMY_KEYS` frozenset to validate taxonomy keys before use in JSONB path expressions
+  - Added "SQL Injection Prevention" section to SECURITY.md documenting all controls
+  - Added 15 regression tests covering injection attempts, whitelist fallback, and parameterisation
 - **2026-03-31**: Document cryptographic algorithms (OpenSSF Best Practices)
   - Added "Cryptographic Algorithms" section listing all algorithms in use
   - Documented Fernet (AES-128-CBC + HMAC-SHA256) Encrypt-then-MAC construction and why it is not vulnerable to known CBC-mode attacks

--- a/pipeline/db/postgres_client_docs.py
+++ b/pipeline/db/postgres_client_docs.py
@@ -788,16 +788,35 @@ class PostgresDocMixin:
             page, page_size, filters, filter_map, sort_by, sort_order
         )
 
+    _ALLOWED_TAXONOMY_KEYS = frozenset({"sdg", "cross_cutting_theme"})
+
     @staticmethod
-    def _taxonomy_clause(key: str, value: Any) -> Optional[str]:
-        """Build a WHERE clause for taxonomy (JSONB) filters."""
+    def _taxonomy_clause(key: str, value: Any, params: List[Any]) -> Optional[str]:
+        """Build a WHERE clause for taxonomy (JSONB) filters.
+
+        Uses jsonb_path_exists with the ``vars`` argument so that
+        taxonomy codes are passed as query parameters, not interpolated
+        into the SQL string.  ``key`` is validated against a strict
+        whitelist to prevent injection via the JSONB path.
+        """
+        if key not in PostgresDocMixin._ALLOWED_TAXONOMY_KEYS:
+            return None
+
         codes = value if isinstance(value, list) else [value]
-        conditions = [
-            f"jsonb_path_exists(sys_taxonomies, "
-            f"'$.{key}[*].code ? (@ == \"{code}\")')"
-            for code in codes
-        ]
-        return f"({' OR '.join(conditions)})" if conditions else None
+        if not codes:
+            return None
+
+        # jsonb_path_exists(col, '$.sdg[*].code ? (@ == $v)',
+        #                   jsonb_build_object('v', %s))
+        path = f"$.{key}[*].code ? (@ == $v)"
+        conditions = []
+        for code in codes:
+            conditions.append(
+                f"jsonb_path_exists(sys_taxonomies, "
+                f"'{path}', jsonb_build_object('v', %s::text))"
+            )
+            params.append(str(code))
+        return f"({' OR '.join(conditions)})"
 
     @staticmethod
     def _column_clause(col: str, value: Any, params: List[Any]) -> str:
@@ -843,7 +862,7 @@ class PostgresDocMixin:
                 else:
                     where_clauses.append(f"({col} IS NOT TRUE OR {col} IS NULL)")
             elif key in ("sdg", "cross_cutting_theme"):
-                clause = self._taxonomy_clause(key, value)
+                clause = self._taxonomy_clause(key, value, params)
                 if clause:
                     where_clauses.append(clause)
             elif key in filter_map:
@@ -869,25 +888,20 @@ class PostgresDocMixin:
         if where_sql:
             where_sql = "WHERE " + where_sql
 
-        # Sort mapping
-        sort_col = "map_published_year"  # Default
-        if sort_by == "year":
-            sort_col = "map_published_year"
-        elif sort_by == "title":
-            sort_col = "map_title"
-        elif sort_by == "last_updated":
-            # Convert sys_last_updated (epoch) to timestamp, fallback
-            sort_col = (
+        # Sort mapping — all values are hardcoded SQL fragments, never user input
+        sort_map = {
+            "year": "map_published_year",
+            "title": "map_title",
+            "last_updated": (
                 "COALESCE(to_timestamp(sys_last_updated), "
                 "sys_status_timestamp, '1970-01-01'::timestamp)"
-            )
-        elif sort_by in ("sdg", "cross_cutting_theme"):
-            # Sort by first taxonomy code in the array
-            # Extract first element's code from JSONB array: sys_taxonomies->'sdg'->0->'code'
-            sort_col = f"COALESCE(sys_taxonomies->'{sort_by}'->0->>'code', 'zzz')"
-        else:
-            # Default for unknown fields
-            sort_col = "map_published_year"
+            ),
+            "sdg": "COALESCE(sys_taxonomies->'sdg'->0->>'code', 'zzz')",
+            "cross_cutting_theme": (
+                "COALESCE(sys_taxonomies->'cross_cutting_theme'" "->0->>'code', 'zzz')"
+            ),
+        }
+        sort_col = sort_map.get(sort_by, "map_published_year")
 
         # Handle sort order
         order_direction = "DESC" if sort_order.lower() == "desc" else "ASC"

--- a/tests/unit/test_sql_injection_prevention.py
+++ b/tests/unit/test_sql_injection_prevention.py
@@ -1,0 +1,219 @@
+"""Tests that sort_by and taxonomy filter parameters cannot inject SQL.
+
+Regression tests for GitHub issue #264: SQL injection via sort_by
+parameter interpolated into raw SQL, and taxonomy filter codes
+interpolated into jsonb_path_exists expressions.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipeline.db.postgres_client_docs import PostgresDocMixin
+
+
+@pytest.fixture()
+def client():
+    """Create a PostgresDocMixin with mocked DB connection."""
+    with patch.object(PostgresDocMixin, "__init__", lambda self: None):
+        c = PostgresDocMixin.__new__(PostgresDocMixin)
+        c.docs_table = "docs_test"
+        c.data_source = "test"
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (0,)
+        mock_cursor.fetchall.return_value = []
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        c._get_conn = MagicMock(return_value=mock_conn)
+        c._mock_cursor = mock_cursor
+        return c
+
+
+def _get_executed_sql(client):
+    """Return the SQL string from the last cur.execute call."""
+    return client._mock_cursor.execute.call_args[0][0]
+
+
+# -- sort_by whitelist tests --------------------------------------------------
+
+
+class TestSortByWhitelist:
+    """sort_by must resolve to a hardcoded SQL fragment via dict lookup."""
+
+    @pytest.mark.unit
+    def test_sort_by_year(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="year",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY map_published_year ASC" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_title(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="title",
+            sort_order="desc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY map_title DESC" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_sdg(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="sdg",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY COALESCE(sys_taxonomies->'sdg'" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_cross_cutting_theme(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="cross_cutting_theme",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY COALESCE(sys_taxonomies->'cross_cutting_theme'" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_last_updated(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="last_updated",
+            sort_order="desc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY COALESCE(to_timestamp(sys_last_updated)" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_injection_falls_back_to_default(self, client):
+        """Malicious sort_by value must not appear in generated SQL."""
+        payload = "year'; DROP TABLE docs_test; --"
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by=payload,
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert payload not in sql
+        assert "DROP TABLE" not in sql
+        assert "ORDER BY map_published_year ASC" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_unknown_value_falls_back_to_default(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="nonexistent_field",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY map_published_year ASC" in sql
+
+    @pytest.mark.unit
+    def test_sort_order_injection_normalised(self, client):
+        """Malicious sort_order must not appear in generated SQL."""
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="year",
+            sort_order="desc; DROP TABLE docs_test;--",
+        )
+        sql = _get_executed_sql(client)
+        assert "DROP TABLE" not in sql
+        assert "ORDER BY map_published_year ASC" in sql
+
+
+# -- taxonomy clause tests ----------------------------------------------------
+
+
+class TestTaxonomyClauseParameterised:
+    """Taxonomy codes must be passed as query parameters, never interpolated."""
+
+    @pytest.mark.unit
+    def test_sdg_codes_are_parameterised(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", ["sdg1", "sdg5"], params)
+        assert clause is not None
+        assert "sdg1" not in clause
+        assert "sdg5" not in clause
+        assert "%s" in clause
+        assert params == ["sdg1", "sdg5"]
+
+    @pytest.mark.unit
+    def test_cross_cutting_theme_parameterised(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause(
+            "cross_cutting_theme", ["gender"], params
+        )
+        assert clause is not None
+        assert "gender" not in clause
+        assert "%s" in clause
+        assert params == ["gender"]
+
+    @pytest.mark.unit
+    def test_injection_in_code_value_is_parameterised(self):
+        payload = "x')) OR 1=1 --"
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", [payload], params)
+        assert clause is not None
+        assert payload not in clause
+        assert params == [payload]
+
+    @pytest.mark.unit
+    def test_disallowed_taxonomy_key_returns_none(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("malicious_key", ["value"], params)
+        assert clause is None
+        assert params == []
+
+    @pytest.mark.unit
+    def test_empty_codes_returns_none(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", [], params)
+        assert clause is None
+
+    @pytest.mark.unit
+    def test_single_string_value_converted_to_list(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", "sdg3", params)
+        assert clause is not None
+        assert params == ["sdg3"]
+
+    @pytest.mark.unit
+    def test_uses_jsonb_path_vars(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", ["sdg1"], params)
+        assert "jsonb_build_object" in clause
+        assert "$v" in clause


### PR DESCRIPTION
## Summary

- **sort_by SQL injection** (line 887): replaced f-string interpolation of user-supplied `sort_by` into `ORDER BY` clause with a whitelist `dict.get()` lookup — unrecognised values fall back to `map_published_year`
- **taxonomy code SQL injection** (line 797): replaced f-string interpolation of taxonomy codes in `jsonb_path_exists` with parameterized `vars` argument (`jsonb_build_object('v', %s::text)`) and added `_ALLOWED_TAXONOMY_KEYS` frozenset to validate the JSONB path key
- Updated SECURITY.md with new "SQL Injection Prevention" section, changelog entry, and PR checklist items
- Updated CLAUDE.md SQL guidance to cover dynamic SQL fragments (ORDER BY, JSONB paths)

Closes #264

## Test plan

- [x] 15 new unit tests covering all sort_by values, injection payloads, taxonomy parameterisation, disallowed keys, and edge cases
- [x] All pre-existing unit tests still pass (1129 passed)
- [x] All pre-commit hooks pass (black, isort, flake8, mypy, bandit, gitleaks, detect-secrets, code-metrics)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)