### PR TITLE
Release v1.4.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -260,6 +260,12 @@ OAUTH_MICROSOFT_CLIENT_ID=
 OAUTH_MICROSOFT_CLIENT_SECRET=
 OAUTH_MICROSOFT_TENANT_ID=common
 
+# Disable email/password login and registration. When true, users can only
+# sign in via configured OAuth providers (Google / Microsoft). The backend
+# does not mount the email login/register routes and the frontend hides the
+# email form and Register tab.
+DISABLE_EMAIL_LOGIN=false
+
 # Frontend feature flag for user module UI (must match USER_MODULE above)
 # Values: off | on_passive | on_active (legacy: true → on_active, false → off)
 REACT_APP_USER_MODULE=off

--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,11 @@ AUTH_SECRET_KEY=
 # Base URL for email links (verification, password reset)
 APP_BASE_URL=http://localhost:3000
 
+# Base URL for OAuth callback endpoints (must match redirect URIs registered
+# in the OAuth provider). In production behind a reverse proxy, this should be
+# the public URL including any path prefix, e.g. https://example.com/api
+OAUTH_CALLBACK_BASE_URL=http://localhost:8000
+
 # Registration controls — restrict who can sign up
 # Comma-separated list of allowed email domains (e.g. "example.com,corp.org").
 # Leave empty for open registration (anyone can register).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -21,7 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -36,7 +36,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:
@@ -49,7 +49,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:
@@ -62,7 +62,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:
@@ -75,7 +75,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "rc/v1.2.0"
+    target-branch: "rc/v1.4.0"
     schedule:
       interval: "monthly"
     labels:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,7 @@ jobs:
         if: always()
 
   container-scan:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     needs: security-scan
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Evidence Lab will be documented in this file.
 
+## [1.4.0] - 2026-04-12
+
+Evidence Lab v1.4.0 is a security and authentication release. It fixes a SQL injection vulnerability in the documents API, adds conditional OAuth login buttons, and improves deployment configuration for OAuth callbacks.
+
+### Security
+- Fixed SQL injection via `sort_by` parameter interpolated into raw SQL — replaced f-string interpolation with whitelist dictionary lookup (#264, #266)
+- Fixed SQL injection via taxonomy filter codes interpolated into `jsonb_path_exists` — replaced with parameterized `vars` argument (#264, #266)
+- Added `_ALLOWED_TAXONOMY_KEYS` frozenset to validate taxonomy keys before use in JSONB path expressions (#266)
+- Added "SQL Injection Prevention" section to SECURITY.md documenting all dynamic SQL controls (#266)
+- Updated CLAUDE.md SQL guidance to cover dynamic SQL fragments (ORDER BY, JSONB paths) (#266)
+- Added 15 regression tests for SQL injection prevention (#266)
+
+### Authentication
+- Added conditional OAuth buttons — Google and Microsoft SSO buttons only appear when the corresponding secrets are configured (#265)
+- Added `DISABLE_EMAIL_LOGIN` environment variable to hide email/password login when only OAuth is desired (#265)
+- Fixed OAuth secrets to be read solely from `.env` file in the API service (#265)
+- Pinned langgraph and langgraph-prebuilt to working versions (#265)
+
+### Documentation & CI
+- Added `OAUTH_CALLBACK_BASE_URL` to `.env.example` and auth documentation (#261)
+- Updated dependabot target-branch to `rc/v1.4.0` (#263)
+- Skipped container-scan for dependabot PRs to reduce CI costs
+
+### What's Changed
+- fix: prevent SQL injection via sort_by and taxonomy filter parameters (#266)
+- feat: conditional OAuth buttons and DISABLE_EMAIL_LOGIN (#265)
+- ci: update dependabot target-branch to rc/v1.4.0 (#263)
+- docs: add OAUTH_CALLBACK_BASE_URL to .env.example and auth docs (#261)
+- ci: skip container-scan for dependabot PRs
+
+**Full diff:** https://github.com/dividor/evidencelab/compare/v1.3.0...v1.4.0
+
+---
+
 ## [1.3.0] - 2026-03-30
 
 Evidence Lab v1.3.0 is a security and code quality release focused on achieving the [OpenSSF Best Practices](https://www.bestpractices.dev/projects/12335) baseline badge. It hardens the CI pipeline, enforces stricter static analysis, documents cryptographic practices, and raises the bar on code quality tooling throughout the project.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ Follow `SECURITY.md` protocols. Key rules:
 - **Path traversal protection** on file-serving endpoints: double URL decoding, null byte rejection, `Path.resolve()` canonicalization, `relative_to()` containment, explicit extension whitelist.
 - **Data source validation**: always validate `data_source` against the whitelist from `config.json`. Never trust user input directly.
 - **Request body size limits**: enforced at middleware (`MAX_REQUEST_BODY_BYTES`, default 2 MB). POST/PUT/PATCH only.
-- **SQL**: always use parameterized queries. Never concatenate user input into SQL strings.
+- **SQL**: always use parameterized queries (`%s` placeholders). Never interpolate user input into SQL strings via f-strings, `.format()`, or `%`. For dynamic SQL fragments that cannot be parameterized (e.g., `ORDER BY` columns, JSONB path expressions), use **whitelist dictionary lookups** that map user input to hardcoded SQL — never interpolate the input itself. See `_get_paginated_documents_impl()` for the canonical pattern.
 
 ### Secrets & Credentials
 - **Never hardcode secrets.** Use environment variables exclusively.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -136,6 +136,17 @@ The `/file/{file_path}` endpoint implements comprehensive path traversal protect
 - Directory containment verification using `relative_to()`
 - Explicit file extension whitelist
 
+#### SQL Injection Prevention
+
+All SQL queries use parameterized queries (`%s` placeholders) for user-supplied values. Dynamic SQL fragments that cannot be parameterized (e.g., `ORDER BY` column names, JSONB path expressions) use **whitelist dictionaries** that map user input to hardcoded SQL strings — user input is never interpolated into SQL.
+
+Specific controls:
+
+- **Sort columns**: `sort_by` API parameter is resolved via a `dict.get()` lookup against a hardcoded map; unrecognised values fall back to a safe default
+- **Sort direction**: `sort_order` is normalised to a binary `"ASC"` / `"DESC"` choice
+- **Taxonomy filters**: JSONB path expressions use `jsonb_path_exists` with the `vars` argument so taxonomy codes are bound as query parameters; the taxonomy key is validated against `_ALLOWED_TAXONOMY_KEYS`
+- **Table names**: derived from `config.json` (operator-controlled), never from user input
+
 #### Data Source Validation
 
 API endpoints validate `data_source` parameters against a whitelist loaded from `config.json`, preventing:
@@ -368,6 +379,8 @@ Before submitting a PR, ensure:
 
 - [ ] No hardcoded secrets or credentials
 - [ ] Input validation for user-provided data
+- [ ] All SQL uses parameterized queries — no f-string/format interpolation of user input
+- [ ] Dynamic SQL fragments (ORDER BY, JSONB paths) use whitelist lookups, not interpolation
 - [ ] Pre-commit hooks pass (including Bandit, Gitleaks)
 - [ ] No new security warnings in CI
 - [ ] Sensitive operations are properly authenticated
@@ -414,6 +427,12 @@ MD4, MD5 (for security purposes), RC4, single DES, 3DES, SHA-1 (for security pur
 
 ## Changelog
 
+- **2026-04-12**: Fix SQL injection via `sort_by` and taxonomy filter parameters (#264)
+  - Replaced f-string interpolation of `sort_by` in `ORDER BY` clause with a whitelist dictionary lookup (hardcoded SQL fragments only)
+  - Replaced f-string interpolation of taxonomy codes in `jsonb_path_exists` with parameterized `vars` argument (`jsonb_build_object('v', %s::text)`)
+  - Added `_ALLOWED_TAXONOMY_KEYS` frozenset to validate taxonomy keys before use in JSONB path expressions
+  - Added "SQL Injection Prevention" section to SECURITY.md documenting all controls
+  - Added 15 regression tests covering injection attempts, whitelist fallback, and parameterisation
 - **2026-03-31**: Document cryptographic algorithms (OpenSSF Best Practices)
   - Added "Cryptographic Algorithms" section listing all algorithms in use
   - Documented Fernet (AES-128-CBC + HMAC-SHA256) Encrypt-then-MAC construction and why it is not vulnerable to known CBC-mode attacks

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -179,11 +179,9 @@ services:
       - SMTP_USER=${SMTP_USER:-}
       - SMTP_PASSWORD=${SMTP_PASSWORD:-}
       - SMTP_FROM=${SMTP_FROM:-noreply@evidencelab.ai}
-      - OAUTH_GOOGLE_CLIENT_ID=${OAUTH_GOOGLE_CLIENT_ID:-}
-      - OAUTH_GOOGLE_CLIENT_SECRET=${OAUTH_GOOGLE_CLIENT_SECRET:-}
-      - OAUTH_MICROSOFT_CLIENT_ID=${OAUTH_MICROSOFT_CLIENT_ID:-}
-      - OAUTH_MICROSOFT_CLIENT_SECRET=${OAUTH_MICROSOFT_CLIENT_SECRET:-}
-      - OAUTH_MICROSOFT_TENANT_ID=${OAUTH_MICROSOFT_TENANT_ID:-common}
+      # OAuth secrets read exclusively via env_file above. Do NOT add
+      # ${OAUTH_*:-} substitutions here — host env vars (even empty ones
+      # inherited from parent processes) would override .env values.
     extra_hosts:
       - "host.docker.internal:host-gateway"
     depends_on:

--- a/docs/admin/user-administration.md
+++ b/docs/admin/user-administration.md
@@ -85,7 +85,23 @@ The **tenant ID** controls who can sign in:
 
 Evidence Lab requests the `openid`, `email`, `profile`, and `User.Read` scopes.
 
-#### 4. Setting Up Email (SMTP)
+#### 4. Disabling Email Login (OAuth-only mode)
+
+To force all users to sign in via OAuth (Google and/or Microsoft) and remove email/password login and registration entirely:
+
+```env
+DISABLE_EMAIL_LOGIN=true
+```
+
+When this is set:
+
+- The backend does **not** mount the `/auth/login`, `/auth/cookie-login`, or `/auth/register` endpoints — direct API calls to them return 404.
+- The login modal hides the email form and the **Register** tab.
+- Only the OAuth buttons for providers with credentials configured are shown.
+
+The login modal also automatically hides any OAuth provider whose credentials are not configured. If both `OAUTH_GOOGLE_*` and `OAUTH_MICROSOFT_*` are unset, only the Google button would be missing — so ensure at least one OAuth provider is fully configured before enabling `DISABLE_EMAIL_LOGIN`, otherwise users will have no way to sign in.
+
+#### 5. Setting Up Email (SMTP)
 
 Evidence Lab sends two types of email: **account verification** (on registration) and **password reset**. Configure your SMTP server:
 
@@ -107,7 +123,7 @@ AUTH_RESET_TOKEN_LIFETIME=86400      # Password reset: 24 hours (default)
 AUTH_VERIFY_TOKEN_LIFETIME=604800    # Email verification: 7 days (default)
 ```
 
-#### 5. Testing Emails with Mailpit
+#### 6. Testing Emails with Mailpit
 
 For local development, [Mailpit](https://mailpit.axllent.org/) provides a fake SMTP server with a web inbox — no real emails are sent.
 

--- a/docs/admin/user-administration.md
+++ b/docs/admin/user-administration.md
@@ -51,6 +51,14 @@ OAUTH_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 OAUTH_GOOGLE_CLIENT_SECRET=your-client-secret
 ```
 
+5. Set `OAUTH_CALLBACK_BASE_URL` to the public base URL that the browser uses to reach the API. In production behind a reverse proxy this includes the path prefix:
+
+```env
+OAUTH_CALLBACK_BASE_URL=https://yourdomain.com/api
+```
+
+   The redirect URI registered in Google must match: `{OAUTH_CALLBACK_BASE_URL}/auth/google/callback`. For local development the default (`http://localhost:8000`) is used when this variable is unset.
+
 Evidence Lab requests the `openid`, `email`, and `profile` scopes. If a user registers with email/password first and then signs in with Google using the same email, the accounts are automatically linked.
 
 #### 3. Setting Up Microsoft / Azure OAuth
@@ -61,7 +69,7 @@ To enable "Sign in with Microsoft":
 2. Register a new application
 3. Under **Authentication**, add a **Web** redirect URI:
    - Local development: `http://localhost:8000/auth/microsoft/callback`
-   - Production: `https://yourdomain.com/api/auth/microsoft/callback`
+   - Production: `{OAUTH_CALLBACK_BASE_URL}/auth/microsoft/callback` (e.g. `https://yourdomain.com/api/auth/microsoft/callback`)
 4. Under **Certificates & secrets**, create a new client secret
 5. Copy the values into your `.env`:
 

--- a/pipeline/db/postgres_client_docs.py
+++ b/pipeline/db/postgres_client_docs.py
@@ -788,16 +788,35 @@ class PostgresDocMixin:
             page, page_size, filters, filter_map, sort_by, sort_order
         )
 
+    _ALLOWED_TAXONOMY_KEYS = frozenset({"sdg", "cross_cutting_theme"})
+
     @staticmethod
-    def _taxonomy_clause(key: str, value: Any) -> Optional[str]:
-        """Build a WHERE clause for taxonomy (JSONB) filters."""
+    def _taxonomy_clause(key: str, value: Any, params: List[Any]) -> Optional[str]:
+        """Build a WHERE clause for taxonomy (JSONB) filters.
+
+        Uses jsonb_path_exists with the ``vars`` argument so that
+        taxonomy codes are passed as query parameters, not interpolated
+        into the SQL string.  ``key`` is validated against a strict
+        whitelist to prevent injection via the JSONB path.
+        """
+        if key not in PostgresDocMixin._ALLOWED_TAXONOMY_KEYS:
+            return None
+
         codes = value if isinstance(value, list) else [value]
-        conditions = [
-            f"jsonb_path_exists(sys_taxonomies, "
-            f"'$.{key}[*].code ? (@ == \"{code}\")')"
-            for code in codes
-        ]
-        return f"({' OR '.join(conditions)})" if conditions else None
+        if not codes:
+            return None
+
+        # jsonb_path_exists(col, '$.sdg[*].code ? (@ == $v)',
+        #                   jsonb_build_object('v', %s))
+        path = f"$.{key}[*].code ? (@ == $v)"
+        conditions = []
+        for code in codes:
+            conditions.append(
+                f"jsonb_path_exists(sys_taxonomies, "
+                f"'{path}', jsonb_build_object('v', %s::text))"
+            )
+            params.append(str(code))
+        return f"({' OR '.join(conditions)})"
 
     @staticmethod
     def _column_clause(col: str, value: Any, params: List[Any]) -> str:
@@ -843,7 +862,7 @@ class PostgresDocMixin:
                 else:
                     where_clauses.append(f"({col} IS NOT TRUE OR {col} IS NULL)")
             elif key in ("sdg", "cross_cutting_theme"):
-                clause = self._taxonomy_clause(key, value)
+                clause = self._taxonomy_clause(key, value, params)
                 if clause:
                     where_clauses.append(clause)
             elif key in filter_map:
@@ -869,25 +888,20 @@ class PostgresDocMixin:
         if where_sql:
             where_sql = "WHERE " + where_sql
 
-        # Sort mapping
-        sort_col = "map_published_year"  # Default
-        if sort_by == "year":
-            sort_col = "map_published_year"
-        elif sort_by == "title":
-            sort_col = "map_title"
-        elif sort_by == "last_updated":
-            # Convert sys_last_updated (epoch) to timestamp, fallback
-            sort_col = (
+        # Sort mapping — all values are hardcoded SQL fragments, never user input
+        sort_map = {
+            "year": "map_published_year",
+            "title": "map_title",
+            "last_updated": (
                 "COALESCE(to_timestamp(sys_last_updated), "
                 "sys_status_timestamp, '1970-01-01'::timestamp)"
-            )
-        elif sort_by in ("sdg", "cross_cutting_theme"):
-            # Sort by first taxonomy code in the array
-            # Extract first element's code from JSONB array: sys_taxonomies->'sdg'->0->'code'
-            sort_col = f"COALESCE(sys_taxonomies->'{sort_by}'->0->>'code', 'zzz')"
-        else:
-            # Default for unknown fields
-            sort_col = "map_published_year"
+            ),
+            "sdg": "COALESCE(sys_taxonomies->'sdg'->0->>'code', 'zzz')",
+            "cross_cutting_theme": (
+                "COALESCE(sys_taxonomies->'cross_cutting_theme'" "->0->>'code', 'zzz')"
+            ),
+        }
+        sort_col = sort_map.get(sort_by, "map_published_year")
 
         # Handle sort order
         order_direction = "DESC" if sort_order.lower() == "desc" else "ASC"

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,8 +83,12 @@ google-cloud-discoveryengine>=0.13.0
 
 
 # LangGraph agent framework
+# Pinned: newer langgraph-prebuilt releases import ExecutionInfo from
+# langgraph.runtime which the matching langgraph version does not expose,
+# breaking CI. Keep these in lockstep with the working runtime versions.
 deepagents>=0.4.0
-langgraph>=0.4.0
+langgraph==1.0.10
+langgraph-prebuilt==1.0.8
 langgraph-checkpoint-postgres>=2.0.0
 
 # Task queue

--- a/tests/unit/test_sql_injection_prevention.py
+++ b/tests/unit/test_sql_injection_prevention.py
@@ -1,0 +1,219 @@
+"""Tests that sort_by and taxonomy filter parameters cannot inject SQL.
+
+Regression tests for GitHub issue #264: SQL injection via sort_by
+parameter interpolated into raw SQL, and taxonomy filter codes
+interpolated into jsonb_path_exists expressions.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipeline.db.postgres_client_docs import PostgresDocMixin
+
+
+@pytest.fixture()
+def client():
+    """Create a PostgresDocMixin with mocked DB connection."""
+    with patch.object(PostgresDocMixin, "__init__", lambda self: None):
+        c = PostgresDocMixin.__new__(PostgresDocMixin)
+        c.docs_table = "docs_test"
+        c.data_source = "test"
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (0,)
+        mock_cursor.fetchall.return_value = []
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        c._get_conn = MagicMock(return_value=mock_conn)
+        c._mock_cursor = mock_cursor
+        return c
+
+
+def _get_executed_sql(client):
+    """Return the SQL string from the last cur.execute call."""
+    return client._mock_cursor.execute.call_args[0][0]
+
+
+# -- sort_by whitelist tests --------------------------------------------------
+
+
+class TestSortByWhitelist:
+    """sort_by must resolve to a hardcoded SQL fragment via dict lookup."""
+
+    @pytest.mark.unit
+    def test_sort_by_year(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="year",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY map_published_year ASC" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_title(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="title",
+            sort_order="desc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY map_title DESC" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_sdg(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="sdg",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY COALESCE(sys_taxonomies->'sdg'" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_cross_cutting_theme(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="cross_cutting_theme",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY COALESCE(sys_taxonomies->'cross_cutting_theme'" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_last_updated(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="last_updated",
+            sort_order="desc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY COALESCE(to_timestamp(sys_last_updated)" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_injection_falls_back_to_default(self, client):
+        """Malicious sort_by value must not appear in generated SQL."""
+        payload = "year'; DROP TABLE docs_test; --"
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by=payload,
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert payload not in sql
+        assert "DROP TABLE" not in sql
+        assert "ORDER BY map_published_year ASC" in sql
+
+    @pytest.mark.unit
+    def test_sort_by_unknown_value_falls_back_to_default(self, client):
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="nonexistent_field",
+            sort_order="asc",
+        )
+        sql = _get_executed_sql(client)
+        assert "ORDER BY map_published_year ASC" in sql
+
+    @pytest.mark.unit
+    def test_sort_order_injection_normalised(self, client):
+        """Malicious sort_order must not appear in generated SQL."""
+        client._get_paginated_documents_impl(
+            page=1,
+            page_size=10,
+            filters={},
+            filter_map={},
+            sort_by="year",
+            sort_order="desc; DROP TABLE docs_test;--",
+        )
+        sql = _get_executed_sql(client)
+        assert "DROP TABLE" not in sql
+        assert "ORDER BY map_published_year ASC" in sql
+
+
+# -- taxonomy clause tests ----------------------------------------------------
+
+
+class TestTaxonomyClauseParameterised:
+    """Taxonomy codes must be passed as query parameters, never interpolated."""
+
+    @pytest.mark.unit
+    def test_sdg_codes_are_parameterised(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", ["sdg1", "sdg5"], params)
+        assert clause is not None
+        assert "sdg1" not in clause
+        assert "sdg5" not in clause
+        assert "%s" in clause
+        assert params == ["sdg1", "sdg5"]
+
+    @pytest.mark.unit
+    def test_cross_cutting_theme_parameterised(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause(
+            "cross_cutting_theme", ["gender"], params
+        )
+        assert clause is not None
+        assert "gender" not in clause
+        assert "%s" in clause
+        assert params == ["gender"]
+
+    @pytest.mark.unit
+    def test_injection_in_code_value_is_parameterised(self):
+        payload = "x')) OR 1=1 --"
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", [payload], params)
+        assert clause is not None
+        assert payload not in clause
+        assert params == [payload]
+
+    @pytest.mark.unit
+    def test_disallowed_taxonomy_key_returns_none(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("malicious_key", ["value"], params)
+        assert clause is None
+        assert params == []
+
+    @pytest.mark.unit
+    def test_empty_codes_returns_none(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", [], params)
+        assert clause is None
+
+    @pytest.mark.unit
+    def test_single_string_value_converted_to_list(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", "sdg3", params)
+        assert clause is not None
+        assert params == ["sdg3"]
+
+    @pytest.mark.unit
+    def test_uses_jsonb_path_vars(self):
+        params = []
+        clause = PostgresDocMixin._taxonomy_clause("sdg", ["sdg1"], params)
+        assert "jsonb_build_object" in clause
+        assert "$v" in clause

--- a/ui/backend/routes/auth.py
+++ b/ui/backend/routes/auth.py
@@ -24,26 +24,38 @@ _OAUTH_CALLBACK_BASE = os.environ.get(
 # Where to redirect the browser after a successful OAuth login.
 _APP_BASE_URL = os.environ.get("APP_BASE_URL", "http://localhost:3000")
 
+# When DISABLE_EMAIL_LOGIN is true, email/password login and registration
+# routes are not mounted at all — forcing users to sign in via OAuth only.
+DISABLE_EMAIL_LOGIN = os.environ.get("DISABLE_EMAIL_LOGIN", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
 router = APIRouter()
 
 # ---------------------------------------------------------------------------
-# Email/password auth
+# Email/password auth — mounted only when DISABLE_EMAIL_LOGIN is not set.
+# Verify and reset-password routers remain available so OAuth users who also
+# have an email on file can still verify / reset if needed.
 # ---------------------------------------------------------------------------
 
-router.include_router(
-    fastapi_users.get_auth_router(bearer_backend),
-    prefix="/login",
-    tags=["auth"],
-)
-router.include_router(
-    fastapi_users.get_auth_router(cookie_backend),
-    prefix="/cookie-login",
-    tags=["auth"],
-)
-router.include_router(
-    fastapi_users.get_register_router(UserRead, UserCreate),
-    tags=["auth"],
-)
+if not DISABLE_EMAIL_LOGIN:
+    router.include_router(
+        fastapi_users.get_auth_router(bearer_backend),
+        prefix="/login",
+        tags=["auth"],
+    )
+    router.include_router(
+        fastapi_users.get_auth_router(cookie_backend),
+        prefix="/cookie-login",
+        tags=["auth"],
+    )
+    router.include_router(
+        fastapi_users.get_register_router(UserRead, UserCreate),
+        tags=["auth"],
+    )
+
 router.include_router(
     fastapi_users.get_verify_router(UserRead),
     tags=["auth"],

--- a/ui/backend/routes/config.py
+++ b/ui/backend/routes/config.py
@@ -276,10 +276,26 @@ async def get_datasources_config(
 
 @router.get("/config/auth-status")
 def get_auth_status():
-    """Return the user module mode (for frontend feature flag)."""
+    """Return auth module mode and available login methods (for frontend)."""
+    email_disabled = os.environ.get("DISABLE_EMAIL_LOGIN", "false").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    google_enabled = bool(
+        os.environ.get("OAUTH_GOOGLE_CLIENT_ID")
+        and os.environ.get("OAUTH_GOOGLE_CLIENT_SECRET")
+    )
+    microsoft_enabled = bool(
+        os.environ.get("OAUTH_MICROSOFT_CLIENT_ID")
+        and os.environ.get("OAUTH_MICROSOFT_CLIENT_SECRET")
+    )
     return {
         "user_module_enabled": _USER_MODULE,
         "user_module_mode": _USER_MODULE_MODE,
+        "email_login_disabled": email_disabled,
+        "google_oauth_enabled": google_enabled,
+        "microsoft_oauth_enabled": microsoft_enabled,
     }
 
 

--- a/ui/frontend/src/components/auth/LoginModal.test.tsx
+++ b/ui/frontend/src/components/auth/LoginModal.test.tsx
@@ -26,6 +26,33 @@ const mockAuthValue = (overrides: Partial<AuthContextValue> = {}): AuthContextVa
   ...overrides,
 });
 
+interface MockAuthStatusOverrides {
+  email_login_disabled?: boolean;
+  google_oauth_enabled?: boolean;
+  microsoft_oauth_enabled?: boolean;
+}
+
+const mockAuthStatusResponse = (overrides: MockAuthStatusOverrides = {}) => {
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url.includes('/config/auth-status')) {
+      return Promise.resolve({
+        data: {
+          email_login_disabled: overrides.email_login_disabled ?? false,
+          google_oauth_enabled: overrides.google_oauth_enabled ?? true,
+          microsoft_oauth_enabled: overrides.microsoft_oauth_enabled ?? true,
+        },
+      });
+    }
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+};
+
+beforeEach(() => {
+  mockedAxios.get.mockReset();
+  mockedAxios.post.mockReset();
+  mockAuthStatusResponse();
+});
+
 const renderModal = (
   authValue?: AuthContextValue,
   props?: Partial<React.ComponentProps<typeof LoginModal>>,
@@ -58,10 +85,39 @@ describe('LoginModal', () => {
     expect(screen.getByLabelText('Last name')).toBeInTheDocument();
   });
 
-  it('shows OAuth buttons', () => {
+  it('shows OAuth buttons when providers are enabled', async () => {
     renderModal();
-    expect(screen.getByText(/Sign in with Google/)).toBeInTheDocument();
-    expect(screen.getByText(/Sign in with Microsoft/)).toBeInTheDocument();
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
+    expect(await screen.findByText(/Sign in with Microsoft/)).toBeInTheDocument();
+  });
+
+  it('hides Google button when google_oauth_enabled is false', async () => {
+    mockAuthStatusResponse({ google_oauth_enabled: false });
+    renderModal();
+    expect(await screen.findByText(/Sign in with Microsoft/)).toBeInTheDocument();
+    expect(screen.queryByText(/Sign in with Google/)).not.toBeInTheDocument();
+  });
+
+  it('hides Microsoft button when microsoft_oauth_enabled is false', async () => {
+    mockAuthStatusResponse({ microsoft_oauth_enabled: false });
+    renderModal();
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
+    expect(screen.queryByText(/Sign in with Microsoft/)).not.toBeInTheDocument();
+  });
+
+  it('hides email form, Register tab and "or" divider when email login is disabled', async () => {
+    mockAuthStatusResponse({ email_login_disabled: true });
+    renderModal();
+    // OAuth buttons still render
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
+    // Email form and Register tab are gone
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Register', { selector: 'button.login-tab' }),
+    ).not.toBeInTheDocument();
+    // "or" divider is also hidden when no email form follows
+    expect(screen.queryByText('or')).not.toBeInTheDocument();
   });
 
   it('switches to register tab', () => {
@@ -120,17 +176,19 @@ describe('LoginModal — Forgot password', () => {
     expect(screen.getByText('Back to Sign In')).toBeInTheDocument();
   });
 
-  it('returns to login mode when "Back to Sign In" is clicked', () => {
+  it('returns to login mode when "Back to Sign In" is clicked', async () => {
     renderModal();
+    // Wait for auth-status fetch to complete so OAuth buttons would appear
+    await screen.findByText(/Sign in with Google/);
     fireEvent.click(screen.getByText('Forgot password?'));
     fireEvent.click(screen.getByText('Back to Sign In'));
-    // Should be back in login mode with OAuth buttons visible
     expect(screen.getByText(/Sign in with Google/)).toBeInTheDocument();
     expect(screen.getByText('Forgot password?')).toBeInTheDocument();
   });
 
-  it('hides OAuth buttons and password field in forgot mode', () => {
+  it('hides OAuth buttons and password field in forgot mode', async () => {
     renderModal();
+    await screen.findByText(/Sign in with Google/);
     fireEvent.click(screen.getByText('Forgot password?'));
     expect(screen.queryByText(/Sign in with Google/)).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
@@ -269,11 +327,10 @@ describe('LoginModal — Reset password', () => {
     });
   });
 
-  it('can navigate to Sign In tab from reset mode', () => {
+  it('can navigate to Sign In tab from reset mode', async () => {
     renderModal(undefined, { resetToken: 'test-token-abc' });
     fireEvent.click(screen.getByText('Sign In', { selector: 'button.login-tab' }));
-    // Should now show login form
-    expect(screen.getByText(/Sign in with Google/)).toBeInTheDocument();
+    expect(await screen.findByText(/Sign in with Google/)).toBeInTheDocument();
     expect(screen.getByLabelText('Password')).toBeInTheDocument();
   });
 });

--- a/ui/frontend/src/components/auth/LoginModal.tsx
+++ b/ui/frontend/src/components/auth/LoginModal.tsx
@@ -1,8 +1,20 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import API_BASE_URL from '../../config';
 import { useAuth } from '../../hooks/useAuth';
 import OAuthButtons from './OAuthButtons';
+
+interface AuthStatus {
+  email_login_disabled: boolean;
+  google_oauth_enabled: boolean;
+  microsoft_oauth_enabled: boolean;
+}
+
+const DEFAULT_AUTH_STATUS: AuthStatus = {
+  email_login_disabled: false,
+  google_oauth_enabled: false,
+  microsoft_oauth_enabled: false,
+};
 
 interface LoginModalProps {
   onClose: () => void;
@@ -151,6 +163,7 @@ interface MainAuthFormProps {
   setLastName: (v: string) => void;
   loading: boolean;
   displaySuccess: string | null;
+  authStatus: AuthStatus;
   onSubmit: (e: React.FormEvent) => void;
   onForgot: () => void;
 }
@@ -158,9 +171,12 @@ interface MainAuthFormProps {
 const MainAuthForm: React.FC<MainAuthFormProps> = ({
   mode, email, setEmail, password, setPassword,
   firstName, setFirstName, lastName, setLastName,
-  loading, displaySuccess,
+  loading, displaySuccess, authStatus,
   onSubmit, onForgot,
-}) => (
+}) => {
+  const showOAuth = authStatus.google_oauth_enabled || authStatus.microsoft_oauth_enabled;
+  const showEmail = !authStatus.email_login_disabled;
+  return (
   <>
     {mode === 'register' && !displaySuccess && (
       <p className="auth-callout">
@@ -168,10 +184,19 @@ const MainAuthForm: React.FC<MainAuthFormProps> = ({
       </p>
     )}
 
-    <OAuthButtons action={mode === 'login' ? 'Sign in' : 'Sign up'} />
+    {showOAuth && (
+      <OAuthButtons
+        action={mode === 'login' ? 'Sign in' : 'Sign up'}
+        googleEnabled={authStatus.google_oauth_enabled}
+        microsoftEnabled={authStatus.microsoft_oauth_enabled}
+      />
+    )}
 
-    <div className="auth-divider"><span>or</span></div>
+    {showOAuth && showEmail && (
+      <div className="auth-divider"><span>or</span></div>
+    )}
 
+    {showEmail && (
     <form onSubmit={onSubmit}>
       {mode === 'register' && (
         <div className="form-group-row">
@@ -246,8 +271,10 @@ const MainAuthForm: React.FC<MainAuthFormProps> = ({
         {loading ? 'Please wait...' : mode === 'login' ? 'Sign In' : 'Create Account'}
       </button>
     </form>
+    )}
   </>
-);
+  );
+};
 
 /* ------------------------------------------------------------------ */
 /*  Main modal                                                        */
@@ -264,6 +291,28 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [loading, setLoading] = useState(false);
+  const [authStatus, setAuthStatus] = useState<AuthStatus>(DEFAULT_AUTH_STATUS);
+
+  useEffect(() => {
+    let cancelled = false;
+    axios.get(`${API_BASE_URL}/config/auth-status`)
+      .then((res) => {
+        if (cancelled) return;
+        setAuthStatus({
+          email_login_disabled: !!res.data.email_login_disabled,
+          google_oauth_enabled: !!res.data.google_oauth_enabled,
+          microsoft_oauth_enabled: !!res.data.microsoft_oauth_enabled,
+        });
+      })
+      .catch(() => { /* keep defaults on failure */ });
+    return () => { cancelled = true; };
+  }, []);
+
+  useEffect(() => {
+    if (authStatus.email_login_disabled && mode === 'register') {
+      setMode('login');
+    }
+  }, [authStatus.email_login_disabled, mode]);
 
   const handleClose = () => {
     clearVerificationMessage();
@@ -371,12 +420,14 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
             >
               Sign In
             </button>
-            <button
-              className={`login-tab ${mode === 'register' ? 'login-tab-active' : ''}`}
-              onClick={() => switchMode('register')}
-            >
-              Register
-            </button>
+            {!authStatus.email_login_disabled && (
+              <button
+                className={`login-tab ${mode === 'register' ? 'login-tab-active' : ''}`}
+                onClick={() => switchMode('register')}
+              >
+                Register
+              </button>
+            )}
           </div>
           {!required && <button className="modal-close" onClick={handleClose}>&times;</button>}
         </div>
@@ -422,6 +473,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
               setLastName={setLastName}
               loading={loading}
               displaySuccess={displaySuccess}
+              authStatus={authStatus}
               onSubmit={mode === 'login' ? handleLogin : handleRegister}
               onForgot={() => switchMode('forgot')}
             />

--- a/ui/frontend/src/components/auth/LoginModal.tsx
+++ b/ui/frontend/src/components/auth/LoginModal.tsx
@@ -295,7 +295,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ onClose, resetToken, required, 
 
   useEffect(() => {
     let cancelled = false;
-    axios.get(`${API_BASE_URL}/config/auth-status`)
+    axios.get<Partial<AuthStatus>>(`${API_BASE_URL}/config/auth-status`)
       .then((res) => {
         if (cancelled) return;
         setAuthStatus({

--- a/ui/frontend/src/components/auth/OAuthButtons.tsx
+++ b/ui/frontend/src/components/auth/OAuthButtons.tsx
@@ -4,9 +4,21 @@ import API_BASE_URL from '../../config';
 interface OAuthButtonsProps {
   /** Label prefix, e.g. "Sign in" or "Sign up" */
   action?: string;
+  /** Whether the Google OAuth button should be rendered. */
+  googleEnabled?: boolean;
+  /** Whether the Microsoft OAuth button should be rendered. */
+  microsoftEnabled?: boolean;
 }
 
-const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
+const OAuthButtons: React.FC<OAuthButtonsProps> = ({
+  action = 'Sign in',
+  googleEnabled = true,
+  microsoftEnabled = true,
+}) => {
+  if (!googleEnabled && !microsoftEnabled) {
+    return null;
+  }
+
   const handleOAuth = async (provider: string) => {
     try {
       const res = await fetch(`${API_BASE_URL}/auth/${provider}/authorize`, {
@@ -27,6 +39,7 @@ const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
 
   return (
     <div className="oauth-buttons">
+      {googleEnabled && (
       <button type="button" className="oauth-button oauth-google" onClick={handleGoogle}>
         <svg width="18" height="18" viewBox="0 0 18 18" aria-hidden="true">
           <path
@@ -48,6 +61,8 @@ const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
         </svg>
         {action} with Google
       </button>
+      )}
+      {microsoftEnabled && (
       <button type="button" className="oauth-button oauth-microsoft" onClick={handleMicrosoft}>
         <svg width="18" height="18" viewBox="0 0 21 21" aria-hidden="true">
           <rect x="1" y="1" width="9" height="9" fill="#f25022" />
@@ -57,6 +72,7 @@ const OAuthButtons: React.FC<OAuthButtonsProps> = ({ action = 'Sign in' }) => {
         </svg>
         {action} with Microsoft
       </button>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Merge rc/v1.4.0 into main for v1.4.0 release.

- fix: SQL injection via `sort_by` and taxonomy filter parameters (#264, #266)
- feat: conditional OAuth buttons and `DISABLE_EMAIL_LOGIN` (#265)
- docs: `OAUTH_CALLBACK_BASE_URL` in `.env.example` and auth docs (#261)
- ci: dependabot target-branch update, skip container-scan for dependabot PRs (#263)

## Test plan

- [x] All PRs merged and CI passing on rc/v1.4.0
- [x] CHANGELOG.md updated with v1.4.0 entry
- [ ] Merge to main, tag v1.4.0, publish GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)