### PR TITLE
feat(v1.0.5): page feedback button with screenshot capture

### DIFF
--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -93,7 +93,7 @@ class TestActivityCreate:
 
     def test_filters_jsonb_size_limit(self):
         """Extremely large filters payload should be rejected."""
-        huge = {"data": "x" * 250_000}
+        huge = {"data": "x" * 1_100_000}
         with pytest.raises(ValidationError, match="size"):
             ActivityCreate(
                 search_id=str(uuid.uuid4()),

--- a/tests/unit/test_feedback_rating_type.py
+++ b/tests/unit/test_feedback_rating_type.py
@@ -1,0 +1,47 @@
+"""Tests for the page_feedback rating type used by the feedback button."""
+
+import pytest
+from pydantic import ValidationError
+
+from ui.backend.auth.schemas import VALID_RATING_TYPES, RatingCreate
+
+pytestmark = pytest.mark.unit
+
+
+class TestPageFeedbackRatingType:
+    def test_page_feedback_in_valid_types(self):
+        assert "page_feedback" in VALID_RATING_TYPES
+
+    def test_rating_create_accepts_page_feedback(self):
+        body = RatingCreate(
+            rating_type="page_feedback",
+            reference_id="https://example.com/search?q=foo",
+            score=3,
+            comment="The export button is hidden on mobile.",
+            url="https://example.com/search?q=foo",
+            context={"screenshot": "data:image/jpeg;base64,/9j/4AAQ"},
+        )
+        assert body.rating_type == "page_feedback"
+        assert body.comment.startswith("The export")
+        assert body.context["screenshot"].startswith("data:image/jpeg")
+
+    def test_rating_create_rejects_unknown_type(self):
+        with pytest.raises(ValidationError) as exc:
+            RatingCreate(
+                rating_type="not_a_real_type",
+                reference_id="x",
+                score=3,
+            )
+        assert "rating_type" in str(exc.value)
+
+    def test_rating_create_rejects_oversized_screenshot(self):
+        # Server cap is 200_000 chars when JSONB is serialized — anything larger
+        # must be rejected before it hits Postgres.
+        oversized = "x" * 201_000
+        with pytest.raises(ValidationError):
+            RatingCreate(
+                rating_type="page_feedback",
+                reference_id="x",
+                score=3,
+                context={"screenshot": oversized},
+            )

--- a/tests/unit/test_feedback_rating_type.py
+++ b/tests/unit/test_feedback_rating_type.py
@@ -34,10 +34,22 @@ class TestPageFeedbackRatingType:
             )
         assert "rating_type" in str(exc.value)
 
+    def test_rating_create_accepts_realistic_screenshot(self):
+        # A 700 KB base64 screenshot fits comfortably under the 1 MB JSONB cap.
+        screenshot = "data:image/jpeg;base64," + ("A" * 700_000)
+        body = RatingCreate(
+            rating_type="page_feedback",
+            reference_id="x",
+            score=4,
+            comment="Captured a busy results page.",
+            context={"screenshot": screenshot},
+        )
+        assert body.context["screenshot"].startswith("data:image/jpeg")
+
     def test_rating_create_rejects_oversized_screenshot(self):
-        # Server cap is 200_000 chars when JSONB is serialized — anything larger
-        # must be rejected before it hits Postgres.
-        oversized = "x" * 201_000
+        # Server cap is 1_000_000 chars when JSONB is serialized — anything
+        # larger must be rejected before it hits Postgres.
+        oversized = "x" * 1_001_000
         with pytest.raises(ValidationError):
             RatingCreate(
                 rating_type="page_feedback",

--- a/tests/unit/test_jsonb_validation.py
+++ b/tests/unit/test_jsonb_validation.py
@@ -75,13 +75,13 @@ class TestValidateJsonb:
             _validate_jsonb(deep)
 
     def test_size_exceeded_raises(self):
-        huge = {"data": "x" * 250_000}
+        huge = {"data": "x" * 1_100_000}
         with pytest.raises(ValueError, match="size"):
             _validate_jsonb(huge)
 
     def test_at_size_limit_passes(self):
         """A payload just under the size limit should pass."""
-        # 200_000 char limit — build something close but under
-        data = {"data": "x" * 199_950}
+        # 1_000_000 char limit — build something close but under
+        data = {"data": "x" * 999_950}
         result = _validate_jsonb(data)
         assert result is data

--- a/tests/unit/test_ratings.py
+++ b/tests/unit/test_ratings.py
@@ -133,7 +133,7 @@ class TestRatingCreate:
 
     def test_context_jsonb_size_limit(self):
         """Extremely large context payload should be rejected."""
-        huge = {"data": "x" * 250_000}
+        huge = {"data": "x" * 1_100_000}
         with pytest.raises(ValidationError, match="size"):
             RatingCreate(
                 rating_type="search_result",
@@ -197,6 +197,7 @@ class TestValidRatingTypes:
             "chat",
             "assistant-basic",
             "assistant-deep-research",
+            "page_feedback",
         }
         assert VALID_RATING_TYPES == expected
 

--- a/ui/backend/auth/schemas.py
+++ b/ui/backend/auth/schemas.py
@@ -12,7 +12,8 @@ from pydantic import BaseModel, Field, computed_field, field_validator
 # ---------------------------------------------------------------------------
 
 _MAX_JSONB_DEPTH = 10
-_MAX_JSONB_SIZE = 200_000  # chars when serialised (≈200 KB)
+# Cap on JSONB-bound payloads when serialised (≈1 MB; under the 2 MB request-body cap).
+_MAX_JSONB_SIZE = 1_000_000
 
 
 def _check_jsonb_depth(

--- a/ui/backend/auth/schemas.py
+++ b/ui/backend/auth/schemas.py
@@ -194,6 +194,9 @@ VALID_RATING_TYPES = {
     "chat",
     "assistant-basic",
     "assistant-deep-research",
+    # Free-form page feedback submitted via the floating feedback button.
+    # Score is unused for this type; clients submit a sentinel value (3).
+    "page_feedback",
 }
 
 

--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "ajv": "^8.18.0",
         "ajv-keywords": "^5.1.0",
         "axios": "^1.13.6",
+        "html2canvas": "^1.4.1",
         "pdfjs-dist": "^3.11.174",
         "plotly.js": "^2.27.0",
         "react": "^18.2.0",
@@ -7288,6 +7289,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/css-loader": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.3.tgz",
@@ -11624,6 +11634,19 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -20931,6 +20954,15 @@
         "node": "*"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -21733,6 +21765,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -6,6 +6,7 @@
     "ajv": "^8.18.0",
     "ajv-keywords": "^5.1.0",
     "axios": "^1.13.6",
+    "html2canvas": "^1.4.1",
     "pdfjs-dist": "^3.11.174",
     "plotly.js": "^2.27.0",
     "react": "^18.2.0",

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -38,6 +38,7 @@ import { SearchTabContent } from './components/app/SearchTabContent';
 import { HeatmapTabContent } from './components/app/HeatmapTabContent';
 import { TabContent } from './components/app/TabContent';
 import { CookieConsent, getGaConsent } from './components/CookieConsent';
+import FeedbackButton from './components/feedback/FeedbackButton';
 import SavedResearchModal from './components/SavedResearchModal';
 import { AuthContext, useAuthState } from './hooks/useAuth';
 import { useGroupDefaults } from './hooks/useGroupDefaults';
@@ -3070,6 +3071,7 @@ function App() {
       />
 
       <CookieConsent />
+      <FeedbackButton />
     </div >
   );
 

--- a/ui/frontend/src/components/feedback/FeedbackButton.tsx
+++ b/ui/frontend/src/components/feedback/FeedbackButton.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import html2canvas from 'html2canvas';
+import FeedbackModal from './FeedbackModal';
+
+const FeedbackButton: React.FC = () => {
+  const [open, setOpen] = useState(false);
+  const [capturing, setCapturing] = useState(false);
+  const [screenshot, setScreenshot] = useState<string | null>(null);
+  const [screenshotError, setScreenshotError] = useState<string | null>(null);
+  const [url, setUrl] = useState('');
+
+  const handleOpen = async () => {
+    setCapturing(true);
+    setScreenshot(null);
+    setScreenshotError(null);
+    setUrl(window.location.href);
+
+    try {
+      const canvas = await html2canvas(document.documentElement, {
+        scale: 0.5,
+        logging: false,
+        useCORS: true,
+        backgroundColor: '#ffffff',
+      });
+      setScreenshot(canvas.toDataURL('image/jpeg', 0.6));
+    } catch (err: unknown) {
+      setScreenshotError(err instanceof Error ? err.message : 'unknown error');
+    } finally {
+      setCapturing(false);
+      setOpen(true);
+    }
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    setScreenshot(null);
+    setScreenshotError(null);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleOpen}
+        disabled={capturing}
+        aria-label="Send feedback"
+        style={{
+          position: 'fixed',
+          bottom: 24,
+          right: 24,
+          zIndex: 9000,
+          padding: '10px 16px',
+          fontSize: '0.85rem',
+          fontWeight: 600,
+          background: 'var(--brand-primary, #2c5cdc)',
+          color: '#fff',
+          border: 'none',
+          borderRadius: 999,
+          boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+          cursor: capturing ? 'wait' : 'pointer',
+          opacity: capturing ? 0.7 : 1,
+        }}
+      >
+        {capturing ? 'Capturing…' : 'Feedback'}
+      </button>
+      <FeedbackModal
+        isOpen={open}
+        onClose={handleClose}
+        url={url}
+        screenshot={screenshot}
+        screenshotError={screenshotError}
+      />
+    </>
+  );
+};
+
+export default FeedbackButton;

--- a/ui/frontend/src/components/feedback/FeedbackButton.tsx
+++ b/ui/frontend/src/components/feedback/FeedbackButton.tsx
@@ -2,6 +2,30 @@ import React, { useState } from 'react';
 import html2canvas from 'html2canvas';
 import FeedbackModal from './FeedbackModal';
 
+const TOOLTIP = 'Send feedback about this page';
+
+// Server allows up to ~1 MB JSONB; leave ~10% headroom for the rest of the
+// payload (rating_type, comment, url, JSON overhead).
+const SCREENSHOT_BYTES_BUDGET = 900_000;
+const JPEG_QUALITY_LADDER = [0.6, 0.4, 0.25];
+
+// Speech-bubble icon — communicates "leave a comment" without needing a label.
+const FeedbackIcon: React.FC<{ size?: number }> = ({ size = 22 }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
 const FeedbackButton: React.FC = () => {
   const [open, setOpen] = useState(false);
   const [capturing, setCapturing] = useState(false);
@@ -22,7 +46,29 @@ const FeedbackButton: React.FC = () => {
         useCORS: true,
         backgroundColor: '#ffffff',
       });
-      setScreenshot(canvas.toDataURL('image/jpeg', 0.6));
+      // Try progressively lower JPEG quality until the encoded URL fits the
+      // server's JSONB budget. Big or busy pages fall back to lower quality
+      // rather than dropping the screenshot entirely.
+      let chosen: string | null = null;
+      let lastSize = 0;
+      for (const quality of JPEG_QUALITY_LADDER) {
+        const dataUrl = canvas.toDataURL('image/jpeg', quality);
+        if (!dataUrl || dataUrl === 'data:,' || dataUrl.length < 100) continue;
+        lastSize = dataUrl.length;
+        if (dataUrl.length <= SCREENSHOT_BYTES_BUDGET) {
+          chosen = dataUrl;
+          break;
+        }
+      }
+      if (chosen) {
+        setScreenshot(chosen);
+      } else if (lastSize === 0) {
+        setScreenshotError('canvas was empty');
+      } else {
+        setScreenshotError(
+          `screenshot too large to attach (${Math.round(lastSize / 1024)} KB at lowest quality)`,
+        );
+      }
     } catch (err: unknown) {
       setScreenshotError(err instanceof Error ? err.message : 'unknown error');
     } finally {
@@ -43,25 +89,28 @@ const FeedbackButton: React.FC = () => {
         type="button"
         onClick={handleOpen}
         disabled={capturing}
-        aria-label="Send feedback"
+        aria-label={TOOLTIP}
+        title={TOOLTIP}
         style={{
           position: 'fixed',
           bottom: 24,
           right: 24,
           zIndex: 9000,
-          padding: '10px 16px',
-          fontSize: '0.85rem',
-          fontWeight: 600,
+          width: 48,
+          height: 48,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
           background: 'var(--brand-primary, #2c5cdc)',
           color: '#fff',
           border: 'none',
-          borderRadius: 999,
+          borderRadius: '50%',
           boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
           cursor: capturing ? 'wait' : 'pointer',
           opacity: capturing ? 0.7 : 1,
         }}
       >
-        {capturing ? 'Capturing…' : 'Feedback'}
+        <FeedbackIcon />
       </button>
       <FeedbackModal
         isOpen={open}

--- a/ui/frontend/src/components/feedback/FeedbackModal.tsx
+++ b/ui/frontend/src/components/feedback/FeedbackModal.tsx
@@ -1,0 +1,225 @@
+import React, { useState } from 'react';
+import axios from 'axios';
+import API_BASE_URL from '../../config';
+
+interface FeedbackModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  url: string;
+  screenshot: string | null;
+  screenshotError: string | null;
+}
+
+// Server enforces a 200 KB cap on the JSONB `context` column. Reject early
+// so the user gets clear feedback instead of a 422 from the server.
+const MAX_SCREENSHOT_BYTES = 180_000;
+
+const FeedbackModal: React.FC<FeedbackModalProps> = ({
+  isOpen,
+  onClose,
+  url,
+  screenshot,
+  screenshotError,
+}) => {
+  const [comment, setComment] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  if (!isOpen) return null;
+
+  const screenshotTooLarge =
+    screenshot !== null && screenshot.length > MAX_SCREENSHOT_BYTES;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!comment.trim()) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const context = screenshot && !screenshotTooLarge ? { screenshot } : null;
+      await axios.post(`${API_BASE_URL}/ratings/`, {
+        rating_type: 'page_feedback',
+        reference_id: url.slice(0, 255),
+        score: 3,
+        comment: comment.trim(),
+        url,
+        context,
+      });
+      setSubmitted(true);
+    } catch (err: unknown) {
+      const responseData = (err as { response?: { data?: unknown } } | null)?.response?.data;
+      setSubmitError(responseData ? JSON.stringify(responseData) : 'Submission failed');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setComment('');
+    setSubmitError(null);
+    setSubmitted(false);
+    onClose();
+  };
+
+  return (
+    <div
+      className="rating-modal-overlay"
+      onClick={handleClose}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0,0,0,0.35)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 9999,
+      }}
+    >
+      <div
+        className="modal-panel feedback-modal"
+        onClick={(e) => e.stopPropagation()}
+        style={{ maxWidth: 520, width: '92%', maxHeight: '90vh', overflowY: 'auto' }}
+      >
+        <div className="modal-header">
+          <h2 style={{ fontSize: '1rem', fontWeight: 600 }}>Send feedback</h2>
+          <div className="modal-header-actions">
+            <button onClick={handleClose} className="modal-close" aria-label="Close">×</button>
+          </div>
+        </div>
+
+        {submitted ? (
+          <div className="modal-body" style={{ padding: '24px 20px', textAlign: 'center' }}>
+            <p style={{ margin: 0, fontSize: '0.9rem' }}>Thanks — your feedback was submitted.</p>
+            <button
+              type="button"
+              onClick={handleClose}
+              style={{
+                marginTop: 16,
+                padding: '6px 14px',
+                fontSize: '0.82rem',
+                background: 'var(--brand-primary)',
+                color: '#fff',
+                border: 'none',
+                borderRadius: 6,
+                cursor: 'pointer',
+              }}
+            >
+              Close
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div className="modal-body" style={{ padding: '16px 20px' }}>
+              <div style={{ marginBottom: 12, fontSize: '0.78rem', color: 'var(--brand-text-secondary)' }}>
+                <strong>Page:</strong>{' '}
+                <span style={{ wordBreak: 'break-all' }}>{url}</span>
+              </div>
+
+              <div style={{ marginBottom: 12 }}>
+                <div style={{ fontSize: '0.78rem', color: 'var(--brand-text-secondary)', marginBottom: 4 }}>
+                  Screenshot
+                </div>
+                {screenshot && !screenshotTooLarge && (
+                  <img
+                    src={screenshot}
+                    alt="Screenshot of current page"
+                    style={{
+                      width: '100%',
+                      border: '1px solid var(--brand-border)',
+                      borderRadius: 6,
+                      maxHeight: 220,
+                      objectFit: 'contain',
+                      background: '#f7f7f7',
+                    }}
+                  />
+                )}
+                {screenshotError && (
+                  <p style={{ margin: 0, color: 'var(--brand-error)', fontSize: '0.78rem' }}>
+                    Could not capture screenshot: {screenshotError}. Feedback will be submitted without it.
+                  </p>
+                )}
+                {screenshotTooLarge && (
+                  <p style={{ margin: 0, color: 'var(--brand-error)', fontSize: '0.78rem' }}>
+                    Screenshot too large to attach; feedback will be submitted without it.
+                  </p>
+                )}
+              </div>
+
+              <textarea
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder="Tell us what went well or what needs improvement…"
+                rows={4}
+                maxLength={2000}
+                required
+                style={{
+                  width: '100%',
+                  padding: '8px 10px',
+                  border: '1px solid var(--brand-border)',
+                  borderRadius: 6,
+                  resize: 'vertical',
+                  fontSize: '0.85rem',
+                  fontFamily: 'inherit',
+                }}
+              />
+
+              {submitError && (
+                <p style={{ margin: '8px 0 0', color: 'var(--brand-error)', fontSize: '0.78rem' }}>
+                  {submitError}
+                </p>
+              )}
+            </div>
+
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                padding: '12px 20px',
+                borderTop: '1px solid var(--brand-border-light)',
+                gap: 8,
+              }}
+            >
+              <button
+                type="button"
+                onClick={handleClose}
+                disabled={submitting}
+                style={{
+                  padding: '6px 14px',
+                  fontSize: '0.82rem',
+                  background: 'transparent',
+                  color: 'var(--brand-text-secondary)',
+                  border: '1px solid var(--brand-border)',
+                  borderRadius: 6,
+                  cursor: submitting ? 'not-allowed' : 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !comment.trim()}
+                style={{
+                  padding: '6px 14px',
+                  fontSize: '0.82rem',
+                  background:
+                    submitting || !comment.trim()
+                      ? 'var(--brand-border)'
+                      : 'var(--brand-primary)',
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: 6,
+                  cursor: submitting || !comment.trim() ? 'not-allowed' : 'pointer',
+                }}
+              >
+                {submitting ? 'Submitting…' : 'Submit'}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default FeedbackModal;

--- a/ui/frontend/src/components/feedback/FeedbackModal.tsx
+++ b/ui/frontend/src/components/feedback/FeedbackModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import axios from 'axios';
 import API_BASE_URL from '../../config';
+import StarRating from '../ratings/StarRating';
 
 interface FeedbackModalProps {
   isOpen: boolean;
@@ -10,9 +11,19 @@ interface FeedbackModalProps {
   screenshotError: string | null;
 }
 
-// Server enforces a 200 KB cap on the JSONB `context` column. Reject early
-// so the user gets clear feedback instead of a 422 from the server.
-const MAX_SCREENSHOT_BYTES = 180_000;
+// Server enforces a 1 MB cap on the JSONB `context` column. Leave a little
+// headroom for the rest of the payload so we never trip a 422.
+const MAX_SCREENSHOT_BYTES = 950_000;
+
+const FONT_SIZE_HINT = '0.78rem';
+const FONT_SIZE_BUTTON = '0.82rem';
+const BORDER_DEFAULT = '1px solid var(--brand-border)';
+const BUTTON_PADDING = '6px 14px';
+const COLOR_TEXT_SECONDARY = 'var(--brand-text-secondary)';
+const COLOR_ERROR = 'var(--brand-error)';
+const COLOR_PRIMARY = 'var(--brand-primary)';
+const COLOR_BORDER = 'var(--brand-border)';
+const RADIUS_DEFAULT = 6;
 
 const FeedbackModal: React.FC<FeedbackModalProps> = ({
   isOpen,
@@ -21,6 +32,7 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
   screenshot,
   screenshotError,
 }) => {
+  const [score, setScore] = useState(0);
   const [comment, setComment] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -30,21 +42,24 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
 
   const screenshotTooLarge =
     screenshot !== null && screenshot.length > MAX_SCREENSHOT_BYTES;
+  const canSubmit = score >= 1 && comment.trim().length > 0;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!comment.trim()) return;
+    if (!canSubmit) return;
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const context = screenshot && !screenshotTooLarge ? { screenshot } : null;
+      const context: Record<string, unknown> = {};
+      if (screenshot && !screenshotTooLarge) context.screenshot = screenshot;
+      if (screenshotError) context.screenshot_error = screenshotError;
       await axios.post(`${API_BASE_URL}/ratings/`, {
         rating_type: 'page_feedback',
         reference_id: url.slice(0, 255),
-        score: 3,
+        score,
         comment: comment.trim(),
         url,
-        context,
+        context: Object.keys(context).length > 0 ? context : null,
       });
       setSubmitted(true);
     } catch (err: unknown) {
@@ -56,6 +71,7 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
   };
 
   const handleClose = () => {
+    setScore(0);
     setComment('');
     setSubmitError(null);
     setSubmitted(false);
@@ -79,7 +95,7 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
       <div
         className="modal-panel feedback-modal"
         onClick={(e) => e.stopPropagation()}
-        style={{ maxWidth: 520, width: '92%', maxHeight: '90vh', overflowY: 'auto' }}
+        style={{ maxWidth: 420, width: '92%' }}
       >
         <div className="modal-header">
           <h2 style={{ fontSize: '1rem', fontWeight: 600 }}>Send feedback</h2>
@@ -96,12 +112,12 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
               onClick={handleClose}
               style={{
                 marginTop: 16,
-                padding: '6px 14px',
-                fontSize: '0.82rem',
-                background: 'var(--brand-primary)',
+                padding: BUTTON_PADDING,
+                fontSize: FONT_SIZE_BUTTON,
+                background: COLOR_PRIMARY,
                 color: '#fff',
                 border: 'none',
-                borderRadius: 6,
+                borderRadius: RADIUS_DEFAULT,
                 cursor: 'pointer',
               }}
             >
@@ -111,39 +127,24 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
         ) : (
           <form onSubmit={handleSubmit}>
             <div className="modal-body" style={{ padding: '16px 20px' }}>
-              <div style={{ marginBottom: 12, fontSize: '0.78rem', color: 'var(--brand-text-secondary)' }}>
-                <strong>Page:</strong>{' '}
-                <span style={{ wordBreak: 'break-all' }}>{url}</span>
-              </div>
+              <p
+                style={{
+                  margin: '0 0 14px',
+                  fontSize: FONT_SIZE_HINT,
+                  color: COLOR_TEXT_SECONDARY,
+                  lineHeight: 1.4,
+                }}
+              >
+                The page URL and a screenshot are captured automatically — no need
+                to describe what you were looking at. Just share the context: what
+                you expected, what surprised you, or what would make this better.
+              </p>
 
-              <div style={{ marginBottom: 12 }}>
-                <div style={{ fontSize: '0.78rem', color: 'var(--brand-text-secondary)', marginBottom: 4 }}>
-                  Screenshot
+              <div style={{ marginBottom: 16, textAlign: 'center' }}>
+                <StarRating score={score} onChange={setScore} size={28} />
+                <div style={{ marginTop: 6, fontSize: FONT_SIZE_HINT, color: COLOR_TEXT_SECONDARY }}>
+                  {score === 0 ? 'Click a star to rate' : `${score} / 5`}
                 </div>
-                {screenshot && !screenshotTooLarge && (
-                  <img
-                    src={screenshot}
-                    alt="Screenshot of current page"
-                    style={{
-                      width: '100%',
-                      border: '1px solid var(--brand-border)',
-                      borderRadius: 6,
-                      maxHeight: 220,
-                      objectFit: 'contain',
-                      background: '#f7f7f7',
-                    }}
-                  />
-                )}
-                {screenshotError && (
-                  <p style={{ margin: 0, color: 'var(--brand-error)', fontSize: '0.78rem' }}>
-                    Could not capture screenshot: {screenshotError}. Feedback will be submitted without it.
-                  </p>
-                )}
-                {screenshotTooLarge && (
-                  <p style={{ margin: 0, color: 'var(--brand-error)', fontSize: '0.78rem' }}>
-                    Screenshot too large to attach; feedback will be submitted without it.
-                  </p>
-                )}
               </div>
 
               <textarea
@@ -156,16 +157,29 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                 style={{
                   width: '100%',
                   padding: '8px 10px',
-                  border: '1px solid var(--brand-border)',
-                  borderRadius: 6,
+                  border: BORDER_DEFAULT,
+                  borderRadius: RADIUS_DEFAULT,
                   resize: 'vertical',
                   fontSize: '0.85rem',
                   fontFamily: 'inherit',
                 }}
               />
 
+              <div
+                style={{
+                  marginTop: 10,
+                  fontSize: FONT_SIZE_HINT,
+                  color: COLOR_TEXT_SECONDARY,
+                }}
+              >
+                {screenshot && !screenshotTooLarge && '✓ Screenshot attached'}
+                {screenshotTooLarge && '⚠ Screenshot was too large to attach'}
+                {screenshotError && `⚠ Screenshot capture failed: ${screenshotError}`}
+                {!screenshot && !screenshotError && '… capturing screenshot'}
+              </div>
+
               {submitError && (
-                <p style={{ margin: '8px 0 0', color: 'var(--brand-error)', fontSize: '0.78rem' }}>
+                <p style={{ margin: '8px 0 0', color: COLOR_ERROR, fontSize: FONT_SIZE_HINT }}>
                   {submitError}
                 </p>
               )}
@@ -185,12 +199,12 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
                 onClick={handleClose}
                 disabled={submitting}
                 style={{
-                  padding: '6px 14px',
-                  fontSize: '0.82rem',
+                  padding: BUTTON_PADDING,
+                  fontSize: FONT_SIZE_BUTTON,
                   background: 'transparent',
-                  color: 'var(--brand-text-secondary)',
-                  border: '1px solid var(--brand-border)',
-                  borderRadius: 6,
+                  color: COLOR_TEXT_SECONDARY,
+                  border: BORDER_DEFAULT,
+                  borderRadius: RADIUS_DEFAULT,
                   cursor: submitting ? 'not-allowed' : 'pointer',
                 }}
               >
@@ -198,18 +212,15 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({
               </button>
               <button
                 type="submit"
-                disabled={submitting || !comment.trim()}
+                disabled={submitting || !canSubmit}
                 style={{
-                  padding: '6px 14px',
-                  fontSize: '0.82rem',
-                  background:
-                    submitting || !comment.trim()
-                      ? 'var(--brand-border)'
-                      : 'var(--brand-primary)',
+                  padding: BUTTON_PADDING,
+                  fontSize: FONT_SIZE_BUTTON,
+                  background: submitting || !canSubmit ? COLOR_BORDER : COLOR_PRIMARY,
                   color: '#fff',
                   border: 'none',
-                  borderRadius: 6,
-                  cursor: submitting || !comment.trim() ? 'not-allowed' : 'pointer',
+                  borderRadius: RADIUS_DEFAULT,
+                  cursor: submitting || !canSubmit ? 'not-allowed' : 'pointer',
                 }}
               >
                 {submitting ? 'Submitting…' : 'Submit'}

--- a/ui/frontend/src/tests/feedbackButton.test.tsx
+++ b/ui/frontend/src/tests/feedbackButton.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// html2canvas relies on browser APIs (canvas, document.fonts) that jsdom only
+// partially implements. Replace it with a deterministic stub.
+jest.mock('html2canvas', () => ({
+  __esModule: true,
+  default: jest.fn(() =>
+    Promise.resolve({
+      toDataURL: () => 'data:image/jpeg;base64,STUB',
+    }),
+  ),
+}));
+
+// Stub axios so the modal's submit doesn't try to hit the network.
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(() => Promise.resolve({ data: {} })),
+    isAxiosError: jest.fn(() => false),
+  },
+}));
+
+import FeedbackButton from '../components/feedback/FeedbackButton';
+
+describe('FeedbackButton', () => {
+  test('renders a feedback trigger button', () => {
+    render(<FeedbackButton />);
+    expect(screen.getByRole('button', { name: /send feedback/i })).toBeInTheDocument();
+  });
+
+  test('clicking the trigger opens the modal with the current URL', async () => {
+    render(<FeedbackButton />);
+    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }));
+    expect(await screen.findByRole('heading', { name: /send feedback/i })).toBeInTheDocument();
+    expect(screen.getByText(/Page:/)).toBeInTheDocument();
+  });
+
+  test('cancel button closes the modal', async () => {
+    render(<FeedbackButton />);
+    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }));
+    await screen.findByRole('heading', { name: /send feedback/i });
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByRole('heading', { name: /send feedback/i })).not.toBeInTheDocument();
+  });
+
+  test('submit is disabled until the user types a comment', async () => {
+    render(<FeedbackButton />);
+    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }));
+    await screen.findByRole('heading', { name: /send feedback/i });
+    const submit = screen.getByRole('button', { name: /^submit$/i });
+    expect(submit).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText(/Tell us what went well/i), {
+      target: { value: 'The export button is hidden.' },
+    });
+    expect(submit).not.toBeDisabled();
+  });
+});

--- a/ui/frontend/src/tests/feedbackButton.test.tsx
+++ b/ui/frontend/src/tests/feedbackButton.test.tsx
@@ -13,10 +13,11 @@ jest.mock('html2canvas', () => ({
 }));
 
 // Stub axios so the modal's submit doesn't try to hit the network.
+const mockAxiosPost = jest.fn(() => Promise.resolve({ data: {} }));
 jest.mock('axios', () => ({
   __esModule: true,
   default: {
-    post: jest.fn(() => Promise.resolve({ data: {} })),
+    post: (...args: unknown[]) => mockAxiosPost(...args),
     isAxiosError: jest.fn(() => false),
   },
 }));
@@ -24,35 +25,63 @@ jest.mock('axios', () => ({
 import FeedbackButton from '../components/feedback/FeedbackButton';
 
 describe('FeedbackButton', () => {
-  test('renders a feedback trigger button', () => {
-    render(<FeedbackButton />);
-    expect(screen.getByRole('button', { name: /send feedback/i })).toBeInTheDocument();
+  beforeEach(() => {
+    mockAxiosPost.mockClear();
   });
 
-  test('clicking the trigger opens the modal with the current URL', async () => {
+  test('renders an icon button with a tooltip', () => {
     render(<FeedbackButton />);
-    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }));
-    expect(await screen.findByRole('heading', { name: /send feedback/i })).toBeInTheDocument();
-    expect(screen.getByText(/Page:/)).toBeInTheDocument();
+    const trigger = screen.getByRole('button', { name: /send feedback/i });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger).toHaveAttribute('title', 'Send feedback about this page');
   });
 
-  test('cancel button closes the modal', async () => {
+  test('opening the modal does not show URL or screenshot', async () => {
     render(<FeedbackButton />);
     fireEvent.click(screen.getByRole('button', { name: /send feedback/i }));
     await screen.findByRole('heading', { name: /send feedback/i });
-    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
-    expect(screen.queryByRole('heading', { name: /send feedback/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/Page:/)).not.toBeInTheDocument();
+    expect(screen.queryByAltText(/screenshot/i)).not.toBeInTheDocument();
   });
 
-  test('submit is disabled until the user types a comment', async () => {
+  test('submit is disabled until both a star rating and a comment are provided', async () => {
     render(<FeedbackButton />);
     fireEvent.click(screen.getByRole('button', { name: /send feedback/i }));
     await screen.findByRole('heading', { name: /send feedback/i });
     const submit = screen.getByRole('button', { name: /^submit$/i });
     expect(submit).toBeDisabled();
+
+    // Comment alone is not enough.
     fireEvent.change(screen.getByPlaceholderText(/Tell us what went well/i), {
-      target: { value: 'The export button is hidden.' },
+      target: { value: 'Looks great' },
     });
+    expect(submit).toBeDisabled();
+
+    // Pick 4 stars.
+    const stars = document.querySelectorAll('.star-rating-star');
+    fireEvent.click(stars[3]);
     expect(submit).not.toBeDisabled();
+  });
+
+  test('submit posts rating_type, score, comment, and url', async () => {
+    render(<FeedbackButton />);
+    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }));
+    await screen.findByRole('heading', { name: /send feedback/i });
+
+    fireEvent.change(screen.getByPlaceholderText(/Tell us what went well/i), {
+      target: { value: 'Worked well' },
+    });
+    const stars = document.querySelectorAll('.star-rating-star');
+    fireEvent.click(stars[4]); // 5 stars
+    fireEvent.click(screen.getByRole('button', { name: /^submit$/i }));
+
+    await screen.findByText(/your feedback was submitted/i);
+
+    expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+    const [, body] = mockAxiosPost.mock.calls[0] as [string, Record<string, unknown>];
+    expect(body.rating_type).toBe('page_feedback');
+    expect(body.score).toBe(5);
+    expect(body.comment).toBe('Worked well');
+    expect(typeof body.url).toBe('string');
   });
 });


### PR DESCRIPTION
## Summary
Adds a floating feedback button (bottom-right, every screen) that lets users send a 0–5 star rating + comment. The page URL and a screenshot of the rendered page are captured automatically and stored on the existing `user_ratings` table — no new endpoint or migration needed.

- Circular chat-bubble icon button with a tooltip ("Send feedback about this page").
- Modal: short hint copy → 0–5 stars → required comment → submit. The page URL and screenshot **preview** are intentionally hidden so users focus on context, but both are still captured into the row (URL on the column, screenshot in `context.screenshot`).
- Capture path uses progressive JPEG quality (0.6 → 0.4 → 0.25) so larger pages still fit. Modal surfaces capture status ("✓ Screenshot attached" / specific failure reason).
- New `page_feedback` value added to `VALID_RATING_TYPES`. Submissions land via the existing `POST /ratings/` endpoint.
- JSONB context cap raised from 200 KB → 1 MB so realistic full-page screenshots reliably attach. Still well under the 2 MB request-body middleware limit.

## Test plan
- [ ] `pytest tests/unit/test_feedback_rating_type.py` — 5 tests pass (valid type, accepted payload, unknown type rejected, realistic screenshot accepted, oversized rejected).
- [ ] `cd ui/frontend && npm test -- --testPathPattern=feedbackButton` — 4 tests pass (icon + tooltip render, no URL/screenshot in modal, submit gated on stars+comment, payload shape).
- [ ] In the running UI, hover the floating button → tooltip shows.
- [ ] Submit feedback on a search results page → row in `user_ratings` with `rating_type='page_feedback'`, `score` 1–5, `url` set, `context->>'screenshot'` is a JPEG data URL.
- [ ] On a heavy page that previously failed: confirm modal shows "✓ Screenshot attached" or a specific failure reason rather than silently dropping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)