### PR TITLE
build(deps): bump langchain 1.2.15, langchain-openai 1.1.12, langgraph-prebuilt 1.0.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,11 +69,11 @@ asyncpg==0.31.0
 aiosmtplib==5.1.0
 
 # LangChain and LLM integration
-langchain==1.2.10
+langchain==1.2.15
 langchain-core==1.2.19
 langchain-community==0.4.1
 langchain-huggingface==1.2.0
-langchain-openai==1.1.10
+langchain-openai==1.1.12
 langchain-anthropic==1.3.3
 langchain-google-vertexai>=3.0.0,<4.0.0
 
@@ -88,7 +88,7 @@ google-cloud-discoveryengine>=0.13.0
 # breaking CI. Keep these in lockstep with the working runtime versions.
 deepagents>=0.4.0
 langgraph==1.0.10
-langgraph-prebuilt==1.0.8
+langgraph-prebuilt==1.0.9
 langgraph-checkpoint-postgres>=2.0.0
 
 # Task queue


### PR DESCRIPTION
## Summary
- Bumps `langchain` 1.2.10 → 1.2.15
- Bumps `langchain-openai` 1.1.10 → 1.1.12
- Bumps `langgraph-prebuilt` 1.0.8 → 1.0.9

Replaces #281, #280, #278 — those PRs were originally targeted at `rc/v1.4.0` and had stale CI failures from 2026-04-13. Combining all three patch bumps into a single PR off `rc/v1.5.0` so unit + integration tests run together against the current release branch.

## Test plan
- [ ] CI: `tests` job (unit) green
- [ ] CI: `code-quality`, `security-scan`, `sbom` green
- [ ] Integration tests run locally if CI's `integration-tests` job is skip-gated: `docker compose exec -T pipeline pytest tests/integration -v -s`
- [ ] Smoke: assistant + search endpoints respond

Closes #281, #280, #278.

https://claude.ai/code/session_01BTcNpWp6JEMaNecBztHVYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTcNpWp6JEMaNecBztHVYK)_