### PR TITLE
fix: scope AI summary ratings per drilldown node

### DIFF
--- a/scripts/quality/code_metrics.py
+++ b/scripts/quality/code_metrics.py
@@ -8,6 +8,8 @@ Metrics:
 - Maintainability Index (radon, Python only)
 """
 
+from __future__ import annotations
+
 import argparse
 import ast
 import json

--- a/ui/frontend/src/components/app/SearchTabContent.tsx
+++ b/ui/frontend/src/components/app/SearchTabContent.tsx
@@ -510,7 +510,11 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
 
   const [aiRatingModalOpen, setAiRatingModalOpen] = useState(false);
   const [aiRatingModalInitialScore, setAiRatingModalInitialScore] = useState(0);
-  const aiRating = aiSummaryRatings.get('');
+  // Scope ratings to the currently-viewed summary node so each drilldown summary
+  // is rated independently. Root summary keeps item_id=null/'' for back-compat
+  // with ratings created before drilldown scoping existed.
+  const aiRatingItemId = aiDrilldownCurrentNodeId || '';
+  const aiRating = aiSummaryRatings.get(aiRatingItemId);
 
   // Score-filtered results (same threshold used throughout)
   const visibleResults = useMemo(() =>
@@ -828,6 +832,7 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
                 submitAiRating({
                   ratingType: 'ai_summary',
                   referenceId: searchId,
+                  itemId: aiDrilldownCurrentNodeId || undefined,
                   score,
                   comment,
                   context: {

--- a/ui/frontend/src/components/app/SearchTabContent.tsx
+++ b/ui/frontend/src/components/app/SearchTabContent.tsx
@@ -369,6 +369,20 @@ const isAiSummaryVisible = (
   return results.length > 0 || loading || Boolean(summary);
 };
 
+/** Resolve the AI-rating scope for a drilldown node id.
+ *
+ * The Map key for cached ratings uses ``''`` for the root summary (back-compat
+ * with ratings created before drilldown scoping), while the submit payload
+ * needs ``undefined`` for the root so it serialises to ``null`` server-side.
+ * Both shapes are derived here so the component body avoids the conditionals
+ * (keeps its cyclomatic complexity below the repo threshold). */
+const resolveAiRatingScope = (
+  drilldownNodeId: string | null | undefined,
+): { key: string; itemId: string | undefined } => ({
+  key: drilldownNodeId || '',
+  itemId: drilldownNodeId || undefined,
+});
+
 export const SearchTabContent: React.FC<SearchTabContentProps> = ({
   filtersExpanded,
   activeFiltersCount,
@@ -513,8 +527,8 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
   // Scope ratings to the currently-viewed summary node so each drilldown summary
   // is rated independently. Root summary keeps item_id=null/'' for back-compat
   // with ratings created before drilldown scoping existed.
-  const aiRatingItemId = aiDrilldownCurrentNodeId || '';
-  const aiRating = aiSummaryRatings.get(aiRatingItemId);
+  const aiRatingScope = resolveAiRatingScope(aiDrilldownCurrentNodeId);
+  const aiRating = aiSummaryRatings.get(aiRatingScope.key);
 
   // Score-filtered results (same threshold used throughout)
   const visibleResults = useMemo(() =>
@@ -832,7 +846,7 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
                 submitAiRating({
                   ratingType: 'ai_summary',
                   referenceId: searchId,
-                  itemId: aiDrilldownCurrentNodeId || undefined,
+                  itemId: aiRatingScope.itemId,
                   score,
                   comment,
                   context: {

--- a/ui/frontend/src/tests/searchTabContent.aiRating.test.tsx
+++ b/ui/frontend/src/tests/searchTabContent.aiRating.test.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import { act, render } from '@testing-library/react';
+
+import { SearchTabContent } from '../components/app/SearchTabContent';
+import { DrilldownNode, SearchResult } from '../types/api';
+
+// Capture the props the AiSummaryPanel receives so we can assert on
+// `ratingScore`, which is what the rating star component renders from.
+let mockAiSummaryProps: Record<string, unknown> | null = null;
+jest.mock('../components/AiSummaryPanel', () => ({
+  AiSummaryPanel: (props: Record<string, unknown>) => {
+    mockAiSummaryProps = props;
+    return <div data-testid="ai-summary-panel" />;
+  },
+}));
+
+jest.mock('../components/filters/FiltersPanel', () => ({
+  FiltersPanel: () => <div>Filters Panel</div>,
+}));
+
+jest.mock('../components/SearchResultsList', () => ({
+  SearchResultsList: () => <div data-testid="results-list" />,
+}));
+
+// Capture RatingModal props so a test can fire its onSubmit and observe the
+// itemId that gets sent to submitRating.
+let mockRatingModalProps: Record<string, unknown> | null = null;
+jest.mock('../components/ratings/RatingModal', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => {
+    mockRatingModalProps = props;
+    return <div data-testid="rating-modal" />;
+  },
+}));
+
+// useAuth must report authenticated so SearchTabContent enables the
+// `ai_summary` ratings query and passes `isAuthenticated` down.
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ isAuthenticated: true, user: { id: 'u-1' } }),
+}));
+
+// Controlled useRatings: return a Map with one rating for the root summary
+// (item_id=null/'') and one for a drilldown node ('dd-1'). Capture the
+// last submitRating call so we can assert the itemId argument.
+const mockSubmitRating = jest.fn(async (params: Record<string, unknown>) => ({
+  id: 'new-rating',
+  ...params,
+}));
+
+jest.mock('../hooks/useRatings', () => {
+  const buildMap = () => {
+    const map = new Map<string, Record<string, unknown>>();
+    map.set('', { id: 'r-root', item_id: null, score: 5, comment: 'root review' });
+    map.set('dd-1', { id: 'r-dd1', item_id: 'dd-1', score: 3, comment: 'drilldown review' });
+    return map;
+  };
+  return {
+    __esModule: true,
+    useRatings: ({ ratingType }: { ratingType: string }) => ({
+      ratings: ratingType === 'ai_summary' ? buildMap() : new Map(),
+      loading: false,
+      submitRating: mockSubmitRating,
+      deleteRating: jest.fn(),
+      refresh: jest.fn(),
+    }),
+    default: ({ ratingType }: { ratingType: string }) => ({
+      ratings: ratingType === 'ai_summary' ? buildMap() : new Map(),
+      loading: false,
+      submitRating: mockSubmitRating,
+      deleteRating: jest.fn(),
+      refresh: jest.fn(),
+    }),
+  };
+});
+
+const buildResult = (overrides: Partial<SearchResult> = {}): SearchResult => ({
+  chunk_id: 'chunk-1',
+  doc_id: 'doc-1',
+  text: 'Sample text',
+  page_num: 1,
+  headings: [],
+  score: 0.9,
+  title: 'Report A',
+  organization: 'UNICEF',
+  year: '2023',
+  metadata: {},
+  ...overrides,
+});
+
+const buildTree = (currentId: string): DrilldownNode => ({
+  id: 'root',
+  label: 'root',
+  summary: 'root summary',
+  prompt: '',
+  results: [],
+  translatedText: null,
+  translatedLang: null,
+  expanded: true,
+  children: currentId === 'dd-1' || currentId === 'dd-2' ? [
+    {
+      id: currentId,
+      label: 'child',
+      summary: 'child summary',
+      prompt: '',
+      results: [],
+      translatedText: null,
+      translatedLang: null,
+      expanded: true,
+      children: [],
+    },
+  ] : [],
+});
+
+const baseProps = {
+  filtersExpanded: false,
+  activeFiltersCount: 0,
+  onToggleFiltersExpanded: jest.fn(),
+  onClearFilters: jest.fn(),
+  facets: null,
+  selectedFilters: {},
+  collapsedFilters: new Set<string>(),
+  expandedFilterLists: new Set<string>(),
+  filterSearchTerms: {},
+  titleSearchResults: [],
+  facetSearchResults: {},
+  onRemoveFilter: jest.fn(),
+  onToggleFilter: jest.fn(),
+  onFilterSearchTermChange: jest.fn(),
+  onToggleFilterListExpansion: jest.fn(),
+  onFilterValuesChange: jest.fn(),
+  searchDenseWeight: 0.8,
+  onSearchDenseWeightChange: jest.fn(),
+  keywordBoostShortQueries: true,
+  onKeywordBoostChange: jest.fn(),
+  semanticHighlighting: true,
+  onSemanticHighlightingChange: jest.fn(),
+  minScore: 0,
+  maxScore: 1,
+  onMinScoreChange: jest.fn(),
+  autoMinScore: false,
+  onAutoMinScoreToggle: jest.fn(),
+  rerankEnabled: false,
+  onRerankToggle: jest.fn(),
+  recencyBoostEnabled: false,
+  onRecencyBoostToggle: jest.fn(),
+  recencyWeight: 0.15,
+  onRecencyWeightChange: jest.fn(),
+  recencyScaleDays: 365,
+  onRecencyScaleDaysChange: jest.fn(),
+  minChunkSize: 100,
+  onMinChunkSizeChange: jest.fn(),
+  sectionTypes: [] as string[],
+  onSectionTypesChange: jest.fn(),
+  deduplicateEnabled: false,
+  onDeduplicateToggle: jest.fn(),
+  aiSummaryEnabled: true,
+  aiSummaryCollapsed: false,
+  aiSummaryExpanded: true,
+  aiSummaryLoading: false,
+  aiSummary: 'Some AI summary text',
+  aiSummaryResults: [] as SearchResult[],
+  aiPrompt: '',
+  showPromptModal: false,
+  selectedDomain: 'uneg',
+  results: [buildResult()] as SearchResult[],
+  loading: false,
+  query: 'test',
+  selectedDoc: null,
+  onResultClick: jest.fn(),
+  onOpenPrompt: jest.fn(),
+  onClosePrompt: jest.fn(),
+  onToggleCollapsed: jest.fn(),
+  onToggleExpanded: jest.fn(),
+  onOpenMetadata: jest.fn(),
+  onLanguageChange: jest.fn(),
+  searchId: 'search-123',
+};
+
+describe('SearchTabContent AI summary rating scoping', () => {
+  beforeEach(() => {
+    mockAiSummaryProps = null;
+    mockRatingModalProps = null;
+    mockSubmitRating.mockClear();
+    window.history.replaceState(null, '', '/');
+  });
+
+  test('shows the root summary rating when no drilldown is active', () => {
+    render(
+      <SearchTabContent
+        {...baseProps}
+        aiDrilldownTree={null}
+        aiDrilldownCurrentNodeId={null}
+      />,
+    );
+    expect(mockAiSummaryProps).not.toBeNull();
+    expect(mockAiSummaryProps!.ratingScore).toBe(5);
+  });
+
+  test('shows the drilldown node rating when drilled into a child', () => {
+    render(
+      <SearchTabContent
+        {...baseProps}
+        aiDrilldownTree={buildTree('dd-1')}
+        aiDrilldownCurrentNodeId="dd-1"
+      />,
+    );
+    expect(mockAiSummaryProps!.ratingScore).toBe(3);
+  });
+
+  test('shows score 0 for a drilldown node that has not been rated yet', () => {
+    render(
+      <SearchTabContent
+        {...baseProps}
+        aiDrilldownTree={buildTree('dd-2')}
+        aiDrilldownCurrentNodeId="dd-2"
+      />,
+    );
+    expect(mockAiSummaryProps!.ratingScore).toBe(0);
+  });
+
+  test('submit uses the drilldown node id as item_id when drilled down', () => {
+    render(
+      <SearchTabContent
+        {...baseProps}
+        aiDrilldownTree={buildTree('dd-2')}
+        aiDrilldownCurrentNodeId="dd-2"
+      />,
+    );
+    act(() => {
+      (mockAiSummaryProps!.onRequestRatingModal as (s: number) => void)(4);
+    });
+    expect(mockRatingModalProps).not.toBeNull();
+    act(() => {
+      (mockRatingModalProps!.onSubmit as (s: number, c: string) => void)(4, 'good');
+    });
+    expect(mockSubmitRating).toHaveBeenCalledTimes(1);
+    const call = mockSubmitRating.mock.calls[0][0];
+    expect(call.ratingType).toBe('ai_summary');
+    expect(call.referenceId).toBe('search-123');
+    expect(call.itemId).toBe('dd-2');
+    expect(call.score).toBe(4);
+  });
+
+  test('submit omits item_id for the root summary (back-compat)', () => {
+    render(
+      <SearchTabContent
+        {...baseProps}
+        aiDrilldownTree={null}
+        aiDrilldownCurrentNodeId={null}
+      />,
+    );
+    act(() => {
+      (mockAiSummaryProps!.onRequestRatingModal as (s: number) => void)(2);
+    });
+    act(() => {
+      (mockRatingModalProps!.onSubmit as (s: number, c: string) => void)(2, '');
+    });
+    const call = mockSubmitRating.mock.calls[0][0];
+    expect(call.itemId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Fix bug where rating an AI summary in a drilldown branch overwrote the root summary's rating instead of creating an independent one. Now scopes each summary's rating by the drilldown node id (`item_id`), with the root keeping `item_id=null` for back-compat.
- Unblock pre-commit on Python-3.9 cached envs by adding `from __future__ import annotations` to `scripts/quality/code_metrics.py` (PEP-604 union syntax was failing at class-definition time).

## Test plan

- [x] 5 new Jest tests in `ui/frontend/src/tests/searchTabContent.aiRating.test.tsx` cover root vs. drilldown rating lookup and the `itemId` payload on submit.
- [x] All existing `searchTabContent` tests still pass (12 + 5 = 17).
- [x] Pre-commit hooks (including code-metrics) pass on both commits.
- [ ] Manual: log in, run a search, rate the root AI summary, highlight text → "find out more", confirm the new summary's stars are empty and rating it does not change the root rating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)