### PR TITLE
fix(data): scripted rename of country 'Syria' to 'Syrian Arab Republic'

### DIFF
--- a/scripts/fixes/fix_syria_country_name.py
+++ b/scripts/fixes/fix_syria_country_name.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""
+Rename country token 'Syria' to 'Syrian Arab Republic' across the country
+metadata fields in PostgreSQL and Qdrant.
+
+Country values are stored as ``'; '``-separated lists (e.g.
+``'Türkiye; Syria'``). This script tokenises each value, replaces an
+exact token ``'Syria'`` with ``'Syrian Arab Republic'``, and rejoins.
+Existing ``'Syrian Arab Republic'`` values are left untouched (idempotent).
+
+Scope (verified against docs_wfp / chunks_wfp on 2026-05-04):
+
+  PostgreSQL:
+    - docs_wfp.map_country                       (text column)
+    - docs_wfp.src_doc_raw_metadata->>'Country'  (JSONB string)
+
+  Qdrant:
+    - documents_<source>.map_country  (payload string)
+    - chunks_<source>.map_country     (payload string)
+
+Out of scope — these intentionally NOT touched:
+  - chunks_<source> Postgres tables: have no country column / key.
+    'Syria' substring matches in chunks JSONB are body-text mentions,
+    not country metadata, and must not be rewritten.
+  - Any other field in any other collection / table.
+
+Usage:
+    # Default — dry-run, no writes:
+    python scripts/fixes/fix_syria_country_name.py --data-source wfp
+
+    # Apply the fix for real:
+    python scripts/fixes/fix_syria_country_name.py --data-source wfp --apply
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from typing import Dict, List, Tuple
+
+from dotenv import load_dotenv
+from qdrant_client import QdrantClient
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+OLD_TOKEN = "Syria"
+NEW_TOKEN = "Syrian Arab Republic"
+SEPARATOR = "; "
+
+
+def rewrite_country(value):
+    """Replace the exact token ``Syria`` with ``Syrian Arab Republic``.
+
+    Accepts either:
+      - a ``'; '``-separated string (e.g. ``'Türkiye; Syria'``); tokens
+        are split, exact-match rewritten, and rejoined.
+      - a list of strings (some Qdrant payloads store countries as a list);
+        each element is rewritten if it equals ``'Syria'``.
+
+    Returns the input unchanged if no rewrite is needed (idempotent).
+    Other types (``None``, dicts, numbers) pass through unchanged.
+    """
+    if isinstance(value, str):
+        if not value:
+            return value
+        tokens = value.split(SEPARATOR)
+        rewritten = [NEW_TOKEN if tok.strip() == OLD_TOKEN else tok for tok in tokens]
+        new = SEPARATOR.join(rewritten)
+        return new if new != value else value
+    if isinstance(value, list):
+        rewritten = [
+            NEW_TOKEN if isinstance(item, str) and item.strip() == OLD_TOKEN else item
+            for item in value
+        ]
+        return rewritten if rewritten != value else value
+    return value
+
+
+def needs_rewrite(value) -> bool:
+    return value is not None and rewrite_country(value) != value
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+
+
+def fix_postgres(conn, data_source: str, apply: bool) -> Dict[str, int]:
+    """Fix docs_<source>.map_country and src_doc_raw_metadata->>'Country'.
+
+    Returns a dict of {phase: count_of_rows_changed}.
+    """
+    table = f"docs_{data_source}"
+    stats = {"map_country_rows": 0, "raw_metadata_rows": 0}
+
+    with conn.cursor() as cur:
+        # Pass 1: map_country column
+        cur.execute(
+            f"SELECT doc_id, map_country FROM {table} "
+            f"WHERE map_country IS NOT NULL AND map_country LIKE %s",
+            (f"%{OLD_TOKEN}%",),
+        )
+        rows = cur.fetchall()
+        column_changes: List[Tuple[str, str, str]] = []
+        for doc_id, val in rows:
+            if needs_rewrite(val):
+                column_changes.append((doc_id, val, rewrite_country(val)))
+        logger.info(
+            "[PG] %s.map_country: %d rows match '%%%s%%', %d need rewrite",
+            table,
+            len(rows),
+            OLD_TOKEN,
+            len(column_changes),
+        )
+        for doc_id, old, new in column_changes:
+            logger.info("  doc=%s  %r -> %r", doc_id, old, new)
+        stats["map_country_rows"] = len(column_changes)
+        if apply and column_changes:
+            for doc_id, old, new in column_changes:
+                cur.execute(
+                    f"UPDATE {table} SET map_country = %s "
+                    f"WHERE doc_id = %s AND map_country = %s",
+                    (new, doc_id, old),
+                )
+                if cur.rowcount != 1:
+                    raise RuntimeError(
+                        f"Expected to update exactly 1 row for doc_id={doc_id}, "
+                        f"got {cur.rowcount}"
+                    )
+
+        # Pass 2: src_doc_raw_metadata->>'Country' JSONB
+        cur.execute(
+            f"SELECT doc_id, src_doc_raw_metadata->>'Country' "
+            f"FROM {table} "
+            f"WHERE src_doc_raw_metadata->>'Country' LIKE %s",
+            (f"%{OLD_TOKEN}%",),
+        )
+        rows = cur.fetchall()
+        jsonb_changes: List[Tuple[str, str, str]] = []
+        for doc_id, val in rows:
+            if needs_rewrite(val):
+                jsonb_changes.append((doc_id, val, rewrite_country(val)))
+        logger.info(
+            "[PG] %s.src_doc_raw_metadata->>'Country': %d rows match, %d need rewrite",
+            table,
+            len(rows),
+            len(jsonb_changes),
+        )
+        for doc_id, old, new in jsonb_changes:
+            logger.info("  doc=%s  %r -> %r", doc_id, old, new)
+        stats["raw_metadata_rows"] = len(jsonb_changes)
+        if apply and jsonb_changes:
+            for doc_id, old, new in jsonb_changes:
+                # jsonb_set with explicit JSON-encoded string value, scoped by
+                # both doc_id and the current value to avoid stomping on
+                # anything that changed in the meantime.
+                cur.execute(
+                    f"UPDATE {table} "
+                    f"SET src_doc_raw_metadata = "
+                    f"  jsonb_set(src_doc_raw_metadata, '{{Country}}', %s::jsonb) "
+                    f"WHERE doc_id = %s "
+                    f"AND src_doc_raw_metadata->>'Country' = %s",
+                    (json.dumps(new), doc_id, old),
+                )
+                if cur.rowcount != 1:
+                    raise RuntimeError(
+                        f"Expected to update exactly 1 raw_metadata row for "
+                        f"doc_id={doc_id}, got {cur.rowcount}"
+                    )
+
+    if apply:
+        conn.commit()
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Qdrant
+# ---------------------------------------------------------------------------
+
+
+def _scroll_country_points(
+    client: QdrantClient, collection: str, batch: int = 200
+) -> List[Tuple[str, str]]:
+    """Yield (point_id, map_country) for every point with a non-null country."""
+    out: List[Tuple[str, str]] = []
+    offset = None
+    while True:
+        points, next_offset = client.scroll(
+            collection_name=collection,
+            limit=batch,
+            with_payload=["map_country"],
+            offset=offset,
+        )
+        for p in points:
+            country = p.payload.get("map_country") if p.payload else None
+            if country:
+                out.append((p.id, country))
+        offset = next_offset
+        if offset is None:
+            break
+    return out
+
+
+def fix_qdrant_collection(client: QdrantClient, collection: str, apply: bool) -> int:
+    """Fix map_country in a Qdrant collection. Returns count of points changed."""
+    logger.info("[Qdrant] Scanning collection: %s", collection)
+    all_pts = _scroll_country_points(client, collection)
+    changes: List[Tuple[str, str, str]] = [
+        (pid, val, rewrite_country(val)) for pid, val in all_pts if needs_rewrite(val)
+    ]
+    logger.info(
+        "[Qdrant] %s: %d points scanned, %d need rewrite",
+        collection,
+        len(all_pts),
+        len(changes),
+    )
+    for pid, old, new in changes[:20]:
+        logger.info("  point=%s  %r -> %r", pid, old, new)
+    if len(changes) > 20:
+        logger.info("  …and %d more (omitted)", len(changes) - 20)
+    if not apply:
+        return len(changes)
+
+    for pid, _old, new in changes:
+        for attempt in range(5):
+            try:
+                client.set_payload(
+                    collection_name=collection,
+                    payload={"map_country": new},
+                    points=[pid],
+                    wait=False,
+                )
+                break
+            except Exception as exc:
+                wait = 2**attempt
+                logger.warning(
+                    "Retry %d for %s point %s: %s (sleep %ds)",
+                    attempt + 1,
+                    collection,
+                    pid,
+                    exc,
+                    wait,
+                )
+                time.sleep(wait)
+        else:
+            raise RuntimeError(f"Failed to update {collection} point {pid}")
+    return len(changes)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _qdrant_client() -> QdrantClient:
+    host = os.getenv("QDRANT_HOST", "http://localhost:6333")
+    # Auto-resolve Docker hostname to localhost for host execution
+    host = host.replace("://qdrant:", "://localhost:")
+    return QdrantClient(url=host, api_key=os.getenv("QDRANT_API_KEY"))
+
+
+def _postgres_conn():
+    import psycopg2  # local import — keeps the import lazy
+
+    try:
+        from pipeline.db.postgres_client_base import build_postgres_dsn
+
+        dsn = build_postgres_dsn()
+    except ImportError:
+        dsn = (
+            f"host={os.environ.get('POSTGRES_HOST', 'localhost')} "
+            f"port={os.environ.get('POSTGRES_PORT', '5432')} "
+            f"user={os.environ.get('POSTGRES_USER', 'evidencelab')} "
+            f"password={os.environ.get('POSTGRES_PASSWORD', 'evidencelab')} "
+            f"dbname={os.environ.get('POSTGRES_DB', 'evidencelab')}"
+        )
+    return psycopg2.connect(dsn)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Rename country 'Syria' to 'Syrian Arab Republic' in metadata."
+    )
+    parser.add_argument(
+        "--data-source",
+        default="wfp",
+        help="Data source name (default: wfp). Affects table and collection names.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the changes. Default is dry-run — nothing is written.",
+    )
+    parser.add_argument(
+        "--skip-postgres",
+        action="store_true",
+        help="Skip PostgreSQL updates.",
+    )
+    parser.add_argument(
+        "--skip-qdrant",
+        action="store_true",
+        help="Skip Qdrant updates.",
+    )
+    args = parser.parse_args()
+
+    env_path = os.path.join(os.path.dirname(__file__), "../../.env")
+    load_dotenv(env_path)
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    logger.info("=" * 60)
+    logger.info(" Syria → Syrian Arab Republic country rename  [%s]", mode)
+    logger.info(" data_source=%s", args.data_source)
+    logger.info("=" * 60)
+
+    pg_stats = {"map_country_rows": 0, "raw_metadata_rows": 0}
+    if not args.skip_postgres:
+        conn = _postgres_conn()
+        try:
+            pg_stats = fix_postgres(conn, args.data_source, apply=args.apply)
+        finally:
+            conn.close()
+
+    qdrant_docs = qdrant_chunks = 0
+    if not args.skip_qdrant:
+        client = _qdrant_client()
+        qdrant_docs = fix_qdrant_collection(
+            client, f"documents_{args.data_source}", apply=args.apply
+        )
+        qdrant_chunks = fix_qdrant_collection(
+            client, f"chunks_{args.data_source}", apply=args.apply
+        )
+
+    label = "applied" if args.apply else "would change"
+    logger.info("-" * 60)
+    logger.info(" Summary  [%s]", mode)
+    logger.info(
+        "   PG  docs.map_country rows %s:           %d",
+        label,
+        pg_stats["map_country_rows"],
+    )
+    logger.info(
+        "   PG  docs.raw_metadata.Country rows %s:  %d",
+        label,
+        pg_stats["raw_metadata_rows"],
+    )
+    logger.info(
+        "   Qdrant documents_%s points %s:         %d",
+        args.data_source,
+        label,
+        qdrant_docs,
+    )
+    logger.info(
+        "   Qdrant chunks_%s    points %s:         %d",
+        args.data_source,
+        label,
+        qdrant_chunks,
+    )
+    if not args.apply:
+        logger.info(" Re-run with --apply to actually write the changes.")
+    logger.info("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_fix_syria_country_name.py
+++ b/tests/unit/test_fix_syria_country_name.py
@@ -1,0 +1,106 @@
+"""Unit tests for the Syria country rename helpers.
+
+Locks in the token-precise rewrite logic so a future tweak can't
+accidentally mangle 'Syrian Arab Republic' (which contains 'Syria' as
+a substring) or rewrite a body-text mention of Syria.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module — it lives under scripts/fixes/, not
+# under a package, so we import via spec.
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "fixes"
+    / "fix_syria_country_name.py"
+)
+_spec = importlib.util.spec_from_file_location("fix_syria_country_name", _SCRIPT_PATH)
+fix_syria = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fix_syria)
+
+
+@pytest.mark.unit
+class TestRewriteCountryString:
+    """String form: '; '-separated country lists."""
+
+    def test_bare_token_in_list_is_rewritten(self):
+        assert (
+            fix_syria.rewrite_country("Türkiye; Syria")
+            == "Türkiye; Syrian Arab Republic"
+        )
+
+    def test_bare_token_alone_is_rewritten(self):
+        assert fix_syria.rewrite_country("Syria") == "Syrian Arab Republic"
+
+    def test_already_correct_value_is_unchanged(self):
+        # Idempotence — value must come back identical (same object even).
+        v = "Türkiye; Syrian Arab Republic"
+        assert fix_syria.rewrite_country(v) is v
+
+    def test_syrian_arab_republic_substring_is_not_partially_rewritten(self):
+        # 'Syrian Arab Republic' contains 'Syria' as a substring; the
+        # token-precise rewrite must leave it alone.
+        v = "Iraq; Syrian Arab Republic; Lebanon"
+        assert fix_syria.rewrite_country(v) is v
+
+    def test_body_text_mention_in_value_is_not_rewritten(self):
+        # If someone ever crammed prose into the country field, the
+        # rewriter still only touches an EXACT 'Syria' token. A token
+        # like 'Syrian crisis' would not be rewritten because its
+        # stripped form != 'Syria'.
+        v = "Syrian crisis context"
+        assert fix_syria.rewrite_country(v) is v
+
+    def test_multi_position_token(self):
+        assert (
+            fix_syria.rewrite_country("Syria; Iraq; Türkiye")
+            == "Syrian Arab Republic; Iraq; Türkiye"
+        )
+
+    def test_empty_and_none_passthrough(self):
+        assert fix_syria.rewrite_country("") == ""
+        assert fix_syria.rewrite_country(None) is None
+
+
+@pytest.mark.unit
+class TestRewriteCountryList:
+    """List form: some Qdrant payloads store countries as a list."""
+
+    def test_bare_token_in_list_is_rewritten(self):
+        assert fix_syria.rewrite_country(["Türkiye", "Syria"]) == [
+            "Türkiye",
+            "Syrian Arab Republic",
+        ]
+
+    def test_already_correct_list_is_unchanged(self):
+        v = ["Türkiye", "Syrian Arab Republic"]
+        assert fix_syria.rewrite_country(v) is v
+
+    def test_list_without_syria_is_unchanged(self):
+        v = ["Bangladesh", "Chad", "Iraq"]
+        assert fix_syria.rewrite_country(v) is v
+
+    def test_non_string_items_in_list_are_passed_through(self):
+        # Defensive — never crash on weird payload contents, just leave
+        # non-string items alone.
+        v = ["Syria", None, 42]
+        assert fix_syria.rewrite_country(v) == ["Syrian Arab Republic", None, 42]
+
+
+@pytest.mark.unit
+class TestNeedsRewrite:
+    def test_true_for_bare_token(self):
+        assert fix_syria.needs_rewrite("Türkiye; Syria") is True
+
+    def test_false_for_full_name(self):
+        assert fix_syria.needs_rewrite("Syrian Arab Republic") is False
+
+    def test_false_for_unrelated_value(self):
+        assert fix_syria.needs_rewrite("Iraq; Lebanon") is False
+
+    def test_false_for_none(self):
+        assert fix_syria.needs_rewrite(None) is False


### PR DESCRIPTION
## Context

For the WFP dataset, one document's country field is \`Türkiye; Syria\` instead of \`Türkiye; Syrian Arab Republic\` — producing a duplicate entry in the Country filter for what should be the same country.

## Scope (dry-run output, verified 2026-05-04)

| Target | Rows / Points to change |
|---|---:|
| PG \`docs_wfp.map_country\` | 1 |
| PG \`docs_wfp.src_doc_raw_metadata->>'Country'\` | 1 |
| Qdrant \`documents_wfp\` payload | 1 |
| Qdrant \`chunks_wfp\` payload | 308 |

The 308 chunk points are all chunks of the single affected doc (\`e05892d1-428f-54db-8a7b-e56c9f8574f4\`) — Qdrant denormalises \`map_country\` per chunk for filtering.

**Intentionally out of scope:**
- Postgres \`chunks_wfp\` rows — there is no country column / JSONB key on chunks. The 2055/2623 \`Syria\` substring matches in chunks JSONB are body text and table data, not country metadata, and must NOT be rewritten.
- Other countries, other queries, free-text mentions — the rewriter is token-precise (splits on \`'; '\`, replaces tokens whose stripped value equals exactly \`'Syria'\`).
- Already-correct \`Syrian Arab Republic\` values — idempotent.

## Safety

- Default behavior is dry-run; \`--apply\` is opt-in.
- Each PG UPDATE is scoped by both \`doc_id\` AND the current value, and asserts \`rowcount == 1\` so any drift fails loudly.
- Each Qdrant \`set_payload\` retries up to 5× with exponential backoff.
- 15 unit tests cover the rewrite logic — including the substring trap (\`'Syrian Arab Republic'\` must NOT be partially rewritten) and the body-text trap (\`'Syrian crisis context'\` must NOT be rewritten).

## Test plan

- [x] \`pytest tests/unit/test_fix_syria_country_name.py\` — 15 passed
- [x] Dry-run against prod DB — exactly the expected counts (1 / 1 / 1 / 308)
- [x] Pre-commit (black, isort, flake8, bandit, code-metrics) all clean
- [ ] After merge: run \`python scripts/fixes/fix_syria_country_name.py --data-source wfp --apply\` against prod; verify the Country sidebar collapses 'Syria' into 'Syrian Arab Republic' for the affected doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)