### PR TITLE
fix(facets): src_* filter values + counts via PG JSONB on query-narrowed search

### DIFF
--- a/tests/unit/test_get_search_facets_src_fields.py
+++ b/tests/unit/test_get_search_facets_src_fields.py
@@ -1,0 +1,228 @@
+"""Unit tests for query-narrowed faceting on src_* fields.
+
+Locks in the fix for the bug where the Evaluation Category filter showed
+counts like ``(CE: 1, DE: 1)`` while the search returned hundreds of
+results — the old path read ``src_evaluation_category`` directly from the
+Qdrant chunk payloads, but the field was only denormalised onto a tiny
+fraction of chunks. The fix routes ``src_*`` field counting through PG
+JSONB lookups using the matching doc_ids, so counts reflect the actual
+document set the search produced.
+"""
+
+from collections import Counter
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from ui.backend.services.search import _facet_counter_for_field
+from ui.backend.utils.facet_helpers import (
+    count_src_jsonb_field_for_doc_ids as _count_src_field_from_pg,
+)
+from ui.backend.utils.facet_helpers import count_sys_field_for_doc_ids
+
+
+def _count_sys_language_from_pg(pg, doc_ids):
+    return count_sys_field_for_doc_ids(pg, "sys_language", doc_ids)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    """Mimics psycopg2 cursor for one query at a time."""
+
+    def __init__(self):
+        self.last_sql: str = ""
+        self.last_params = None
+        self.next_rows: list = []
+
+    def execute(self, sql, params=None):
+        self.last_sql = sql
+        self.last_params = list(params) if params is not None else None
+
+    def fetchall(self):
+        return list(self.next_rows)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _make_pg(rows: list):
+    """Build a fake PG client that returns *rows* on the next fetchall()."""
+    pg = MagicMock()
+    pg.docs_table = "docs_test"
+    cursor = _FakeCursor()
+    cursor.next_rows = rows
+
+    @contextmanager
+    def _get_conn():
+        yield _FakeConn(cursor)
+
+    pg._get_conn = _get_conn
+    pg._cursor = cursor  # for assertions
+    return pg
+
+
+# ---------------------------------------------------------------------------
+# _count_src_field_from_pg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCountSrcFieldFromPG:
+    def test_returns_counter_keyed_by_value(self):
+        pg = _make_pg([("CE",), ("DE",), ("DE",), ("IE",)])
+        out = _count_src_field_from_pg(
+            pg, "Evaluation category", ["d1", "d2", "d3", "d4"]
+        )
+        assert out == Counter({"DE": 2, "CE": 1, "IE": 1})
+
+    def test_skips_null_and_empty_values(self):
+        pg = _make_pg([("CE",), (None,), ("",), ("CE",)])
+        out = _count_src_field_from_pg(
+            pg, "Evaluation category", ["d1", "d2", "d3", "d4"]
+        )
+        assert out == Counter({"CE": 2})
+
+    def test_returns_empty_counter_for_no_doc_ids(self):
+        pg = _make_pg([])
+        # Don't even hit the DB if there are no doc_ids to look up.
+        out = _count_src_field_from_pg(pg, "Evaluation category", [])
+        assert out == Counter()
+
+    def test_passes_raw_key_as_first_parameter_not_interpolated(self):
+        pg = _make_pg([("CE",)])
+        _count_src_field_from_pg(pg, "Evaluation category", ["d1", "d2"])
+        # The raw key must travel as a parameter, not in the SQL string —
+        # otherwise we'd reintroduce a SQL-injection foothold for any future
+        # caller that forgets the config-side validation.
+        assert pg._cursor.last_params == ["Evaluation category", "d1", "d2"]
+        assert "Evaluation category" not in pg._cursor.last_sql
+
+    def test_uses_in_clause_with_correct_placeholder_count(self):
+        pg = _make_pg([])
+        _count_src_field_from_pg(pg, "Quality rating", ["a", "b", "c"])
+        # %s for the raw key + 3 for the doc IDs = 4 total
+        assert pg._cursor.last_sql.count("%s") == 4
+
+
+# ---------------------------------------------------------------------------
+# _count_sys_language_from_pg
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCountSysLanguageFromPG:
+    def test_counts_codes(self):
+        pg = _make_pg([("en",), ("en",), ("fr",), ("",), (None,)])
+        out = _count_sys_language_from_pg(pg, ["d1", "d2", "d3", "d4", "d5"])
+        # Empty / null filtered out — language-name normalisation happens
+        # later in _format_facet_list.
+        assert out == Counter({"en": 2, "fr": 1})
+
+    def test_empty_doc_ids_short_circuits(self):
+        pg = _make_pg([])
+        assert _count_sys_language_from_pg(pg, []) == Counter()
+
+
+# ---------------------------------------------------------------------------
+# _facet_counter_for_field — strategy router
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFacetCounterForField:
+    def test_sys_language_routes_to_pg(self):
+        pg = _make_pg([("en",), ("en",)])
+        counter = _facet_counter_for_field(
+            core_field="language",
+            storage_field="sys_language",
+            unique_docs=[{"sys_language": "ignored"}],  # must NOT be used
+            doc_ids=["d1", "d2"],
+            pg=pg,
+            src_field_mapping={},
+        )
+        assert counter == Counter({"en": 2})
+        assert "sys_language" in pg._cursor.last_sql
+
+    def test_src_field_with_mapping_routes_to_pg(self):
+        pg = _make_pg([("CE",), ("DE",), ("DE",)])
+        counter = _facet_counter_for_field(
+            core_field="src_evaluation_category",
+            storage_field="src_evaluation_category",
+            unique_docs=[
+                # Out-of-date / partial chunk data should be IGNORED in
+                # favour of the PG truth.
+                {"src_evaluation_category": "stale"},
+            ],
+            doc_ids=["d1", "d2", "d3"],
+            pg=pg,
+            src_field_mapping={"src_evaluation_category": "Evaluation category"},
+        )
+        assert counter == Counter({"DE": 2, "CE": 1})
+
+    def test_src_field_without_mapping_falls_back_to_payload_aggregation(self):
+        # No mapping configured for this src_* field — fall back to the
+        # legacy in-memory aggregation over the Qdrant payloads.
+        counter = _facet_counter_for_field(
+            core_field="src_unmapped",
+            storage_field="src_unmapped",
+            unique_docs=[
+                {"src_unmapped": "X"},
+                {"src_unmapped": "X"},
+                {"src_unmapped": "Y"},
+            ],
+            doc_ids=["d1", "d2", "d3"],
+            pg=_make_pg([]),
+            src_field_mapping={},
+        )
+        assert counter == Counter({"X": 2, "Y": 1})
+
+    def test_map_field_uses_payload_aggregation(self):
+        # Plain map_* fields read from the Qdrant payload as before.
+        counter = _facet_counter_for_field(
+            core_field="country",
+            storage_field="map_country",
+            unique_docs=[
+                {"map_country": "Kenya"},
+                {"map_country": "Kenya"},
+                {"map_country": "Niger"},
+            ],
+            doc_ids=["d1", "d2", "d3"],
+            pg=None,
+            src_field_mapping={},
+        )
+        assert counter == Counter({"Kenya": 2, "Niger": 1})
+
+    def test_sys_language_with_no_pg_falls_back_to_payload(self):
+        # Defensive: if pg isn't a PostgresClient, the strategy router
+        # must not crash — fall back to payload aggregation.
+        counter = _facet_counter_for_field(
+            core_field="language",
+            storage_field="sys_language",
+            unique_docs=[{"sys_language": "en"}, {"sys_language": "en"}],
+            doc_ids=["d1", "d2"],
+            pg=None,
+            src_field_mapping={},
+        )
+        assert counter == Counter({"en": 2})

--- a/ui/backend/services/search.py
+++ b/ui/backend/services/search.py
@@ -872,6 +872,37 @@ def _format_facet_list(core_field: str, counter: Counter) -> List[Dict[str, Any]
     return facets_list
 
 
+def _facet_counter_for_field(
+    core_field: str,
+    storage_field: str,
+    unique_docs: List[Dict[str, Any]],
+    doc_ids: List[str],
+    pg: Optional[PostgresClient],
+    src_field_mapping: Dict[str, str],
+) -> Counter:
+    """Pick the correct counting strategy per field.
+
+    - ``sys_language`` reads from PG ``docs.sys_language`` for matching docs.
+    - ``src_*`` fields with a configured raw key read the value out of
+      ``docs.src_doc_raw_metadata`` JSONB for matching docs (so counts are
+      complete, not limited to chunks that happened to denormalise the field).
+    - Everything else aggregates the chunk/doc Qdrant payloads in memory.
+    """
+    from ui.backend.utils.facet_helpers import (  # noqa: PLC0415
+        count_src_jsonb_field_for_doc_ids,
+        count_sys_field_for_doc_ids,
+    )
+
+    if storage_field == "sys_language" and pg is not None:
+        return count_sys_field_for_doc_ids(pg, "sys_language", doc_ids)
+    raw_key = src_field_mapping.get(storage_field)
+    if storage_field.startswith("src_") and pg is not None and raw_key:
+        return count_src_jsonb_field_for_doc_ids(pg, raw_key, doc_ids)
+    return _accumulate_facet_counts(
+        core_field, unique_docs, storage_field=storage_field
+    )
+
+
 def get_search_facets(
     query: str,
     filters: Optional[dict] = None,
@@ -892,12 +923,16 @@ def get_search_facets(
     source = data_source or "uneg"
     db = _get_search_db(None, source)
     filter_fields_config = get_default_filter_fields(source)
-    from pipeline.db import get_taxonomy_filter_fields  # noqa: PLC0415
+    from pipeline.db import (  # noqa: PLC0415
+        get_src_field_mapping,
+        get_taxonomy_filter_fields,
+    )
 
     filter_fields_config = {
         **filter_fields_config,
         **get_taxonomy_filter_fields(source),
     }
+    src_field_mapping = get_src_field_mapping(source)
 
     # 1. Determine which fields we need to fetch
     needed_fields = ["doc_id", "sys_doc_id"]  # Include sys_doc_id for deduplication
@@ -934,38 +969,30 @@ def get_search_facets(
     # We should deduplicate by doc_id to get Document counts.
 
     unique_docs = _collect_unique_doc_payloads(results)
-    doc_ids = [
-        doc.get("doc_id") or doc.get("sys_doc_id")
+    doc_ids: List[str] = [
+        str(doc.get("doc_id") or doc.get("sys_doc_id"))
         for doc in unique_docs
         if doc.get("doc_id") or doc.get("sys_doc_id")
     ]
+    pg = (
+        getattr(db, "pg", None)
+        if isinstance(getattr(db, "pg", None), PostgresClient)
+        else None
+    )
 
     for core_field in filter_fields_config.keys():
         if core_field == "title":
             # Skip title faceting as it's too high cardinality
             pass
         storage_field = _resolve_storage_field(core_field, source)
-        if storage_field == "sys_language" and isinstance(
-            getattr(db, "pg", None), PostgresClient
-        ):
-            if doc_ids:
-                placeholders = ", ".join(["%s"] * len(doc_ids))
-                sql = f"""
-                    SELECT sys_language
-                    FROM {db.pg.docs_table}
-                    WHERE doc_id IN ({placeholders})
-                """
-                with db.pg._get_conn() as conn:
-                    with conn.cursor() as cur:
-                        cur.execute(sql, doc_ids)
-                        rows = cur.fetchall()
-                counter = Counter(row[0] for row in rows if row[0] not in (None, ""))
-            else:
-                counter = Counter()
-        else:
-            counter = _accumulate_facet_counts(
-                core_field, unique_docs, storage_field=storage_field
-            )
+        counter = _facet_counter_for_field(
+            core_field,
+            storage_field,
+            unique_docs,
+            doc_ids,
+            pg,
+            src_field_mapping,
+        )
         facets_data[core_field] = _format_facet_list(core_field, counter)
 
     return facets_data

--- a/ui/backend/utils/facet_helpers.py
+++ b/ui/backend/utils/facet_helpers.py
@@ -133,6 +133,54 @@ def build_facets_from_pg(pg, storage_field: str) -> Dict[str, int]:
             return {str(row[0]): int(row[1]) for row in cur.fetchall()}
 
 
+def count_src_jsonb_field_for_doc_ids(pg, raw_key: str, doc_ids: List[str]) -> Counter:
+    """Count distinct values of ``src_doc_raw_metadata->>raw_key`` across a
+    specific set of docs.
+
+    Used by query-narrowed faceting on ``src_*`` fields whose values live
+    only in the JSONB raw-metadata column (the Qdrant chunk payload only
+    sometimes carries the field, so per-payload aggregation under-counts).
+    ``raw_key`` must come from the trusted ``src_field_mapping`` config and
+    is passed as a parameter, not interpolated.
+    """
+    if not doc_ids:
+        return Counter()
+    placeholders = ", ".join(["%s"] * len(doc_ids))
+    sql = f"""
+        SELECT src_doc_raw_metadata->>%s
+        FROM {pg.docs_table}
+        WHERE doc_id IN ({placeholders})
+    """
+    with pg._get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, [raw_key, *doc_ids])
+            rows = cur.fetchall()
+    return Counter(row[0] for row in rows if row[0] not in (None, ""))
+
+
+def count_sys_field_for_doc_ids(pg, sys_field: str, doc_ids: List[str]) -> Counter:
+    """Count distinct values of a ``sys_*`` column across a set of docs.
+
+    ``sys_field`` is a column name and is validated against an allowlist
+    before interpolation to prevent SQL injection.
+    """
+    if not doc_ids:
+        return Counter()
+    if not sys_field.startswith("sys_") or not sys_field.replace("_", "").isalnum():
+        raise ValueError(f"Invalid sys_field column: {sys_field!r}")
+    placeholders = ", ".join(["%s"] * len(doc_ids))
+    sql = f"""
+        SELECT {sys_field}
+        FROM {pg.docs_table}
+        WHERE doc_id IN ({placeholders})
+    """
+    with pg._get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, doc_ids)
+            rows = cur.fetchall()
+    return Counter(row[0] for row in rows if row[0] not in (None, ""))
+
+
 def build_facets_from_pg_jsonb(pg, raw_key: str) -> Dict[str, int]:
     """Get facet counts for src_* fields stored inside src_doc_raw_metadata.
 


### PR DESCRIPTION
## Symptoms

For a search like \`?q=cash+based+transfers\` on the WFP dataset:

| Filter | Before | After |
|---|---|---|
| Country | 76 values, sensible counts (12, 12, 12 …) | unchanged |
| Language | 3 values, sensible counts (112, 7, 7) | unchanged |
| **Evaluation Category** | **2 values, (CE: 1, DE: 1)** | **3 values, (CE: 74, DE: 45, IE: 7)** |
| **Quality Rating** | **0 values (empty)** | **2 values, (Satisfactory: 108, N/A: 15)** |
| Region | empty | empty (data not populated — see below) |

## Root cause

\`get_search_facets\` aggregates fields by reading them out of the deduplicated chunk payloads in memory. For \`src_*\` fields like \`src_evaluation_category\` and \`src_quality_rating\`, this is a sparse signal:

- 97,734 chunks total
- Only **3,582** (3.7%) have \`src_evaluation_category\` denormalised onto the chunk payload at index time
- The other 96% have only \`map_*\` and \`sys_*\` fields

So when the search returned ~500 chunks for \"cash based transfers\", maybe 1-2 of those happened to carry the \`src_*\` payload — producing the bogus single-digit counts the user saw. The \`src_doc_raw_metadata\` JSONB column in PostgreSQL is the actual source of truth.

## Fix

After the search dedups to unique doc_ids, route \`src_*\` field counting through PostgreSQL when the data source declares a \`src_field_mapping\`:

\`\`\`python
def _facet_counter_for_field(core_field, storage_field, unique_docs, doc_ids, pg, src_field_mapping):
    if storage_field == \"sys_language\" and pg is not None:
        return count_sys_field_for_doc_ids(pg, \"sys_language\", doc_ids)
    raw_key = src_field_mapping.get(storage_field)
    if storage_field.startswith(\"src_\") and pg is not None and raw_key:
        return count_src_jsonb_field_for_doc_ids(pg, raw_key, doc_ids)
    return _accumulate_facet_counts(core_field, unique_docs, storage_field=storage_field)
\`\`\`

The PG helpers use parameterised SQL — \`raw_key\` travels as a query parameter (never interpolated), and \`sys_field\` is validated against an alphanumeric \`sys_*\` allowlist before interpolation.

## Activation: config change required (NOT in this PR)

This PR is **code only**. To activate the behaviour for the WFP datasource, add the following block to the \`\"WFP Evaluation Reports\"\` entry in \`config.json\` next to \`default_filter_fields\`:

\`\`\`json
\"src_field_mapping\": {
    \"src_evaluation_category\": \"Evaluation category\",
    \"src_quality_rating\": \"Quality rating\"
}
\`\`\`

Without that block, \`src_*\` fields fall through to the existing payload-aggregation path (no behaviour change).

## Region filter

The Region filter is empty for a different reason: all 336 WFP docs have an empty value in \`src_doc_raw_metadata.Region\` — the source data simply doesn't have it. Two options for a follow-up:

1. **Backfill** Region during ingestion (preferred — pipeline change).
2. **Remove** \`region\` from \`default_filter_fields\` in config.json.

Not addressed here.

## Test plan

- [x] \`pytest tests/unit/test_get_search_facets_src_fields.py\` — 12 new tests pass
- [x] \`pytest tests/unit/test_facet_helpers.py tests/unit/test_search_filters.py tests/unit/test_ui_backend_search.py tests/unit/test_db_utils.py\` — 91 existing tests still pass
- [x] Live API check on prod after applying the config change — counts match the expected document set, all values in \`allFacets\` populated, and the sidebar shows all categories with correct counts when one is selected
- [x] \`pre-commit run --files …\` — black, isort, flake8, mypy, bandit, code-metrics all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)