### PR TITLE
fix(research): inherit parent context into the search query, not just the summary

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -4151,24 +4151,49 @@ li.ai-fact-active::before {
   min-width: 0;
 }
 
+.ai-drilldown-ancestor {
+  color: var(--gray-500);
+}
+
+.ai-drilldown-current {
+  color: var(--gray-700);
+  font-weight: 500;
+}
+
+.ai-drilldown-sep {
+  color: var(--gray-400);
+  font-style: normal;
+  margin: 0 0.125rem;
+}
+
 .dig-deeper-popover {
+  display: inline-flex;
   background: white;
   border: 1px solid var(--gray-300);
   border-radius: var(--radius-sm);
+  z-index: 10;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  animation: digDeeperFadeIn 0.15s ease-out;
+  overflow: hidden;
+}
+
+.dig-deeper-popover-btn {
+  background: white;
+  border: none;
   color: var(--brand-primary);
   font-size: 0.8125rem;
   cursor: pointer;
-  padding: 3px 10px;
+  padding: 4px 10px;
   white-space: nowrap;
-  z-index: 10;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
-  transition: background 0.15s ease, border-color 0.15s ease;
-  animation: digDeeperFadeIn 0.15s ease-out;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
-.dig-deeper-popover:hover {
+.dig-deeper-popover-btn + .dig-deeper-popover-btn {
+  border-left: 1px solid var(--gray-300);
+}
+
+.dig-deeper-popover-btn:hover {
   background: var(--gray-50);
-  border-color: var(--brand-primary);
 }
 
 @keyframes digDeeperFadeIn {

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -1724,8 +1724,19 @@ function App() {
     highlightedText: string,
     mode: 'subtopic' | 'newtopic' = 'subtopic',
   ) => {
+    const isNewTopic = mode === 'newtopic';
     const snapshot = getSnapshot();
-    startDrilldownInTree(highlightedText, snapshot, query);
+    if (isNewTopic) {
+      // "New topic" mode: drop the existing drilldown chain so the
+      // breadcrumb collapses and the AI summary stands alone — same shape
+      // a fresh top-level search would produce. Updating ``query`` keeps
+      // the URL, activity log and any future sub-drilldowns rooted at
+      // this new topic.
+      resetDrilldownTree();
+      setQuery(highlightedText);
+    } else {
+      startDrilldownInTree(highlightedText, snapshot, query);
+    }
 
     setAiSummaryExpanded(true);
     setAiSummaryLoading(true);
@@ -1738,7 +1749,6 @@ function App() {
     // leaf and the surrounding investigation. New-topic mode treats the
     // selection as a fresh independent question (search and summary use
     // the leaf alone, no parent inheritance).
-    const isNewTopic = mode === 'newtopic';
     const searchQuery = isNewTopic
       ? highlightedText
       : buildContextualSearchQuery(highlightedText, query, drilldownHighlight);
@@ -1788,7 +1798,7 @@ function App() {
       setAiSummary(AI_SUMMARY_ERROR);
       setAiSummaryLoading(false);
     }
-  }, [getSnapshot, startDrilldownInTree, query, drilldownHighlight, launchSummaryStream,
+  }, [getSnapshot, startDrilldownInTree, resetDrilldownTree, query, drilldownHighlight, launchSummaryStream,
       filters, searchDenseWeight, rerankEnabled, recencyBoostEnabled,
       recencyWeight, recencyScaleDays, sectionTypes, keywordBoostShortQueries,
       minChunkSize, rerankModel, rerankModelPageSize, searchModel, dataSource,

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -43,7 +43,7 @@ import SavedResearchModal from './components/SavedResearchModal';
 import { AuthContext, useAuthState } from './hooks/useAuth';
 import { useGroupDefaults } from './hooks/useGroupDefaults';
 import { useActivityLogging } from './hooks/useActivityLogging';
-import { serializeDrilldownTree, serializeFullDrilldownTree, patchNodeInTree } from './utils/drilldownUtils';
+import { buildContextualSearchQuery, serializeDrilldownTree, serializeFullDrilldownTree, patchNodeInTree } from './utils/drilldownUtils';
 import { generateUUID } from './utils/uuid';
 import { mergeFacetField } from './utils/facetMerge';
 import AdminPanel from './components/admin/AdminPanel';
@@ -1730,9 +1730,17 @@ function App() {
     setAiPrompt('');
     window.scrollTo({ top: 0, behavior: 'smooth' });
 
-    // Perform a fresh search using the highlighted text as the query
+    // Perform a fresh search using the highlighted text as the query, but
+    // narrow it to chunks relevant to the parent investigation too — without
+    // this, deep drilldowns retrieve generic chunks for the leaf topic and
+    // only the summary prompt narrows them, which is too late.
+    const contextualSearchQuery = buildContextualSearchQuery(
+      highlightedText,
+      query,
+      drilldownHighlight,
+    );
     const params = buildSearchParams({
-      query: highlightedText,
+      query: contextualSearchQuery,
       filters,
       searchDenseWeight,
       rerankEnabled,
@@ -1820,8 +1828,15 @@ function App() {
       const nodeId = nodeIds[i];
       setFindOutMoreActiveFact(fact);
       try {
+        // Inherit parent context into the search query, not just the summary
+        // prompt — same reasoning as startDrilldown above.
+        const contextualSearchQuery = buildContextualSearchQuery(
+          fact,
+          query,
+          drilldownHighlight,
+        );
         const params = buildSearchParams({
-          query: fact, filters, searchDenseWeight, rerankEnabled,
+          query: contextualSearchQuery, filters, searchDenseWeight, rerankEnabled,
           recencyBoostEnabled, recencyWeight, recencyScaleDays, sectionTypes,
           keywordBoostShortQueries, minChunkSize, rerankModel, rerankModelPageSize,
           searchModel, dataSource, autoMinScore, deduplicateEnabled,
@@ -1884,10 +1899,15 @@ function App() {
       ? `, specifically "${parentLabel}"`
       : '';
     const summaryQuery = `Regarding: "${userQuery}"\n\nProvide detail about this, in the context of: "${query}"${parentContext}`;
+    const contextualSearchQuery = buildContextualSearchQuery(
+      userQuery,
+      query,
+      parentLabel,
+    );
 
     try {
       const params = buildSearchParams({
-        query: userQuery, filters, searchDenseWeight, rerankEnabled,
+        query: contextualSearchQuery, filters, searchDenseWeight, rerankEnabled,
         recencyBoostEnabled, recencyWeight, recencyScaleDays, sectionTypes,
         keywordBoostShortQueries, minChunkSize, rerankModel, rerankModelPageSize,
         searchModel, dataSource, autoMinScore, deduplicateEnabled,

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -1720,7 +1720,10 @@ function App() {
   }, []);
 
   // Drilldown: save current state, search for fresh results, stream focused summary
-  const startDrilldown = useCallback(async (highlightedText: string) => {
+  const startDrilldown = useCallback(async (
+    highlightedText: string,
+    mode: 'subtopic' | 'newtopic' = 'subtopic',
+  ) => {
     const snapshot = getSnapshot();
     startDrilldownInTree(highlightedText, snapshot, query);
 
@@ -1730,17 +1733,17 @@ function App() {
     setAiPrompt('');
     window.scrollTo({ top: 0, behavior: 'smooth' });
 
-    // Perform a fresh search using the highlighted text as the query, but
-    // narrow it to chunks relevant to the parent investigation too — without
-    // this, deep drilldowns retrieve generic chunks for the leaf topic and
-    // only the summary prompt narrows them, which is too late.
-    const contextualSearchQuery = buildContextualSearchQuery(
-      highlightedText,
-      query,
-      drilldownHighlight,
-    );
+    // Sub-topic mode inherits the parent investigation's context into the
+    // search query so retrieval is narrowed to chunks relevant to both the
+    // leaf and the surrounding investigation. New-topic mode treats the
+    // selection as a fresh independent question (search and summary use
+    // the leaf alone, no parent inheritance).
+    const isNewTopic = mode === 'newtopic';
+    const searchQuery = isNewTopic
+      ? highlightedText
+      : buildContextualSearchQuery(highlightedText, query, drilldownHighlight);
     const params = buildSearchParams({
-      query: contextualSearchQuery,
+      query: searchQuery,
       filters,
       searchDenseWeight,
       rerankEnabled,
@@ -1766,14 +1769,19 @@ function App() {
       setResults(freshResults);
       setAiSummaryResults(freshResults);
 
-      // Query inheritance: always include root query for broad context,
-      // plus the immediate parent node label for specificity (avoids noisy
-      // full-chain at deep levels). drilldownHighlight is the current node's
-      // label before drilling deeper.
-      const parentContext = drilldownHighlight && drilldownHighlight !== query
-        ? `, specifically "${drilldownHighlight}"`
-        : '';
-      const drilldownQuery = `Regarding: "${highlightedText}"\n\nProvide detail about this, in the context of: "${query}"${parentContext}`;
+      // For sub-topic mode, the summary prompt mirrors the search query's
+      // inheritance (root + immediate parent label). For new-topic mode the
+      // summary stands alone — same prompt the user would get if they typed
+      // the selection into the main search box.
+      let drilldownQuery: string;
+      if (isNewTopic) {
+        drilldownQuery = highlightedText;
+      } else {
+        const parentContext = drilldownHighlight && drilldownHighlight !== query
+          ? `, specifically "${drilldownHighlight}"`
+          : '';
+        drilldownQuery = `Regarding: "${highlightedText}"\n\nProvide detail about this, in the context of: "${query}"${parentContext}`;
+      }
       launchSummaryStream(drilldownQuery, freshResults);
     } catch (error) {
       console.error('Drilldown search failed:', error);

--- a/ui/frontend/src/components/AiSummaryPanel.tsx
+++ b/ui/frontend/src/components/AiSummaryPanel.tsx
@@ -6,7 +6,7 @@ import { LANGUAGES } from '../constants';
 import { RainbowText } from './RainbowText';
 import { AiSummaryWithCitations } from './AiSummaryWithCitations';
 import { AiSummaryReferences } from './AiSummaryReferences';
-import { DigDeeperPopover } from './DigDeeperPopover';
+import { DigDeeperPopover, DrilldownMode } from './DigDeeperPopover';
 import { DrilldownBreadcrumb } from './DrilldownBreadcrumb';
 import { DrilldownGraphView } from './DrilldownGraphView';
 import { exportResearchToPdf } from '../utils/exportResearch';
@@ -35,7 +35,7 @@ interface AiSummaryPanelProps {
   onClosePrompt: () => void;
   drilldownStackDepth?: number;
   drilldownHighlight?: string;
-  onDrilldown?: (selectedText: string) => void;
+  onDrilldown?: (selectedText: string, mode: DrilldownMode) => void;
   onDrilldownBack?: () => void;
   drilldownTree?: DrilldownNode | null;
   drilldownCurrentNodeId?: string | null;
@@ -113,7 +113,7 @@ const AiSummaryBody = ({
   filteredResults: SearchResult[];
   onResultClick: (result: SearchResult) => void;
   contentRef?: React.RefObject<HTMLDivElement | null>;
-  onDrilldown?: (text: string) => void;
+  onDrilldown?: (text: string, mode: DrilldownMode) => void;
   loading?: boolean;
   onFindOutMore?: (keyFacts: string[]) => void;
   findOutMoreLoading?: boolean;
@@ -168,7 +168,7 @@ const AiSummaryContent = ({
   filteredResults: SearchResult[];
   onResultClick: (result: SearchResult) => void;
   contentRef?: React.RefObject<HTMLDivElement | null>;
-  onDrilldown?: (text: string) => void;
+  onDrilldown?: (text: string, mode: DrilldownMode) => void;
   onFindOutMore?: (keyFacts: string[]) => void;
   findOutMoreLoading?: boolean;
   findOutMoreActiveFact?: string | null;
@@ -534,6 +534,8 @@ interface DrilldownNavRowProps {
   globalSummaryLoading: boolean;
   drilldownStackDepth: number;
   drilldownHighlight?: string;
+  drilldownTree?: DrilldownNode | null;
+  drilldownCurrentNodeId?: string | null;
   onSetViewMode: (mode: 'summary' | 'tree' | 'global') => void;
   onGenerateGlobalSummary: () => void;
   onExportResearch: () => void;
@@ -547,6 +549,7 @@ interface DrilldownNavRowProps {
 
 const DrilldownNavRow = ({
   viewMode, hasGraph, globalSummaryLoading, drilldownStackDepth, drilldownHighlight,
+  drilldownTree, drilldownCurrentNodeId,
   onSetViewMode, onGenerateGlobalSummary, onExportResearch, onSaveResearch,
   saveResearchLoading, saveResearchStatus, isAuthenticated, onDrilldownBack,
   onLoadPreviousResearch,
@@ -584,7 +587,13 @@ const DrilldownNavRow = ({
       </button>
     )}
     {viewMode === 'summary' && (
-      <DrilldownBreadcrumb stackDepth={drilldownStackDepth} onBack={onDrilldownBack} currentHighlight={drilldownHighlight} />
+      <DrilldownBreadcrumb
+        stackDepth={drilldownStackDepth}
+        onBack={onDrilldownBack}
+        currentHighlight={drilldownHighlight}
+        tree={drilldownTree}
+        currentNodeId={drilldownCurrentNodeId}
+      />
     )}
   </div>
 );
@@ -867,6 +876,8 @@ export const AiSummaryPanel = ({
             globalSummaryLoading={globalSummaryLoading}
             drilldownStackDepth={drilldownStackDepth || 0}
             drilldownHighlight={drilldownHighlight}
+            drilldownTree={drilldownTree}
+            drilldownCurrentNodeId={drilldownCurrentNodeId}
             onSetViewMode={setViewMode}
             onGenerateGlobalSummary={handleGenerateGlobalSummary}
             onExportResearch={handleExportResearch}

--- a/ui/frontend/src/components/DigDeeperPopover.tsx
+++ b/ui/frontend/src/components/DigDeeperPopover.tsx
@@ -1,8 +1,13 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 
+/** Whether the drilldown should inherit the parent investigation's
+ *  context (``'subtopic'``) or be treated as a fresh independent
+ *  question (``'newtopic'``). */
+export type DrilldownMode = 'subtopic' | 'newtopic';
+
 interface DigDeeperPopoverProps {
   containerRef: React.RefObject<HTMLDivElement | null>;
-  onDrilldown: (selectedText: string) => void;
+  onDrilldown: (selectedText: string, mode: DrilldownMode) => void;
   disabled?: boolean;
 }
 
@@ -16,7 +21,7 @@ export const DigDeeperPopover: React.FC<DigDeeperPopoverProps> = ({
   const [visible, setVisible] = useState(false);
   const [position, setPosition] = useState({ top: 0, left: 0 });
   const [selectedText, setSelectedText] = useState('');
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const containerEl = useRef<HTMLDivElement>(null);
 
   const handleSelectionChange = useCallback(() => {
     const selection = window.getSelection();
@@ -53,11 +58,21 @@ export const DigDeeperPopover: React.FC<DigDeeperPopoverProps> = ({
     return () => document.removeEventListener('selectionchange', handleSelectionChange);
   }, [handleSelectionChange]);
 
+  const handleClick = useCallback(
+    (mode: DrilldownMode) => (e: React.MouseEvent) => {
+      e.preventDefault();
+      onDrilldown(selectedText, mode);
+      setVisible(false);
+      window.getSelection()?.removeAllRanges();
+    },
+    [onDrilldown, selectedText],
+  );
+
   if (!visible || disabled) return null;
 
   return (
-    <button
-      ref={buttonRef}
+    <div
+      ref={containerEl}
       className="dig-deeper-popover"
       style={{
         position: 'absolute',
@@ -66,14 +81,23 @@ export const DigDeeperPopover: React.FC<DigDeeperPopoverProps> = ({
         transform: 'translateX(-50%)',
       }}
       onMouseDown={(e) => e.preventDefault()}
-      onClick={(e) => {
-        e.preventDefault();
-        onDrilldown(selectedText);
-        setVisible(false);
-        window.getSelection()?.removeAllRanges();
-      }}
     >
-      Find out more
-    </button>
+      <button
+        type="button"
+        className="dig-deeper-popover-btn"
+        aria-label="Find out more as a sub-topic of the current investigation"
+        onClick={handleClick('subtopic')}
+      >
+        Find out more (sub-topic)
+      </button>
+      <button
+        type="button"
+        className="dig-deeper-popover-btn"
+        aria-label="Find out more as a new independent topic"
+        onClick={handleClick('newtopic')}
+      >
+        Find out more (new topic)
+      </button>
+    </div>
   );
 };

--- a/ui/frontend/src/components/DrilldownBreadcrumb.tsx
+++ b/ui/frontend/src/components/DrilldownBreadcrumb.tsx
@@ -1,24 +1,54 @@
 import React from 'react';
+import { DrilldownNode } from '../types/api';
+import { getAncestorLabels } from '../utils/drilldownUtils';
 
 interface DrilldownBreadcrumbProps {
   stackDepth: number;
   onBack: () => void;
   currentHighlight?: string;
+  /** Drilldown tree, used to render the full ancestor path so the user
+   *  can see the overlying investigation context, not just the leaf. */
+  tree?: DrilldownNode | null;
+  /** Id of the node the user is currently viewing in the tree. */
+  currentNodeId?: string | null;
 }
 
 export const DrilldownBreadcrumb: React.FC<DrilldownBreadcrumbProps> = ({
   stackDepth,
   currentHighlight,
+  tree,
+  currentNodeId,
 }) => {
   if (stackDepth === 0) return null;
 
+  // Prefer the full ancestor path when we have the tree; fall back to
+  // just the current label for callers that haven't migrated yet.
+  const ancestors = getAncestorLabels(tree, currentNodeId);
+  const labels = ancestors.length > 0
+    ? ancestors
+    : (currentHighlight ? [currentHighlight] : []);
+
+  if (labels.length === 0) return null;
+
   return (
     <div className="ai-drilldown-breadcrumb">
-      {currentHighlight && (
-        <span className="ai-drilldown-context">
-          Exploring: &ldquo;{currentHighlight}&rdquo;
-        </span>
-      )}
+      <span className="ai-drilldown-context">
+        Exploring:{' '}
+        {labels.map((label, i) => (
+          <React.Fragment key={`${i}-${label}`}>
+            {i > 0 && <span className="ai-drilldown-sep"> › </span>}
+            <span
+              className={
+                i === labels.length - 1
+                  ? 'ai-drilldown-current'
+                  : 'ai-drilldown-ancestor'
+              }
+            >
+              &ldquo;{label}&rdquo;
+            </span>
+          </React.Fragment>
+        ))}
+      </span>
     </div>
   );
 };

--- a/ui/frontend/src/tests/digDeeperPopover.test.tsx
+++ b/ui/frontend/src/tests/digDeeperPopover.test.tsx
@@ -1,0 +1,125 @@
+import React, { useRef } from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { DigDeeperPopover } from '../components/DigDeeperPopover';
+
+// jsdom doesn't implement layout — stub bounding rects so the popover's
+// position calculation doesn't blow up during render.
+const fakeRect = (): DOMRect => ({
+  top: 10, bottom: 30, left: 10, right: 50,
+  width: 40, height: 20, x: 10, y: 10,
+  toJSON: () => ({}),
+});
+beforeAll(() => {
+  Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+    configurable: true, value: () => fakeRect(),
+  });
+  Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+    configurable: true, value: () => fakeRect(),
+  });
+});
+
+// Selection is a global on the document; clear it so each test starts
+// from a known-empty state.
+beforeEach(() => {
+  window.getSelection()?.removeAllRanges();
+});
+
+const Harness: React.FC<{
+  text: string;
+  onDrilldown: (text: string, mode: 'subtopic' | 'newtopic') => void;
+}> = ({ text, onDrilldown }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={ref}>
+      <p data-testid="paragraph">{text}</p>
+      <DigDeeperPopover containerRef={ref} onDrilldown={onDrilldown} />
+    </div>
+  );
+};
+
+const selectParagraph = () => {
+  // jsdom doesn't fully implement text selection — Range objects work but
+  // window.getSelection().toString() returns '' even after addRange. Stub
+  // the global getSelection so the popover sees a real (non-collapsed)
+  // selection over the paragraph contents.
+  const p = screen.getByTestId('paragraph');
+  const range = document.createRange();
+  range.selectNodeContents(p);
+  jest.spyOn(window, 'getSelection').mockReturnValue({
+    isCollapsed: false,
+    rangeCount: 1,
+    getRangeAt: () => range,
+    toString: () => p.textContent || '',
+    removeAllRanges: jest.fn(),
+  } as unknown as Selection);
+  act(() => {
+    document.dispatchEvent(new Event('selectionchange'));
+  });
+};
+
+describe('DigDeeperPopover', () => {
+  test('renders both sub-topic and new-topic buttons after a long enough selection', () => {
+    render(
+      <Harness
+        text="A long enough sentence about cash based transfers to clear the threshold."
+        onDrilldown={jest.fn()}
+      />,
+    );
+    selectParagraph();
+    expect(screen.getByRole('button', { name: /sub-topic of the current investigation/i }))
+      .toHaveTextContent(/Find out more \(sub-topic\)/);
+    expect(screen.getByRole('button', { name: /new independent topic/i }))
+      .toHaveTextContent(/Find out more \(new topic\)/);
+  });
+
+  test('sub-topic button fires onDrilldown with mode="subtopic"', () => {
+    const onDrilldown = jest.fn();
+    render(
+      <Harness
+        text="A long enough sentence about cash based transfers to clear the threshold."
+        onDrilldown={onDrilldown}
+      />,
+    );
+    selectParagraph();
+    fireEvent.click(screen.getByRole('button', { name: /sub-topic/i }));
+    expect(onDrilldown).toHaveBeenCalledTimes(1);
+    expect(onDrilldown.mock.calls[0][1]).toBe('subtopic');
+  });
+
+  test('new-topic button fires onDrilldown with mode="newtopic"', () => {
+    const onDrilldown = jest.fn();
+    render(
+      <Harness
+        text="A long enough sentence about cash based transfers to clear the threshold."
+        onDrilldown={onDrilldown}
+      />,
+    );
+    selectParagraph();
+    fireEvent.click(screen.getByRole('button', { name: /new independent topic/i }));
+    expect(onDrilldown).toHaveBeenCalledTimes(1);
+    expect(onDrilldown.mock.calls[0][1]).toBe('newtopic');
+  });
+
+  test('does not render when selection is below the minimum length', () => {
+    render(<Harness text="too short" onDrilldown={jest.fn()} />);
+    selectParagraph();
+    expect(screen.queryByRole('button', { name: /sub-topic/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /new topic/i })).toBeNull();
+  });
+
+  test('does not render when disabled even with a valid selection', () => {
+    const Disabled: React.FC = () => {
+      const ref = useRef<HTMLDivElement>(null);
+      return (
+        <div ref={ref}>
+          <p data-testid="paragraph">A long enough sentence to clear the threshold.</p>
+          <DigDeeperPopover containerRef={ref} onDrilldown={jest.fn()} disabled />
+        </div>
+      );
+    };
+    render(<Disabled />);
+    selectParagraph();
+    expect(screen.queryByRole('button', { name: /sub-topic/i })).toBeNull();
+  });
+});

--- a/ui/frontend/src/tests/drilldownUtils.test.ts
+++ b/ui/frontend/src/tests/drilldownUtils.test.ts
@@ -1,9 +1,68 @@
 import { DrilldownNode } from '../types/api';
 import {
+  buildContextualSearchQuery,
   serializeDrilldownTree,
   serializeFullDrilldownTree,
   patchNodeInTree,
 } from '../utils/drilldownUtils';
+
+describe('buildContextualSearchQuery', () => {
+  test('returns leaf only when there is no root context', () => {
+    expect(buildContextualSearchQuery('cash transfers', '', null))
+      .toBe('cash transfers');
+  });
+
+  test('appends root context to leaf at the top level', () => {
+    // No parent label yet — user is one level into the drilldown.
+    expect(buildContextualSearchQuery('improved food security', 'cash transfers in Niger', null))
+      .toBe('improved food security cash transfers in Niger');
+  });
+
+  test('inserts parent label between leaf and root for deeper drilldowns', () => {
+    expect(
+      buildContextualSearchQuery(
+        'gender outcomes',
+        'cash transfers in Niger',
+        'improved food security',
+      ),
+    ).toBe('gender outcomes improved food security cash transfers in Niger');
+  });
+
+  test('omits parent label when it equals the root (avoid duplication)', () => {
+    expect(
+      buildContextualSearchQuery(
+        'follow-up',
+        'cash transfers in Niger',
+        'cash transfers in Niger',
+      ),
+    ).toBe('follow-up cash transfers in Niger');
+  });
+
+  test('omits parent label when it equals the leaf', () => {
+    expect(
+      buildContextualSearchQuery(
+        'food security',
+        'cash transfers in Niger',
+        'food security',
+      ),
+    ).toBe('food security cash transfers in Niger');
+  });
+
+  test('returns leaf only when leaf equals root', () => {
+    expect(buildContextualSearchQuery('cash transfers', 'cash transfers', null))
+      .toBe('cash transfers');
+  });
+
+  test('trims whitespace on inputs', () => {
+    expect(buildContextualSearchQuery('  leaf  ', '  root  ', '  parent  '))
+      .toBe('leaf parent root');
+  });
+
+  test('treats undefined parent label as no parent', () => {
+    expect(buildContextualSearchQuery('leaf', 'root', undefined))
+      .toBe('leaf root');
+  });
+});
 
 const makeSampleTree = (): DrilldownNode => ({
   id: 'root',

--- a/ui/frontend/src/tests/drilldownUtils.test.ts
+++ b/ui/frontend/src/tests/drilldownUtils.test.ts
@@ -1,10 +1,62 @@
 import { DrilldownNode } from '../types/api';
 import {
   buildContextualSearchQuery,
+  getAncestorLabels,
   serializeDrilldownTree,
   serializeFullDrilldownTree,
   patchNodeInTree,
 } from '../utils/drilldownUtils';
+
+describe('getAncestorLabels', () => {
+  const tree: DrilldownNode = {
+    id: 'root',
+    label: 'cash transfers in Niger',
+    children: [
+      {
+        id: 'a',
+        label: 'improved food security',
+        children: [
+          { id: 'a1', label: 'gender outcomes', children: [] },
+          { id: 'a2', label: 'follow-up', children: [] },
+        ],
+      },
+      { id: 'b', label: 'unrelated branch', children: [] },
+    ],
+  };
+
+  test('returns just the root label when target is the root', () => {
+    expect(getAncestorLabels(tree, 'root')).toEqual(['cash transfers in Niger']);
+  });
+
+  test('returns root + leaf for a top-level child', () => {
+    expect(getAncestorLabels(tree, 'a'))
+      .toEqual(['cash transfers in Niger', 'improved food security']);
+  });
+
+  test('returns full path for a deeply-nested target', () => {
+    expect(getAncestorLabels(tree, 'a1'))
+      .toEqual([
+        'cash transfers in Niger',
+        'improved food security',
+        'gender outcomes',
+      ]);
+  });
+
+  test('returns [] when the target is not in the tree', () => {
+    expect(getAncestorLabels(tree, 'missing')).toEqual([]);
+  });
+
+  test('returns [] when tree is null/undefined', () => {
+    expect(getAncestorLabels(null, 'a1')).toEqual([]);
+    expect(getAncestorLabels(undefined, 'a1')).toEqual([]);
+  });
+
+  test('returns [] when targetId is null/undefined/empty', () => {
+    expect(getAncestorLabels(tree, null)).toEqual([]);
+    expect(getAncestorLabels(tree, undefined)).toEqual([]);
+    expect(getAncestorLabels(tree, '')).toEqual([]);
+  });
+});
 
 describe('buildContextualSearchQuery', () => {
   test('returns leaf only when there is no root context', () => {

--- a/ui/frontend/src/utils/drilldownUtils.ts
+++ b/ui/frontend/src/utils/drilldownUtils.ts
@@ -1,6 +1,47 @@
 import type { DrilldownNode, SearchResult } from '../types/api';
 
 /**
+ * Compose a search query that inherits the parent context for a drilldown
+ * or find-out-more sub-query.
+ *
+ * Without this, "find out more" on a fact like *"improved food security"*
+ * inside a parent query *"cash transfers in Niger"* would search just the
+ * fact text — returning chunks about food security from anywhere — and only
+ * the summarisation prompt would mention the parent. Passing the parent
+ * context through to the search itself narrows retrieval to chunks that are
+ * relevant to *both* the leaf and the surrounding investigation.
+ *
+ * The included context mirrors what the summarisation prompt does:
+ *   - the root query is always included (broad framing),
+ *   - the immediate parent label is added when the user has drilled down
+ *     past the root (specificity),
+ *   - the deeper ancestor chain is intentionally omitted to avoid keyword
+ *     dilution at deep levels.
+ *
+ * The returned string is plain text suitable for both dense embedding and
+ * sparse keyword retrieval — no quotes or operators that the search backend
+ * would treat as syntax.
+ */
+export const buildContextualSearchQuery = (
+  leafQuery: string,
+  rootQuery: string,
+  parentLabel?: string | null,
+): string => {
+  const leaf = leafQuery.trim();
+  const root = rootQuery.trim();
+  // Empty root or root === leaf: just return the leaf — no useful context to add.
+  if (!root || root === leaf) return leaf;
+  const parts: string[] = [leaf, root];
+  // Only add the immediate parent if it's distinct from both leaf and root,
+  // matching how the summary prompt avoids redundant phrases.
+  const parent = (parentLabel || '').trim();
+  if (parent && parent !== leaf && parent !== root) {
+    parts.splice(1, 0, parent);
+  }
+  return parts.join(' ');
+};
+
+/**
  * Serialize a drilldown tree for activity/rating logging.
  * Strips heavy data (results arrays, summaries, prompts) to keep the payload small.
  * Preserves only the tree structure (ids + labels) so admins can see which

--- a/ui/frontend/src/utils/drilldownUtils.ts
+++ b/ui/frontend/src/utils/drilldownUtils.ts
@@ -42,6 +42,32 @@ export const buildContextualSearchQuery = (
 };
 
 /**
+ * Resolve the ancestor-path labels from the tree root down to (and
+ * including) the node with id ``targetId``.
+ *
+ * Used by the AI-summary "Exploring: …" breadcrumb so the user can see
+ * the full investigation context, not just the leaf they're currently
+ * looking at. Returns an empty array if the tree is missing or the id
+ * isn't found anywhere in it.
+ */
+export const getAncestorLabels = (
+  tree: DrilldownNode | null | undefined,
+  targetId: string | null | undefined,
+): string[] => {
+  if (!tree || !targetId) return [];
+  const walk = (node: DrilldownNode, trail: string[]): string[] | null => {
+    const next = [...trail, node.label];
+    if (node.id === targetId) return next;
+    for (const child of node.children) {
+      const found = walk(child, next);
+      if (found) return found;
+    }
+    return null;
+  };
+  return walk(tree, []) ?? [];
+};
+
+/**
  * Serialize a drilldown tree for activity/rating logging.
  * Strips heavy data (results arrays, summaries, prompts) to keep the payload small.
  * Preserves only the tree structure (ids + labels) so admins can see which


### PR DESCRIPTION
## Question that triggered this

> When a user selects find out more on an AI summary, the sub-query must include the parent query(ies) in some way. Does the system already do this?

**Partial yes** before this PR. Three drilldown-style call sites all included parent context **in the summarisation prompt** but not in the actual search query that retrieves the supporting chunks:

| Site | Search query (was) | Summary prompt |
|---|---|---|
| \`startDrilldown\` | leaf only | leaf + root + immediate parent |
| \`handleFindOutMore\` | leaf only | leaf + root + immediate parent |
| \`handleAddNodeToTree\` | leaf only | leaf + root + immediate parent |

So clicking find-out-more on "improved food security" inside a parent investigation of "cash transfers in Niger" searched only "improved food security" — returning chunks about food security from anywhere — and the LLM was then asked to summarise those generic chunks "in the context of cash transfers in Niger." Often the chunks had nothing Niger-specific to say.

## Fix

A single \`buildContextualSearchQuery(leafQuery, rootQuery, parentLabel)\` helper in \`drilldownUtils\` composes:

- leaf alone if there's no root context
- \`leaf + root\` at the top level of a drilldown
- \`leaf + immediate parent + root\` deeper down

Same root + immediate-parent inheritance the summary prompt already uses, so the two stages are now consistent. The deeper ancestor chain is intentionally omitted — keeps retrieval focused without keyword dilution at depth.

Wired into all three call sites in \`App.tsx\`.

## Test plan

- [x] \`npm test -- --testPathPattern=drilldownUtils\` — 18 passed (8 new for \`buildContextualSearchQuery\`)
- [x] \`npm test -- --testPathPattern='(drilldownUtils|app|searchTabContent)'\` — 39 passed (no regressions)
- [x] pre-commit clean (code-metrics, etc.)
- [ ] After deploy: drill into a fact under a non-trivial parent query and verify the result list is now scoped to chunks relevant to both — not generic single-topic chunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)