### PR TITLE
feat(admin): add See more / Show less toggle to ratings comment column

### DIFF
--- a/ui/frontend/src/components/admin/RatingsManager.tsx
+++ b/ui/frontend/src/components/admin/RatingsManager.tsx
@@ -708,6 +708,70 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
 };
 
 // ---------------------------------------------------------------------------
+// Comment cell with per-row "See more" / "Show less" toggle so reviewers can
+// read long feedback without leaving the table row to open the row's context
+// panel. The collapsed view stays narrow and ellipsised; the expanded view
+// wraps to full width and preserves linebreaks.
+// ---------------------------------------------------------------------------
+const COMMENT_TRUNCATE_CHARS = 100;
+
+export const CommentCell: React.FC<{ comment: string | null }> = ({ comment }) => {
+  const [expanded, setExpanded] = useState(false);
+  const text = comment || '';
+  if (!text) {
+    return (
+      <td style={{ fontSize: '0.82rem', color: '#888' }}>-</td>
+    );
+  }
+  const isLong = text.length > COMMENT_TRUNCATE_CHARS;
+  if (!isLong) {
+    return (
+      <td style={{
+        fontSize: '0.82rem', maxWidth: '200px', overflow: 'hidden',
+        textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+      }} title={text}>
+        {text}
+      </td>
+    );
+  }
+  if (expanded) {
+    return (
+      <td style={{
+        fontSize: '0.82rem', maxWidth: '320px', whiteSpace: 'pre-wrap',
+        wordBreak: 'break-word',
+      }}>
+        {text}{' '}
+        <button
+          onClick={(e) => { e.stopPropagation(); setExpanded(false); }}
+          className="admin-show-more-btn"
+          style={{ display: 'inline', padding: 0, marginLeft: 4 }}
+          aria-label="Show less of this comment"
+        >
+          Show less
+        </button>
+      </td>
+    );
+  }
+  return (
+    <td style={{
+      fontSize: '0.82rem', maxWidth: '200px', whiteSpace: 'nowrap',
+    }} title={text}>
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', display: 'inline-block', maxWidth: 'calc(100% - 70px)', verticalAlign: 'bottom' }}>
+        {text.slice(0, COMMENT_TRUNCATE_CHARS).trimEnd()}…
+      </span>{' '}
+      <button
+        onClick={(e) => { e.stopPropagation(); setExpanded(true); }}
+        className="admin-show-more-btn"
+        style={{ display: 'inline', padding: 0, marginLeft: 4 }}
+        aria-label="See full comment"
+      >
+        See more
+      </button>
+    </td>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Rating table row (extracted to reduce cyclomatic complexity)
 // ---------------------------------------------------------------------------
 const hasContext = (r: RatingRow) => r.context && Object.keys(r.context).length > 0;
@@ -727,7 +791,7 @@ const RatingTableRow: React.FC<{
         <td style={{ fontSize: '0.82rem' }}>{rating.user_email || rating.user_display_name || '-'}</td>
         <td style={{ fontSize: '0.82rem' }}>{rating.rating_type.replace(/_/g, ' ')}</td>
         <td style={{ color: '#d4a017', fontSize: '0.9rem', letterSpacing: '1px' }}>{renderStars(rating.score)}</td>
-        <td style={{ fontSize: '0.82rem', maxWidth: '200px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={rating.comment || ''}>{rating.comment || '-'}</td>
+        <CommentCell comment={rating.comment} />
         <td style={{ fontSize: '0.82rem', maxWidth: '150px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={rating.url || ''}>
           {rating.url ? <a href={rating.url} target="_blank" rel="noopener noreferrer" style={{ color: '#1a73e8' }} onClick={(e) => e.stopPropagation()}>link</a> : '-'}
         </td>

--- a/ui/frontend/src/tests/ratingsCommentCell.test.tsx
+++ b/ui/frontend/src/tests/ratingsCommentCell.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { CommentCell } from '../components/admin/RatingsManager';
+
+const renderCell = (comment: string | null) =>
+  render(
+    <table><tbody><tr><CommentCell comment={comment} /></tr></tbody></table>,
+  );
+
+describe('CommentCell', () => {
+  test('renders an em-dash when there is no comment', () => {
+    renderCell(null);
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /see (more|full comment)/i })).toBeNull();
+  });
+
+  test('renders a short comment without a See more toggle', () => {
+    renderCell('Short feedback');
+    expect(screen.getByText('Short feedback')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /see more|see full comment/i })).toBeNull();
+  });
+
+  test('truncates long comments and exposes a "See more" toggle', () => {
+    const long = 'A long comment about the AI summary that goes well over the threshold. '.repeat(5);
+    renderCell(long);
+    // Truncated body shouldn't contain the full text yet
+    expect(screen.queryByText(long)).toBeNull();
+    // ellipsis character is present in the truncated body
+    expect(screen.getByText(/…/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /see full comment/i })).toBeInTheDocument();
+  });
+
+  test('clicking "See more" expands to full comment with "Show less" toggle', () => {
+    const long = 'A long comment about the AI summary that goes well over the threshold. '.repeat(5);
+    renderCell(long);
+    fireEvent.click(screen.getByRole('button', { name: /see full comment/i }));
+    // The cell's textContent should now contain the full comment, and the
+    // ellipsis from the truncated view should be gone.
+    const cell = screen.getByRole('button', { name: /show less of this comment/i }).closest('td');
+    expect(cell?.textContent).toContain(long.trim());
+    expect(cell?.textContent).not.toContain('…');
+  });
+
+  test('clicking "Show less" collapses back to the truncated view', () => {
+    const long = 'A long comment about the AI summary that goes well over the threshold. '.repeat(5);
+    renderCell(long);
+    fireEvent.click(screen.getByRole('button', { name: /see full comment/i }));
+    fireEvent.click(screen.getByRole('button', { name: /show less of this comment/i }));
+    expect(screen.getByRole('button', { name: /see full comment/i })).toBeInTheDocument();
+    expect(screen.getByText(/…/)).toBeInTheDocument();
+  });
+
+  test('toggle clicks do not bubble up (so the row does not also expand)', () => {
+    const onRowClick = jest.fn();
+    render(
+      <table><tbody>
+        <tr onClick={onRowClick}>
+          <CommentCell comment={'A long comment about the AI summary that goes well over the threshold. '.repeat(5)} />
+        </tr>
+      </tbody></table>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /see full comment/i }));
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## What

The Comment column in **Admin → Ratings** truncated long feedback with a CSS ellipsis and only revealed the rest via the browser's title tooltip. Multi-paragraph comments on AI summaries were effectively unreadable without expanding the row's full context panel.

A new \`CommentCell\` component:
- Renders short comments (≤100 chars) exactly as before.
- For longer comments, shows the first ~100 chars + an ellipsis + an inline **See more** button.
- Click expands the cell to a wider, line-wrapping view with a **Show less** button.
- Click handlers stop event propagation so toggling the comment doesn't also expand the row's context panel.
- State is per-row — collapsing one comment doesn't affect others.

## Test plan

- [x] \`npm test -- --testPathPattern=ratingsCommentCell\` — 6 new tests pass (empty, short, long, expand, collapse, click-doesn't-bubble)
- [x] pre-commit clean (code-metrics included)
- [ ] After deploy: sort the Ratings table by Comment, find one with a long comment, confirm the See more / Show less toggle works inline and that clicking it doesn't open the row's expanded context panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)