### PR TITLE
fix(search): fall back to no-rerank when Vertex Discovery Engine returns 503

### DIFF
--- a/tests/unit/test_google_vertex_reranker.py
+++ b/tests/unit/test_google_vertex_reranker.py
@@ -3,7 +3,13 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from ui.backend.services.google_vertex_reranker import rerank_with_google_vertex
+import pytest
+from google.api_core import exceptions as gax_exceptions
+
+from ui.backend.services.google_vertex_reranker import (
+    RerankerUnavailableError,
+    rerank_with_google_vertex,
+)
 
 
 def _make_fake_record(record_id: str, score: float) -> SimpleNamespace:
@@ -92,3 +98,71 @@ def test_rerank_missing_doc_gets_zero_score(mock_de, mock_project):
 
     scores = rerank_with_google_vertex("q", ["a", "b"], "model")
     assert scores == [0.9, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# Transient-failure fallback: known-recoverable Google errors get repackaged
+# as RerankerUnavailableError so the search pipeline can fall back to the
+# unranked results instead of bubbling a 500 to the user.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "transient_exc",
+    [
+        gax_exceptions.ServiceUnavailable("503 The service is currently unavailable."),
+        gax_exceptions.DeadlineExceeded("504 Deadline exceeded."),
+        gax_exceptions.GatewayTimeout("504 Gateway timeout."),
+        gax_exceptions.InternalServerError("500 Internal."),
+    ],
+)
+@patch("pipeline.utilities.google_vertex_client._load_gcp_project_id")
+@patch("google.cloud.discoveryengine_v1", create=True)
+def test_rerank_raises_unavailable_on_known_transient_errors(
+    mock_de, mock_project, transient_exc
+):
+    mock_project.return_value = "p"
+    mock_client = MagicMock()
+    mock_de.RankServiceClient.return_value = mock_client
+    mock_client.ranking_config_path.return_value = "config"
+    mock_client.rank.side_effect = transient_exc
+
+    with pytest.raises(RerankerUnavailableError) as excinfo:
+        rerank_with_google_vertex("q", ["a", "b"], "model")
+
+    # The original Google error must be preserved as the cause so SREs can
+    # still see exactly which transient code fired.
+    assert excinfo.value.__cause__ is transient_exc
+    # And the message should name the kind of failure for log grep-ability.
+    assert type(transient_exc).__name__ in str(excinfo.value)
+
+
+@patch("pipeline.utilities.google_vertex_client._load_gcp_project_id")
+@patch("google.cloud.discoveryengine_v1", create=True)
+def test_rerank_does_not_swallow_real_bugs(mock_de, mock_project):
+    """A non-transient error must still propagate — silently ignoring it
+    would mask a real reranker bug behind the fallback."""
+    mock_project.return_value = "p"
+    mock_client = MagicMock()
+    mock_de.RankServiceClient.return_value = mock_client
+    mock_client.ranking_config_path.return_value = "config"
+    mock_client.rank.side_effect = ValueError("malformed request")
+
+    with pytest.raises(ValueError, match="malformed request"):
+        rerank_with_google_vertex("q", ["a", "b"], "model")
+
+
+@patch("pipeline.utilities.google_vertex_client._load_gcp_project_id")
+@patch("google.cloud.discoveryengine_v1", create=True)
+def test_rerank_permission_denied_propagates(mock_de, mock_project):
+    """Auth/permission errors are not transient — they must surface so an
+    operator notices the credential issue rather than seeing silent
+    no-rerank fallback forever."""
+    mock_project.return_value = "p"
+    mock_client = MagicMock()
+    mock_de.RankServiceClient.return_value = mock_client
+    mock_client.ranking_config_path.return_value = "config"
+    mock_client.rank.side_effect = gax_exceptions.PermissionDenied("403 nope")
+
+    with pytest.raises(gax_exceptions.PermissionDenied):
+        rerank_with_google_vertex("q", ["a", "b"], "model")

--- a/tests/unit/test_ui_backend_search.py
+++ b/tests/unit/test_ui_backend_search.py
@@ -182,6 +182,56 @@ def test_rerank_results_updates_scores_and_limit(monkeypatch):
     assert reranked[0].payload["text"] == "two"
 
 
+def test_rerank_falls_back_to_unranked_on_vertex_unavailable(monkeypatch, caplog):
+    """When the Vertex reranker raises RerankerUnavailableError (transient
+    Google-side outage), rerank_results must return the original results
+    unchanged rather than propagating the error to the search route. A
+    WARNING is emitted so the situation is loud in ops monitoring."""
+    from ui.backend.services.google_vertex_reranker import RerankerUnavailableError
+
+    results = [
+        SimpleNamespace(id="a", payload={"text": "one"}, score=0.10),
+        SimpleNamespace(id="b", payload={"text": "two"}, score=0.20),
+        SimpleNamespace(id="c", payload={"text": "three"}, score=0.30),
+    ]
+
+    def _boom(**_kwargs):
+        raise RerankerUnavailableError(
+            "Vertex Discovery Engine rank API unavailable: "
+            "ServiceUnavailable: 503 The service is currently unavailable."
+        )
+
+    # Force the Vertex code path inside search_models.rerank_results.
+    monkeypatch.setattr(search_models, "_is_google_vertex_reranker", lambda _cfg: True)
+    monkeypatch.setattr(
+        search_models,
+        "_get_rerank_model_config",
+        lambda *a, **kw: {
+            "provider": "google_vertex",
+            "model_id": "semantic-ranker-default-004",
+        },
+    )
+    monkeypatch.setattr(search_models, "rerank_with_google_vertex", _boom)
+    monkeypatch.setattr(
+        search_models,
+        "_resolve_rerank_model_name",
+        lambda *_a, **_kw: "vertex-ai-ranker",
+    )
+
+    caplog.set_level("WARNING")
+    out = search.rerank_results("query", results, limit=None, max_rerank_candidates=0)
+
+    # Original results returned in original order with original scores.
+    assert out is results
+    assert [r.score for r in out] == [0.10, 0.20, 0.30]
+
+    # Loud-and-clear log so an extended outage isn't silent.
+    msgs = " ".join(record.getMessage() for record in caplog.records)
+    assert "VERTEX RERANKER UNAVAILABLE" in msgs
+    assert "no-rerank" in msgs
+    assert "503" in msgs
+
+
 def test_get_models_returns_both(monkeypatch):
     dense_model = object()
     sparse_model = object()

--- a/ui/backend/services/google_vertex_reranker.py
+++ b/ui/backend/services/google_vertex_reranker.py
@@ -3,13 +3,41 @@
 import logging
 from typing import List, Optional
 
+from google.api_core import exceptions as gax_exceptions
+
 logger = logging.getLogger(__name__)
+
+
+class RerankerUnavailableError(RuntimeError):
+    """Raised when an external reranker is temporarily unavailable.
+
+    Distinct from arbitrary errors so callers can fall back to no-rerank
+    on known-transient cases (e.g. Google ``503 UNAVAILABLE``,
+    ``DEADLINE_EXCEEDED``) without swallowing real bugs.
+    """
+
+
+# Errors we treat as transient and recoverable: search should still succeed
+# (without the rerank step) rather than 500 to the user. Anything else
+# propagates so an unexpected bug isn't silently masked.
+_TRANSIENT_RERANK_ERRORS = (
+    gax_exceptions.ServiceUnavailable,
+    gax_exceptions.DeadlineExceeded,
+    gax_exceptions.GatewayTimeout,
+    gax_exceptions.InternalServerError,
+)
 
 
 def rerank_with_google_vertex(
     query: str, documents: List[str], model_id: str
 ) -> List[float]:
-    """Rerank documents using the Vertex AI Ranking API (Discovery Engine)."""
+    """Rerank documents using the Vertex AI Ranking API (Discovery Engine).
+
+    Raises ``RerankerUnavailableError`` on transient Google-side outages
+    (``503 UNAVAILABLE``, ``DEADLINE_EXCEEDED``, ``504``, ``500``) so the
+    caller can fall back to returning the unranked results instead of
+    bubbling a 500 to the user.
+    """
     from google.cloud import (
         discoveryengine_v1 as discoveryengine,  # type: ignore[attr-defined]
     )
@@ -34,7 +62,13 @@ def rerank_with_google_vertex(
         query=query,
         records=records,
     )
-    response = client.rank(request=request)
+    try:
+        response = client.rank(request=request)
+    except _TRANSIENT_RERANK_ERRORS as exc:
+        raise RerankerUnavailableError(
+            f"Vertex Discovery Engine rank API unavailable: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
 
     # Map scores back to original document order
     scores: List[Optional[float]] = [None] * len(documents)

--- a/ui/backend/services/search_models.py
+++ b/ui/backend/services/search_models.py
@@ -21,6 +21,7 @@ from pipeline.utilities.google_vertex_client import (  # noqa: E402
 )
 from ui.backend.services.azure_foundry_reranker import rerank_with_azure_foundry
 from ui.backend.services.google_vertex_reranker import (  # noqa: E402
+    RerankerUnavailableError,
     rerank_with_google_vertex,
 )
 
@@ -365,6 +366,81 @@ def _is_azure_foundry_reranker(config: Dict[str, Any]) -> bool:
     )
 
 
+def _rerank_via_vertex_with_fallback(
+    query: str, documents: List[str], vertex_model_id: str
+) -> Optional[List[float]]:
+    """Call the Vertex reranker; return ``None`` on transient unavailability.
+
+    On a known-transient Google outage (``RerankerUnavailableError``) this
+    emits a prominent ``WARNING`` and returns ``None`` so the caller knows
+    to fall back to the unranked results. Other exceptions propagate so a
+    real bug isn't silently masked.
+    """
+    try:
+        return rerank_with_google_vertex(
+            query=query, documents=documents, model_id=vertex_model_id
+        )
+    except RerankerUnavailableError as exc:
+        bar = "=" * 72
+        logger.warning(
+            "%s\nVERTEX RERANKER UNAVAILABLE — falling back to no-rerank.\n"
+            "  reason : %s\n"
+            "  query  : %r\n"
+            "  docs   : %d (returned in original score order)\n"
+            "  model  : %s\n"
+            "If this persists, switch the model combo's rerank_model to a "
+            "non-Vertex option (e.g. jinaai/jina-reranker-v2-base-multilingual) "
+            "or disable rerank, and check GCP status for Discovery Engine.\n"
+            "%s",
+            bar,
+            exc,
+            query,
+            len(documents),
+            vertex_model_id,
+            bar,
+        )
+        return None
+
+
+def _compute_rerank_scores(
+    query: str,
+    documents: List[str],
+    rerank_model: Optional[str],
+    rerank_config: Dict[str, Any],
+    model_name: str,
+    supported_rerank_models: Optional[Dict[str, Any]],
+    rerank_model_loader: Optional[Any],
+) -> Optional[List[float]]:
+    """Run the appropriate reranker and return per-document scores.
+
+    Returns ``None`` when the chosen backend has signalled a transient
+    unavailability (e.g. Vertex 503), telling the caller to skip the
+    rerank step and return the original result order untouched. Other
+    backends raise on failure so genuine bugs aren't silently swallowed.
+    """
+    if _is_azure_foundry_reranker(rerank_config):
+        deployment = rerank_config.get("model_id", model_name)
+        with _rerank_semaphore:
+            return rerank_with_azure_foundry(
+                query=query,
+                documents=documents,
+                deployment=deployment,
+                config=rerank_config,
+            )
+    if _is_google_vertex_reranker(rerank_config):
+        vertex_model_id = rerank_config.get("model_id", model_name)
+        with _rerank_semaphore:
+            return _rerank_via_vertex_with_fallback(query, documents, vertex_model_id)
+    if rerank_model_loader is not None:
+        reranker = rerank_model_loader(rerank_model)
+    else:
+        reranker = get_rerank_model(
+            rerank_model, supported_rerank_models=supported_rerank_models
+        )
+    with _rerank_semaphore:
+        return list(reranker.rerank(query, documents))
+
+
 def _is_google_vertex_reranker(config: Dict[str, Any]) -> bool:
     return (
         config.get("provider") == "google_vertex"
@@ -468,32 +544,19 @@ def rerank_results(
         rerank_model, supported_rerank_models=supported_rerank_models
     )
     t_rerank_infer_start = time.time()
-    if _is_azure_foundry_reranker(rerank_config):
-        deployment = rerank_config.get("model_id", model_name)
-        with _rerank_semaphore:
-            rerank_scores = rerank_with_azure_foundry(
-                query=query,
-                documents=documents,
-                deployment=deployment,
-                config=rerank_config,
-            )
-    elif _is_google_vertex_reranker(rerank_config):
-        vertex_model_id = rerank_config.get("model_id", model_name)
-        with _rerank_semaphore:
-            rerank_scores = rerank_with_google_vertex(
-                query=query,
-                documents=documents,
-                model_id=vertex_model_id,
-            )
-    else:
-        if rerank_model_loader is not None:
-            reranker = rerank_model_loader(rerank_model)
-        else:
-            reranker = get_rerank_model(
-                rerank_model, supported_rerank_models=supported_rerank_models
-            )
-        with _rerank_semaphore:
-            rerank_scores = list(reranker.rerank(query, documents))
+    rerank_scores = _compute_rerank_scores(
+        query=query,
+        documents=documents,
+        rerank_model=rerank_model,
+        rerank_config=rerank_config,
+        model_name=model_name,
+        supported_rerank_models=supported_rerank_models,
+        rerank_model_loader=rerank_model_loader,
+    )
+    if rerank_scores is None:
+        # Reranker signalled transient unavailability — return the original
+        # result order rather than 500-ing the search route.
+        return results
     t_rerank_infer_end = time.time()
     logger.info(
         "[TIMING] rerank inference: %.3fs (%s docs)",


### PR DESCRIPTION
## Symptom

When Google's Discovery Engine ``rank`` API has a brief outage, every \`/search\` request configured with \`rerank_model=vertex-ai-ranker\` returned **500 Internal Server Error** to the browser:

\`\`\`
google.api_core.exceptions.ServiceUnavailable: 503 The service is currently unavailable.
  google_vertex_reranker.py:37 → client.rank(request=request)
\`\`\`

The infra and the search itself were healthy — only the post-search rerank step was failing.

## Fix

1. **\`rerank_with_google_vertex\`** now wraps the gRPC call and translates the four known-transient \`google.api_core.exceptions\` (\`ServiceUnavailable\`, \`DeadlineExceeded\`, \`GatewayTimeout\`, \`InternalServerError\`) into a typed \`RerankerUnavailableError\`. Auth/permission/quota errors still propagate — silently masking those would hide a real config problem.
2. **\`rerank_results\`** catches \`RerankerUnavailableError\`, returns the original (un-reranked) results, and emits a banner-style \`WARNING\`:

\`\`\`
========================================================================
VERTEX RERANKER UNAVAILABLE — falling back to no-rerank.
  reason : Vertex Discovery Engine rank API unavailable: ServiceUnavailable: 503 …
  query  : 'health and children'
  docs   : 50 (returned in original score order)
  model  : semantic-ranker-default-004
If this persists, switch the model combo's rerank_model to a non-Vertex
option (e.g. jinaai/jina-reranker-v2-base-multilingual) or disable
rerank, and check GCP status for Discovery Engine.
========================================================================
\`\`\`

3. The inline if/elif/else reranker dispatch in \`rerank_results\` is extracted into \`_compute_rerank_scores\` to keep cognitive complexity under the project's gate while making the fallback path readable.

## Trade-offs

- **Result order during a Vertex outage** is the pre-rerank dense+sparse hybrid order, not the rerank-tuned order. Users still get sensible results; quality is just slightly degraded for the duration of Google's blip.
- **Other rerankers** (Azure Foundry, the local Jina cross-encoder) keep their existing behavior — they raise on failure rather than fall back. Easy to extend later if needed.

## Test plan

- [x] \`pytest tests/unit/test_google_vertex_reranker.py tests/unit/test_ui_backend_search.py\` — 20 passed (7 new):
  - 4 parametrised: each of \`ServiceUnavailable\`, \`DeadlineExceeded\`, \`GatewayTimeout\`, \`InternalServerError\` raises \`RerankerUnavailableError\` with the original error chained as \`__cause__\`.
  - 2 negative-control: \`ValueError\` and \`PermissionDenied\` still propagate (no silent swallow).
  - 1 end-to-end: \`rerank_results\` returns originals in original order and emits the \`VERTEX RERANKER UNAVAILABLE\` warning containing \"503\" and \"no-rerank\".
- [x] pre-commit clean (black, isort, flake8, mypy, bandit, code-metrics).
- [ ] After deploy: simulated/observed Vertex outage → \`/search\` returns 200 instead of 500, the warning shows up in api logs, search results appear in pre-rerank order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)