### PR TITLE
fix(auth): preserve search URL params across OAuth login round-trip

### DIFF
--- a/tests/unit/test_oauth.py
+++ b/tests/unit/test_oauth.py
@@ -2,6 +2,16 @@
 
 from unittest.mock import patch
 
+import pytest
+from fastapi_users.router.oauth import generate_state_token
+
+from ui.backend.auth.users import AUTH_SECRET
+from ui.backend.routes.auth import (
+    _APP_BASE_URL,
+    _is_safe_return_to,
+    _resolve_post_login_redirect,
+)
+
 
 class TestOAuthConfiguration:
     """Tests for OAuth client initialization."""
@@ -158,3 +168,86 @@ class TestOAuthExplicitScopes:
             scopes = mod.microsoft_oauth_client.base_scopes
             # 4 scopes: openid, email, profile, User.Read
             assert len(scopes) == 4
+
+
+class TestIsSafeReturnTo:
+    """Tests for the same-origin path validator used by the OAuth flow."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "/",
+            "/?q=foo",
+            "/?q=impact+of+climate+change&rerank=false&sections=findings",
+            "/admin?x=1",
+            "/admin/users?page=2&sort=name",
+            "/path/with/segments",
+        ],
+    )
+    def test_accepts_same_origin_paths(self, value):
+        assert _is_safe_return_to(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            None,
+            "",
+            "//evil.com",
+            "//evil.com/path",
+            "/\\evil.com",
+            "https://evil.com/",
+            "http://evil.com",
+            "javascript:alert(1)",
+            "relative/path",
+            "?q=foo",
+        ],
+    )
+    def test_rejects_unsafe_values(self, value):
+        assert _is_safe_return_to(value) is False
+
+    def test_rejects_overly_long_paths(self):
+        # 2049 chars — one over the cap
+        too_long = "/" + ("a" * 2048)
+        assert _is_safe_return_to(too_long) is False
+
+    def test_accepts_path_at_length_limit(self):
+        at_limit = "/" + ("a" * 2047)  # total length = 2048
+        assert _is_safe_return_to(at_limit) is True
+
+
+class TestResolvePostLoginRedirect:
+    """Tests that the OAuth callback redirect respects the signed state JWT."""
+
+    def test_returns_base_url_when_state_missing(self):
+        assert _resolve_post_login_redirect(None) == _APP_BASE_URL
+        assert _resolve_post_login_redirect("") == _APP_BASE_URL
+
+    def test_returns_base_url_when_state_is_garbage(self):
+        assert _resolve_post_login_redirect("not-a-jwt") == _APP_BASE_URL
+
+    def test_returns_base_url_when_signature_invalid(self):
+        # State signed with the wrong secret must not be trusted.
+        wrong_secret = "x" * 32  # length matches AUTH_SECRET strength, value differs
+        bad_state = generate_state_token({"return_to": "/?q=foo"}, wrong_secret)
+        assert _resolve_post_login_redirect(bad_state) == _APP_BASE_URL
+
+    def test_returns_base_url_when_return_to_missing(self):
+        state = generate_state_token({"sub": "127.0.0.1"}, AUTH_SECRET)
+        assert _resolve_post_login_redirect(state) == _APP_BASE_URL
+
+    def test_returns_base_url_when_return_to_unsafe(self):
+        # Even though state is signed, an unsafe return_to is still rejected
+        # (defense in depth).
+        state = generate_state_token({"return_to": "//evil.com"}, AUTH_SECRET)
+        assert _resolve_post_login_redirect(state) == _APP_BASE_URL
+
+    def test_appends_safe_return_to_to_base_url(self):
+        return_to = "/?q=impact+of+climate+change&rerank=false"
+        state = generate_state_token({"return_to": return_to}, AUTH_SECRET)
+        expected = _APP_BASE_URL.rstrip("/") + return_to
+        assert _resolve_post_login_redirect(state) == expected
+
+    def test_strips_trailing_slash_from_base_url(self):
+        with patch("ui.backend.routes.auth._APP_BASE_URL", "http://localhost:3000/"):
+            state = generate_state_token({"return_to": "/?q=foo"}, AUTH_SECRET)
+            assert _resolve_post_login_redirect(state) == "http://localhost:3000/?q=foo"

--- a/ui/backend/routes/auth.py
+++ b/ui/backend/routes/auth.py
@@ -1,9 +1,12 @@
 """Authentication routes — login, register, verify, OAuth callbacks."""
 
 import os
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import RedirectResponse
+from fastapi_users.jwt import decode_jwt
+from fastapi_users.router.oauth import STATE_TOKEN_AUDIENCE, generate_state_token
 
 from ui.backend.auth.oauth import google_oauth_client, microsoft_oauth_client
 from ui.backend.auth.schemas import UserCreate, UserRead
@@ -23,6 +26,45 @@ _OAUTH_CALLBACK_BASE = os.environ.get(
 
 # Where to redirect the browser after a successful OAuth login.
 _APP_BASE_URL = os.environ.get("APP_BASE_URL", "http://localhost:3000")
+
+# Cap on the post-login return path; long enough for typical search-state URLs.
+_MAX_RETURN_TO_LEN = 2048
+
+
+def _is_safe_return_to(return_to: Optional[str]) -> bool:
+    """True iff return_to is a same-origin path safe to redirect to.
+
+    Rejects protocol-relative URLs (`//evil.com`, `/\\evil.com`) and absolute
+    URLs that would redirect off-domain. Length-capped to guard against abuse.
+    """
+    if not return_to:
+        return False
+    if len(return_to) > _MAX_RETURN_TO_LEN:
+        return False
+    if not return_to.startswith("/"):
+        return False
+    if return_to.startswith("//") or return_to.startswith("/\\"):
+        return False
+    return True
+
+
+def _resolve_post_login_redirect(state: Optional[str]) -> str:
+    """Decode the OAuth state JWT and return a safe absolute redirect URL.
+
+    Falls back to _APP_BASE_URL when state is missing, invalid, or carries
+    an unsafe return_to — defense in depth, even though state is signed.
+    """
+    if not state:
+        return _APP_BASE_URL
+    try:
+        state_data = decode_jwt(state, AUTH_SECRET, [STATE_TOKEN_AUDIENCE])
+    except Exception:
+        return _APP_BASE_URL
+    return_to = state_data.get("return_to")
+    if not _is_safe_return_to(return_to):
+        return _APP_BASE_URL
+    return _APP_BASE_URL.rstrip("/") + return_to
+
 
 # When DISABLE_EMAIL_LOGIN is true, email/password login and registration
 # routes are not mounted at all — forcing users to sign in via OAuth only.
@@ -81,17 +123,22 @@ def _make_oauth_router(oauth_client, provider_name: str):
     cookie set.  We wrap it: the /authorize endpoint returns JSON with
     the authorization_url (consumed by the frontend), and the /callback
     endpoint authenticates the user, sets the httpOnly auth cookie, then
-    redirects the browser back to the application.
+    redirects the browser back to the application — preserving the path
+    and query string the user was on (carried through the signed state JWT).
     """
-    from fastapi_users.router.oauth import generate_state_token
-
     oauth_router = APIRouter()
 
     # --- /authorize --------------------------------------------------------
     @oauth_router.get("/authorize")
-    async def authorize(request: Request, scopes: list[str] = Query(None)):
+    async def authorize(
+        request: Request,
+        scopes: list[str] = Query(None),
+        return_to: Optional[str] = Query(None),
+    ):
         authorize_redirect_url = f"{_OAUTH_CALLBACK_BASE}/auth/{provider_name}/callback"
-        state_data = {"sub": str(request.client.host) if request.client else ""}
+        state_data: dict = {"sub": str(request.client.host) if request.client else ""}
+        if _is_safe_return_to(return_to):
+            state_data["return_to"] = return_to
         state = generate_state_token(state_data, AUTH_SECRET)
         authorization_url = await oauth_client.get_authorization_url(
             authorize_redirect_url,
@@ -156,8 +203,11 @@ def _make_oauth_router(oauth_client, provider_name: str):
         # Log in via cookie backend — sets the httpOnly auth cookie
         login_response = await cookie_backend.login(strategy, user)
 
-        # Convert to a redirect, preserving the Set-Cookie header
-        redirect = RedirectResponse(url=_APP_BASE_URL, status_code=302)
+        # Convert to a redirect, preserving the Set-Cookie header. Land back
+        # on the URL the user was on before OAuth (carried in the signed
+        # state JWT), so search-state query params survive the round-trip.
+        redirect_target = _resolve_post_login_redirect(state)
+        redirect = RedirectResponse(url=redirect_target, status_code=302)
         for header_name, header_value in login_response.raw_headers:
             if header_name.lower() == b"set-cookie":
                 redirect.raw_headers.append((header_name, header_value))

--- a/ui/frontend/src/components/auth/OAuthButtons.test.tsx
+++ b/ui/frontend/src/components/auth/OAuthButtons.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import OAuthButtons from './OAuthButtons';
+
+describe('OAuthButtons', () => {
+  const originalLocation = window.location;
+  let assignedHref = '';
+
+  beforeEach(() => {
+    assignedHref = '';
+
+    // jsdom's window.location is non-configurable; replace with a stub that
+    // captures href assignments without triggering navigation.
+    delete (window as unknown as { location?: Location }).location;
+    (window as unknown as { location: Partial<Location> }).location = {
+      pathname: '/',
+      search: '',
+      get href() {
+        return assignedHref;
+      },
+      set href(value: string) {
+        assignedHref = value;
+      },
+    } as Location;
+
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve({ authorization_url: 'https://idp.example/auth' }),
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    (window as unknown as { location: Location }).location = originalLocation;
+    jest.restoreAllMocks();
+  });
+
+  const setLocation = (pathname: string, search: string) => {
+    (window.location as unknown as { pathname: string }).pathname = pathname;
+    (window.location as unknown as { search: string }).search = search;
+  };
+
+  test('passes current path+query as return_to when starting Google OAuth', async () => {
+    setLocation('/', '?q=impact+of+climate+change&rerank=false&dataset=WFP');
+    render(<OAuthButtons />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Google/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+
+    expect(calledUrl).toContain('/auth/google/authorize');
+    expect(calledUrl).toContain(
+      'return_to=' +
+        encodeURIComponent('/?q=impact+of+climate+change&rerank=false&dataset=WFP'),
+    );
+  });
+
+  test('passes current path+query as return_to when starting Microsoft OAuth', async () => {
+    setLocation('/admin', '?page=2');
+    render(<OAuthButtons />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Microsoft/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+
+    expect(calledUrl).toContain('/auth/microsoft/authorize');
+    expect(calledUrl).toContain('return_to=' + encodeURIComponent('/admin?page=2'));
+  });
+
+  test('sends return_to=%2F when on bare app root', async () => {
+    setLocation('/', '');
+    render(<OAuthButtons microsoftEnabled={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Google/i }));
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1));
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+
+    expect(calledUrl).toContain('return_to=' + encodeURIComponent('/'));
+  });
+
+  test('navigates to the authorization_url returned by the backend', async () => {
+    setLocation('/', '?q=foo');
+    render(<OAuthButtons microsoftEnabled={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Sign in with Google/i }));
+
+    await waitFor(() => expect(assignedHref).toBe('https://idp.example/auth'));
+  });
+});

--- a/ui/frontend/src/components/auth/OAuthButtons.tsx
+++ b/ui/frontend/src/components/auth/OAuthButtons.tsx
@@ -21,7 +21,12 @@ const OAuthButtons: React.FC<OAuthButtonsProps> = ({
 
   const handleOAuth = async (provider: string) => {
     try {
-      const res = await fetch(`${API_BASE_URL}/auth/${provider}/authorize`, {
+      // Round-trip the current path+query through the signed state JWT so the
+      // OAuth callback can redirect back here (the bare app root would lose it).
+      const returnTo = window.location.pathname + window.location.search;
+      const authorizeUrl =
+        `${API_BASE_URL}/auth/${provider}/authorize?return_to=${encodeURIComponent(returnTo)}`;
+      const res = await fetch(authorizeUrl, {
         method: 'GET',
         headers: { 'Accept': 'application/json' },
       });


### PR DESCRIPTION
## Summary

- Before this fix: when a logged-in user ran a search, the URL correctly reflected the search parameters (e.g. `?q=...&rerank=false&sections=...&dataset=...`). If they then logged out and signed back in with **Google or Microsoft SSO**, those URL params were lost. Password login was unaffected.
- Root cause: the OAuth `/callback` redirected to a hardcoded `APP_BASE_URL` with no path or query string — discarding whatever URL the user was on before the SSO round-trip. Password login uses an AJAX POST that never leaves the page, so the URL was preserved by default.
- Fix: round-trip the pre-OAuth `pathname + search` through the signed OAuth state JWT.
  - Frontend ([`OAuthButtons.tsx`](https://github.com/dividor/evidencelab/blob/fix/url_loss/ui/frontend/src/components/auth/OAuthButtons.tsx)) sends `return_to` on `/authorize`.
  - Backend ([`auth.py`](https://github.com/dividor/evidencelab/blob/fix/url_loss/ui/backend/routes/auth.py)) validates same-origin path, embeds it in the signed state, then decodes + re-validates on `/callback` and redirects to `APP_BASE_URL + return_to`. Falls back to `APP_BASE_URL` for any failure.

## Security posture

`return_to` lives inside the signed state JWT so users can't tamper with it, but it is **re-validated on decode anyway** (defense in depth):

- Must start with `/`
- Must not start with `//` or `/\` (rejects protocol-relative open-redirect bypass)
- Must be ≤ 2048 chars

Rejected values: `//evil.com`, `/\evil.com`, `https://evil.com`, `javascript:alert(1)`, relative paths, empty/null. Any failure falls back to `APP_BASE_URL`.

## Test plan

- [x] New backend unit tests in [`tests/unit/test_oauth.py`](https://github.com/dividor/evidencelab/blob/fix/url_loss/tests/unit/test_oauth.py): 25 tests covering `_is_safe_return_to` (positive + negative cases incl. length cap) and `_resolve_post_login_redirect` (missing state, garbage state, wrong-secret state, missing/unsafe `return_to`, base URL trailing-slash handling).
- [x] New frontend unit tests in [`OAuthButtons.test.tsx`](https://github.com/dividor/evidencelab/blob/fix/url_loss/ui/frontend/src/components/auth/OAuthButtons.test.tsx): verifies `return_to` is included in `/authorize` for both Google and Microsoft, default `/` case, and that navigation to the IdP URL still happens.
- [x] Full backend unit suite: 1304 pass (1 pre-existing failure on `test_get_rerank_model_caches`, unrelated — confirmed by stashing this change and reproducing on the unmodified branch).
- [x] Pre-commit hooks pass in Python 3.11 venv (black, isort, flake8, mypy, bandit, detect-secrets, gitleaks, code-metrics).
- [x] Manual verification in browser: opened a search-results URL with multiple query params, logged out, signed in with Google → URL params restored after callback. Same for Microsoft.

## Notes

- Targets `rc/v1.5.0` per project release-branch policy.
- No DB migrations, no new dependencies, no env vars added.