### PR TITLE
fix(assistant): preserve citations across follow-up turns

### DIFF
--- a/prompts/assistant_deep_research_coordinator.j2
+++ b/prompts/assistant_deep_research_coordinator.j2
@@ -64,3 +64,12 @@ Follow these steps for every request:
 
 You are searching documents from: {{ data_source }}
 {% endif %}
+{% if prior_sources %}
+
+## Previously cited sources
+
+The user has already seen these citation numbers in earlier turns of this conversation. They are still resolvable in the UI. Re-use these exact numbers whenever you refer to those sources — do NOT renumber. New sources returned by the researcher will be numbered starting from [{{ next_index }}].
+{% for src in prior_sources %}
+[{{ src.index }}] {{ src.title }}
+{%- endfor %}
+{% endif %}

--- a/prompts/assistant_deep_research_researcher.j2
+++ b/prompts/assistant_deep_research_researcher.j2
@@ -48,3 +48,12 @@ Summarize your findings in a clear, structured format:
 
 You are searching documents from: {{ data_source }}
 {% endif %}
+{% if prior_sources %}
+
+## Previously cited sources
+
+These citation numbers are already in use from earlier turns of this conversation. Re-use them exactly when you refer to the same sources. New results from search_documents will be numbered starting from [{{ next_index }}].
+{% for src in prior_sources %}
+[{{ src.index }}] {{ src.title }}
+{%- endfor %}
+{% endif %}

--- a/prompts/assistant_system.j2
+++ b/prompts/assistant_system.j2
@@ -51,3 +51,12 @@ IMPORTANT: Always search at least twice with different queries before writing yo
 {% if data_source %}
 You are searching documents from: {{ data_source }}
 {% endif %}
+{% if prior_sources %}
+
+## Previously cited sources
+
+The user has already seen these citation numbers in earlier turns of this conversation. They are still resolvable in the UI. Re-use these exact numbers whenever you refer to those sources — do NOT renumber. If you need to introduce new sources via search_documents, they will be numbered starting from [{{ next_index }}].
+{% for src in prior_sources %}
+[{{ src.index }}] {{ src.title }}
+{%- endfor %}
+{% endif %}

--- a/tests/unit/test_assistant_graph.py
+++ b/tests/unit/test_assistant_graph.py
@@ -36,10 +36,13 @@ from ui.backend.services.assistant_graph import (  # noqa: E402
     SearchTracker,
     _build_search_tool,
     _format_search_result,
+    _load_system_prompt,
+    _next_citation_index,
     build_research_agent,
 )
 from ui.backend.services.assistant_service import (  # noqa: E402
     _extract_finish_diagnostics,
+    _extract_prior_sources,
     _is_duplicate_or_subset,
     _is_gemini_message,
     _process_agent_output,
@@ -285,6 +288,87 @@ class TestSearchTracker:
         assert len(tracker.all_results) == 2
         assert tracker.all_results[0]["global_index"] == 1
         assert tracker.all_results[1]["global_index"] == 2
+
+    def test_prior_sources_seed_global_index_counter(self):
+        """A new turn must continue numbering from the highest prior index, not 1."""
+        _mock_search_fn.reset_mock()
+        _mock_search_fn.side_effect = None
+        _mock_search_fn.return_value = [
+            _make_scored_point("c-new", "d-new", "Fresh Doc", "T", 0.9),
+        ]
+
+        prior = [
+            {"chunkId": "c1", "docId": "d1", "title": "Doc 1", "index": 1},
+            {"chunkId": "c2", "docId": "d2", "title": "Doc 2", "index": 5},
+            {"chunkId": "c3", "docId": "d3", "title": "Doc 3", "index": 30},
+        ]
+        tracker = SearchTracker(prior_sources=prior)
+        results = tracker.search("follow-up query")
+
+        # New chunk continues from prior max (30), so gets index 31.
+        assert results[0]["global_index"] == 31
+
+    def test_prior_sources_seed_dedup_set(self):
+        """Re-retrieving a prior chunk in a follow-up turn must not double-count it."""
+        _mock_search_fn.reset_mock()
+        _mock_search_fn.side_effect = None
+        _mock_search_fn.return_value = [
+            _make_scored_point("c-prior", "d1", score=0.9),  # already in prior
+            _make_scored_point("c-new", "d2", score=0.8),  # genuinely new
+        ]
+
+        prior = [
+            {"chunkId": "c-prior", "docId": "d1", "title": "Already Cited", "index": 7},
+        ]
+        tracker = SearchTracker(prior_sources=prior)
+        tracker.search("follow-up query")
+
+        # Only the genuinely-new chunk gets added; the prior chunk is
+        # skipped by dedup. The new index continues from prior max (7+1=8).
+        assert [r["chunk_id"] for r in tracker.all_results] == ["c-new"]
+        assert tracker.all_results[0]["global_index"] == 8
+
+    def test_get_sources_merges_prior_and_new_sorted_by_index(self):
+        """get_sources() must return prior + new entries sorted by global index."""
+        _mock_search_fn.reset_mock()
+        _mock_search_fn.side_effect = None
+        _mock_search_fn.return_value = [
+            _make_scored_point("c-new", "d-new", "New Doc", "Body", 0.9),
+        ]
+
+        prior = [
+            {"chunkId": "c1", "docId": "d1", "title": "Prior 1", "index": 1},
+            {"chunkId": "c3", "docId": "d3", "title": "Prior 3", "index": 3},
+        ]
+        tracker = SearchTracker(prior_sources=prior)
+        tracker.search("follow-up")
+
+        sources = tracker.get_sources()
+        indices = [s["index"] for s in sources]
+        # 1 (prior), 3 (prior), 4 (new, since prior max was 3)
+        assert indices == [1, 3, 4]
+        # Prior entries preserved verbatim (camelCase shape).
+        assert sources[0]["title"] == "Prior 1"
+        assert sources[1]["title"] == "Prior 3"
+        assert sources[2]["title"] == "New Doc"
+
+    def test_prior_sources_default_none_keeps_existing_behavior(self):
+        """Omitting prior_sources must keep single-turn behavior unchanged."""
+        tracker = SearchTracker()
+        assert tracker.prior_sources == []
+        assert tracker._global_result_count == 0
+        assert tracker._seen_ids == set()
+
+    def test_prior_sources_ignores_non_int_index(self):
+        """Defensive: a malformed prior entry without int index must not break init."""
+        prior = [
+            {"chunkId": "c1", "docId": "d1", "title": "Bad", "index": None},
+            {"chunkId": "c2", "docId": "d2", "title": "Ok", "index": 4},
+        ]
+        tracker = SearchTracker(prior_sources=prior)
+        assert tracker._global_result_count == 4
+        # Both chunkIds still seed the dedup set.
+        assert tracker._seen_ids == {"c1", "c2"}
 
     def test_get_new_queries_returns_only_new(self):
         _mock_search_fn.reset_mock()
@@ -994,3 +1078,125 @@ class TestGetSourcesEnrichment:
         sources = tracker.get_sources()
 
         assert sources[0]["headings"] == ["Chapter 1", "Section A"]
+
+
+class TestNextCitationIndex:
+    """Tests for _next_citation_index — the index a new search result will get."""
+
+    def test_empty_or_none_starts_at_1(self):
+        assert _next_citation_index(None) == 1
+        assert _next_citation_index([]) == 1
+
+    def test_returns_one_more_than_max(self):
+        prior = [
+            {"index": 1},
+            {"index": 5},
+            {"index": 3},
+        ]
+        assert _next_citation_index(prior) == 6
+
+    def test_ignores_non_int_indices(self):
+        prior = [
+            {"index": "not an int"},
+            {"index": None},
+            {"index": 7},
+        ]
+        assert _next_citation_index(prior) == 8
+
+    def test_all_non_int_falls_back_to_1(self):
+        assert _next_citation_index([{"index": None}, {"index": "x"}]) == 1
+
+
+class TestExtractPriorSources:
+    """Tests for _extract_prior_sources — pulling sources from history."""
+
+    def test_returns_empty_for_none_or_empty(self):
+        assert _extract_prior_sources(None) == []
+        assert _extract_prior_sources([]) == []
+
+    def test_extracts_sources_from_assistant_messages_only(self):
+        history = [
+            {"role": "user", "content": "Q1", "sources": [{"index": 99}]},
+            {
+                "role": "assistant",
+                "content": "A1",
+                "sources": [{"index": 1, "title": "T"}],
+            },
+        ]
+        result = _extract_prior_sources(history)
+        assert [s["index"] for s in result] == [1]
+
+    def test_dedupes_across_turns_by_index(self):
+        """A citation re-cited in turn 2 must appear only once."""
+        history = [
+            {
+                "role": "assistant",
+                "content": "A1",
+                "sources": [
+                    {"index": 1, "title": "T1"},
+                    {"index": 2, "title": "T2"},
+                ],
+            },
+            {"role": "user", "content": "Q2"},
+            {
+                "role": "assistant",
+                "content": "A2",
+                "sources": [
+                    {
+                        "index": 2,
+                        "title": "T2 (latest)",
+                    },  # duplicate index — latest wins
+                    {"index": 3, "title": "T3"},
+                ],
+            },
+        ]
+        result = _extract_prior_sources(history)
+        assert [s["index"] for s in result] == [1, 2, 3]
+        # Last-write-wins lets the most recent message refine an entry if needed.
+        assert result[1]["title"] == "T2 (latest)"
+
+    def test_ignores_assistant_messages_without_sources(self):
+        history = [
+            {"role": "assistant", "content": "A1"},  # no sources key at all
+            {"role": "assistant", "content": "A2", "sources": []},  # empty list
+            {"role": "assistant", "content": "A3", "sources": None},  # explicit None
+        ]
+        assert _extract_prior_sources(history) == []
+
+    def test_ignores_sources_with_non_int_index(self):
+        history = [
+            {
+                "role": "assistant",
+                "content": "A1",
+                "sources": [
+                    {"index": "abc", "title": "Bad"},
+                    {"index": 2, "title": "Good"},
+                ],
+            },
+        ]
+        result = _extract_prior_sources(history)
+        assert [s["index"] for s in result] == [2]
+
+
+class TestLoadSystemPromptPriorSources:
+    """Tests for _load_system_prompt's prior-sources block."""
+
+    def test_no_prior_sources_omits_block(self):
+        prompt = _load_system_prompt(data_source="wfp")
+        assert "Previously cited sources" not in prompt
+
+    def test_with_prior_sources_includes_block_and_titles(self):
+        prior = [
+            {"index": 1, "title": "Eval of Climate Policies"},
+            {"index": 2, "title": "Resilience Programme Report"},
+        ]
+        prompt = _load_system_prompt(data_source="wfp", prior_sources=prior)
+        assert "Previously cited sources" in prompt
+        assert "[1] Eval of Climate Policies" in prompt
+        assert "[2] Resilience Programme Report" in prompt
+
+    def test_with_prior_sources_advertises_next_index(self):
+        prior = [{"index": 7, "title": "T"}]
+        prompt = _load_system_prompt(data_source="wfp", prior_sources=prior)
+        # New search results should be numbered starting from [8].
+        assert "[8]" in prompt

--- a/tests/unit/test_assistant_routes.py
+++ b/tests/unit/test_assistant_routes.py
@@ -598,3 +598,55 @@ class TestSearchSettingsPassthrough:
         assert settings["field_boost_enabled"] is True
         assert settings["field_boost_fields"] == {"country": 0.5}
         assert settings["dense_weight"] == 0.7
+
+
+class TestMessageToHistoryEntry:
+    """Tests for _message_to_history_entry — the pure shape mapper used by
+    _load_conversation_history when projecting ConversationMessage rows
+    onto the history dict that the agent consumes.
+    """
+
+    def _import_helper(self):
+        # Imported lazily so the module-level mocks at the top of this
+        # file are in place when ui.backend.routes.assistant is first
+        # imported by other tests.
+        from ui.backend.routes.assistant import _message_to_history_entry
+
+        return _message_to_history_entry
+
+    def test_user_entry_never_has_sources(self):
+        helper = self._import_helper()
+        msg = MagicMock(
+            role="user", content="hello", sources={"citations": [{"index": 1}]}
+        )
+        entry = helper(msg)
+        assert entry == {"role": "user", "content": "hello"}
+
+    def test_assistant_entry_with_citations(self):
+        helper = self._import_helper()
+        citations = [{"index": 1, "title": "T1"}, {"index": 2, "title": "T2"}]
+        msg = MagicMock(
+            role="assistant", content="answer", sources={"citations": citations}
+        )
+        entry = helper(msg)
+        assert entry == {"role": "assistant", "content": "answer", "sources": citations}
+
+    def test_assistant_entry_with_no_sources_column(self):
+        helper = self._import_helper()
+        msg = MagicMock(role="assistant", content="answer", sources=None)
+        entry = helper(msg)
+        # No sources key at all — keeps the wire shape minimal.
+        assert entry == {"role": "assistant", "content": "answer"}
+
+    def test_assistant_entry_with_empty_citations_list(self):
+        helper = self._import_helper()
+        msg = MagicMock(role="assistant", content="answer", sources={"citations": []})
+        entry = helper(msg)
+        assert entry == {"role": "assistant", "content": "answer"}
+
+    def test_assistant_entry_with_non_dict_sources_column(self):
+        helper = self._import_helper()
+        # Defensive: legacy rows may have stored a different shape.
+        msg = MagicMock(role="assistant", content="answer", sources={"foo": "bar"})
+        entry = helper(msg)
+        assert entry == {"role": "assistant", "content": "answer"}

--- a/ui/backend/auth/schemas.py
+++ b/ui/backend/auth/schemas.py
@@ -483,9 +483,14 @@ class AssistantChatRequest(BaseModel):
     reranker_model: Optional[str] = None
     search_settings: Optional[AssistantSearchSettings] = None
     deep_research: bool = False
-    conversation_history: Optional[List[Dict[str, str]]] = Field(
+    conversation_history: Optional[List[Dict[str, Any]]] = Field(
         None,
-        description="Prior conversation messages for unauthenticated users",
+        description=(
+            "Prior conversation messages for unauthenticated users. Each "
+            "entry has 'role' and 'content'; assistant entries may also "
+            "carry 'sources' so citation numbers stay resolvable across "
+            "follow-up turns."
+        ),
     )
 
 

--- a/ui/backend/routes/assistant.py
+++ b/ui/backend/routes/assistant.py
@@ -127,6 +127,22 @@ def _resolve_model_config(body: AssistantChatRequest):
     )
 
 
+def _message_to_history_entry(msg) -> dict:
+    """Convert a ``ConversationMessage`` row to the history-dict shape.
+
+    Assistant entries carry their persisted ``sources`` (the citations
+    list previously emitted on the SSE ``sources`` event) so the agent
+    can re-use the same global citation numbers in follow-up turns
+    instead of restarting from [1]. User entries never carry sources.
+    """
+    entry: dict = {"role": msg.role, "content": msg.content}
+    if msg.role == "assistant":
+        sources = (msg.sources or {}).get("citations")
+        if sources:
+            entry["sources"] = sources
+    return entry
+
+
 async def _load_conversation_history(body, user, session):
     """Load prior messages for a thread, returning a list of dicts."""
     if not (body.thread_id and _USER_MODULE and user and session):
@@ -140,7 +156,7 @@ async def _load_conversation_history(body, user, session):
         )
         result = await session.execute(stmt)
         msgs = result.scalars().all()
-        return [{"role": m.role, "content": m.content} for m in msgs]
+        return [_message_to_history_entry(m) for m in msgs]
     except Exception as exc:
         logger.warning("Failed to load thread history: %s", exc)
         return []

--- a/ui/backend/services/assistant_graph.py
+++ b/ui/backend/services/assistant_graph.py
@@ -67,6 +67,7 @@ class SearchTracker:
         data_source: Optional[str] = None,
         reranker_model: Optional[str] = None,
         search_settings: Optional[Dict[str, Any]] = None,
+        prior_sources: Optional[List[Dict[str, Any]]] = None,
     ):
         self.data_source = data_source
         self.reranker_model = reranker_model
@@ -76,6 +77,18 @@ class SearchTracker:
         self._seen_ids: set = set()
         self._emitted_query_count: int = 0
         self._global_result_count: int = 0
+        # Sources carried over from earlier turns in this conversation, in
+        # the SSE/persistence shape (camelCase: chunkId, docId, title, ...,
+        # index). Seeds dedup + index counter so global_index is genuinely
+        # global across the whole thread, not reset per turn.
+        self.prior_sources: List[Dict[str, Any]] = list(prior_sources or [])
+        for s in self.prior_sources:
+            cid = s.get("chunkId")
+            if cid:
+                self._seen_ids.add(cid)
+            idx = s.get("index")
+            if isinstance(idx, int) and idx > self._global_result_count:
+                self._global_result_count = idx
         # Field boost state — lazily initialised on first search
         self._field_boost_fields = self.search_settings.get("field_boost_fields")
         self._field_boost_enabled = bool(
@@ -330,17 +343,15 @@ class SearchTracker:
     def get_sources(self) -> List[Dict[str, Any]]:
         """Build source references from accumulated results.
 
-        Returns all results (not deduplicated by doc_id) so that each
-        global citation index maps to exactly one entry.  Results are
-        ordered by their global index so the frontend can look up
-        ``sources[N-1]`` for citation ``[N]``.
+        Returns prior-turn sources merged with this turn's new results, in
+        the SSE/persistence shape, ordered by global index. Including
+        prior sources lets the frontend resolve citation markers carried
+        over from earlier assistant messages — e.g. when a follow-up
+        question asks for a summary of the previous answer without
+        triggering any new search.
         """
-        ordered = sorted(
-            self.all_results,
-            key=lambda x: x.get("global_index", 0),
-        )
-        sources: List[Dict[str, Any]] = []
-        for r in ordered:
+        new_sources: List[Dict[str, Any]] = []
+        for r in self.all_results:
             text = r.get("text", "")
             entry: Dict[str, Any] = {
                 "chunkId": r.get("chunk_id", ""),
@@ -354,8 +365,9 @@ class SearchTracker:
             }
             if r.get("bbox"):
                 entry["bbox"] = r["bbox"]
-            sources.append(entry)
-        return sources
+            new_sources.append(entry)
+        combined = list(self.prior_sources) + new_sources
+        return sorted(combined, key=lambda x: x.get("index") or 0)
 
 
 def _build_search_tool(tracker: SearchTracker):
@@ -397,10 +409,35 @@ def _build_search_tool(tracker: SearchTracker):
     return search_documents
 
 
-def _load_system_prompt(data_source: Optional[str] = None) -> str:
-    """Load and render the assistant system prompt."""
+def _load_system_prompt(
+    data_source: Optional[str] = None,
+    prior_sources: Optional[List[Dict[str, Any]]] = None,
+) -> str:
+    """Load and render the assistant system prompt.
+
+    When ``prior_sources`` is non-empty, the template emits a block
+    listing the citation numbers already used in earlier turns of the
+    conversation so the model re-uses them instead of restarting from
+    ``[1]``.
+    """
     template = _jinja_env.get_template("assistant_system.j2")
-    return template.render(data_source=data_source)
+    return template.render(
+        data_source=data_source,
+        prior_sources=prior_sources or [],
+        next_index=_next_citation_index(prior_sources),
+    )
+
+
+def _next_citation_index(prior_sources: Optional[List[Dict[str, Any]]]) -> int:
+    """Compute the citation index a new search result would receive."""
+    if not prior_sources:
+        return 1
+    int_indices: List[int] = []
+    for s in prior_sources:
+        idx = s.get("index")
+        if isinstance(idx, int):
+            int_indices.append(idx)
+    return (max(int_indices) + 1) if int_indices else 1
 
 
 def build_research_agent(
@@ -409,6 +446,7 @@ def build_research_agent(
     reranker_model: Optional[str] = None,
     search_settings: Optional[Dict[str, Any]] = None,
     system_prompt_override: Optional[str] = None,
+    prior_sources: Optional[List[Dict[str, Any]]] = None,
 ) -> tuple:
     """
     Build a deep research agent.
@@ -419,6 +457,9 @@ def build_research_agent(
         reranker_model: Optional reranker model key from UI model combo
         search_settings: Optional search parameters (dense_weight, boosts, etc.)
         system_prompt_override: Optional group prompt to append to base prompt
+        prior_sources: Sources cited in earlier turns of this conversation
+            (SSE/persistence shape, keyed by camelCase). Seeds the search
+            tracker so global citation indices remain stable across turns.
 
     Returns:
         Tuple of (compiled_agent, search_tracker)
@@ -430,10 +471,11 @@ def build_research_agent(
         data_source=data_source,
         reranker_model=reranker_model,
         search_settings=search_settings,
+        prior_sources=prior_sources,
     )
     tracker.MAX_SEARCHES = max_queries
     search_tool = _build_search_tool(tracker)
-    system_prompt = _load_system_prompt(data_source)
+    system_prompt = _load_system_prompt(data_source, prior_sources=prior_sources)
 
     if system_prompt_override:
         system_prompt = (
@@ -460,18 +502,32 @@ def build_research_agent(
     return agent, tracker
 
 
-def _load_deep_research_prompt(data_source: Optional[str] = None) -> str:
+def _load_deep_research_prompt(
+    data_source: Optional[str] = None,
+    prior_sources: Optional[List[Dict[str, Any]]] = None,
+) -> str:
     """Load and render the deep research coordinator prompt."""
     template = _jinja_env.get_template("assistant_deep_research_coordinator.j2")
-    return template.render(data_source=data_source)
+    return template.render(
+        data_source=data_source,
+        prior_sources=prior_sources or [],
+        next_index=_next_citation_index(prior_sources),
+    )
 
 
 def _load_researcher_prompt(
-    data_source: Optional[str] = None, max_queries: int = 10
+    data_source: Optional[str] = None,
+    max_queries: int = 10,
+    prior_sources: Optional[List[Dict[str, Any]]] = None,
 ) -> str:
     """Load and render the deep research researcher sub-agent prompt."""
     template = _jinja_env.get_template("assistant_deep_research_researcher.j2")
-    return template.render(data_source=data_source, max_queries=max_queries)
+    return template.render(
+        data_source=data_source,
+        max_queries=max_queries,
+        prior_sources=prior_sources or [],
+        next_index=_next_citation_index(prior_sources),
+    )
 
 
 def build_deep_research_agent(
@@ -480,6 +536,7 @@ def build_deep_research_agent(
     reranker_model: Optional[str] = None,
     search_settings: Optional[Dict[str, Any]] = None,
     system_prompt_override: Optional[str] = None,
+    prior_sources: Optional[List[Dict[str, Any]]] = None,
 ) -> tuple:
     """Build a deep research agent with sub-agent delegation.
 
@@ -498,13 +555,18 @@ def build_deep_research_agent(
         data_source=data_source,
         reranker_model=reranker_model,
         search_settings=search_settings,
+        prior_sources=prior_sources,
     )
     tracker.MAX_SEARCHES = max_queries
 
     search_tool = _build_search_tool(tracker)
 
-    coordinator_prompt = _load_deep_research_prompt(data_source)
-    researcher_prompt = _load_researcher_prompt(data_source, max_queries=max_queries)
+    coordinator_prompt = _load_deep_research_prompt(
+        data_source, prior_sources=prior_sources
+    )
+    researcher_prompt = _load_researcher_prompt(
+        data_source, max_queries=max_queries, prior_sources=prior_sources
+    )
 
     if system_prompt_override:
         coordinator_prompt = (

--- a/ui/backend/services/assistant_service.py
+++ b/ui/backend/services/assistant_service.py
@@ -47,7 +47,7 @@ def _get_langsmith_trace_url(run_id: uuid_mod.UUID) -> Optional[str]:
 
 def _build_conversation_messages(
     query: str,
-    conversation_messages: Optional[List[Dict[str, str]]] = None,
+    conversation_messages: Optional[List[Dict[str, Any]]] = None,
 ) -> List:
     """Build LangChain message objects from conversation history."""
     messages: List = []
@@ -61,6 +61,29 @@ def _build_conversation_messages(
                 messages.append(AIMessage(content=content))
     messages.append(HumanMessage(content=query))
     return messages
+
+
+def _extract_prior_sources(
+    conversation_messages: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Collect every cited source from prior assistant turns, deduped by index.
+
+    Sources are stored per-message in the SSE/persistence shape and carry
+    a stable ``index`` (the global citation number). Merging by index keeps
+    one entry per citation across the whole thread so a follow-up turn can
+    re-use those numbers without renumbering.
+    """
+    if not conversation_messages:
+        return []
+    by_idx: Dict[int, Dict[str, Any]] = {}
+    for msg in conversation_messages:
+        if msg.get("role") != "assistant":
+            continue
+        for src in msg.get("sources") or []:
+            idx = src.get("index")
+            if isinstance(idx, int):
+                by_idx[idx] = src
+    return [by_idx[k] for k in sorted(by_idx.keys())]
 
 
 def _build_done_event(run_id: uuid_mod.UUID) -> Dict[str, Any]:
@@ -297,6 +320,7 @@ async def stream_research_response(
             temperature=temperature,
             max_tokens=max_tokens,
         )
+        prior_sources = _extract_prior_sources(conversation_messages)
         builder = build_deep_research_agent if deep_research else build_research_agent
         agent, tracker = builder(
             llm,
@@ -304,8 +328,15 @@ async def stream_research_response(
             reranker_model,
             search_settings,
             system_prompt_override=system_prompt_override,
+            prior_sources=prior_sources,
         )
         messages = _build_conversation_messages(query, conversation_messages)
+        if prior_sources:
+            logger.info(
+                "[deepres] prior_sources: count=%d max_index=%d",
+                len(prior_sources),
+                max((s.get("index") or 0) for s in prior_sources),
+            )
         cfg = _get_assistant_config()
         if deep_research:
             deep_cfg = cfg.get("deep_research", {})

--- a/ui/frontend/src/components/assistant/AssistantTab.tsx
+++ b/ui/frontend/src/components/assistant/AssistantTab.tsx
@@ -296,7 +296,16 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
       // backend can maintain context across messages (including when the
       // user toggles deep research mid-conversation).
       const history = !isAuthenticated && messages.length > 0
-        ? messages.map((m) => ({ role: m.role, content: m.content }))
+        ? messages.map((m) => {
+            const entry: { role: string; content: string; sources?: SourceReference[] } = {
+              role: m.role,
+              content: m.content,
+            };
+            if (m.role === 'assistant' && m.sources && m.sources.length > 0) {
+              entry.sources = m.sources;
+            }
+            return entry;
+          })
         : undefined;
 
       await streamAssistantChat({

--- a/ui/frontend/src/utils/assistantStream.ts
+++ b/ui/frontend/src/utils/assistantStream.ts
@@ -21,6 +21,9 @@ export interface AssistantStreamHandlers {
 interface ConversationMessage {
   role: string;
   content: string;
+  // Assistant messages also carry their previously emitted sources so the
+  // backend can re-use the same citation numbers in follow-up turns.
+  sources?: SourceReference[];
 }
 
 interface AssistantStreamOptions {


### PR DESCRIPTION
## Summary

The assistant's first answer in a chat cites correctly, but follow-up answers either show dead citation markers or have `[N]` resolve to a different chunk than the user originally saw. This fixes that by making the citation index genuinely global across the conversation — the way the system prompt has always claimed it was.

## Why it was broken

Two root causes:

1. **`SearchTracker` reset on every turn.** `_global_result_count` started at 0 and `_seen_ids` was empty on each new request, so turn 2's `[1]` referred to a brand-new chunk while the model — trusting the system prompt's promise that *"indices are GLOBAL across all searches — they never restart"* — happily reused turn-1's numbers.
2. **The SSE `sources` event was skipped on no-search turns.** A follow-up like *"summarize that"* doesn't trigger a new search, so `tracker.all_results` was empty, the sources event was suppressed, and the synthesis's inherited `[N]` markers had nothing to resolve against.

Reproduced with curl: turn 3 (\"Summarize your previous answer\") returned 20 inline citations with **zero** sources attached.

## What changed

### Backend
- `SearchTracker.__init__` accepts `prior_sources` and seeds `_seen_ids` + `_global_result_count` from them. Same chunk re-retrieved in turn 2 keeps its turn-1 number; new chunks continue from `prior_max + 1`.
- `get_sources()` merges prior + new entries, sorted by index — so the SSE event always carries every citation the synthesis references, even when no new search ran.
- `_load_conversation_history` (authenticated path) and `conversation_history` (unauthenticated path) now carry assistant messages' persisted sources back into the agent. `_message_to_history_entry` extracted as a pure helper for testability.
- `AssistantChatRequest.conversation_history` widened to `List[Dict[str, Any]]`.
- New helper `_extract_prior_sources` dedups across turns by `index` (last-write-wins).

### Prompts
All three templates gain a "Previously cited sources" block listing `[index] title` and announcing the next free index:
- `prompts/assistant_system.j2`
- `prompts/assistant_deep_research_coordinator.j2`
- `prompts/assistant_deep_research_researcher.j2`

### Frontend
- `AssistantTab.tsx`: unauthenticated history payload now forwards each assistant message's `sources`.
- `assistantStream.ts`: `ConversationMessage.sources?: SourceReference[]` added to the type.

### Tests (+22)
- `TestSearchTracker` — prior-source seeding, dedup-on-re-retrieval, merged `get_sources()`, default behaviour, malformed-index handling.
- `TestNextCitationIndex`, `TestExtractPriorSources`, `TestLoadSystemPromptPriorSources`, `TestMessageToHistoryEntry`.

## Verification

**Live end-to-end (WFP collection):**

| Turn | Query | Result |
|---|---|---|
| 1 | "What does WFP say about climate change…" | 30 sources, `[1]..[30]` ✅ |
| 2 | "Tell me more about that task force…" (re-search) | 30 prior preserved + 17 new (indices 31–47), all citations resolve ✅ |
| 3 | "Summarize your previous answer…" (no new search) | Sources event emitted with all 30 prior sources, all inline citations resolve ✅ |

**Local checks:**
- \`pytest tests/unit/\` → 1302 passed, 1 skipped
- \`pre-commit run --files <staged>\` → all hooks pass (black, isort, flake8, mypy, bandit, code-metrics, secrets)

## Test plan
- [ ] Open a fresh chat, ask a multi-part question that returns sources
- [ ] Ask a follow-up that requires new searches — verify new sources are numbered continuing from where turn 1 ended, and clicking any `[N]` opens the expected document
- [ ] Ask a summarising follow-up that should not trigger a new search — verify citations still resolve and clicking them opens the same documents the original turn cited
- [ ] Reload the page mid-thread (authenticated) — verify both messages' citations still resolve after history hydration
- [ ] Try the same in deep-research mode (slower; coordinator + researcher both received the prompt update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)