### PR TITLE
feat(backup): validate the postgres dump archive with pg_restore before declaring success

### DIFF
--- a/scripts/sync/db/dump_postgres.py
+++ b/scripts/sync/db/dump_postgres.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import logging
 import os
+import shlex
 import subprocess
 from datetime import datetime
 from pathlib import Path
@@ -52,6 +53,63 @@ def _get_valid_data_sources(root_dir: Path) -> List[str]:
     ]
 
 
+def _validate_dump_archive(
+    *,
+    root_dir: Path,
+    use_prod: bool,
+    dump_path: Path,
+) -> None:
+    """Validate that the custom-format dump can be read by pg_restore.
+
+    Catches truncated / incomplete dumps early (broken pipe or EOF during
+    write would otherwise produce a file that ``pg_dump`` exited cleanly
+    on but ``pg_restore`` can't read). The validation copies the dump
+    into the postgres container at a scratch path under the data dir
+    (writable by the postgres user, and not under ``/tmp`` so bandit's
+    insecure-tmp check doesn't trip without resorting to ``# nosec``),
+    runs ``pg_restore -l`` against it, and removes the scratch copy on
+    the way out — even if validation fails.
+    """
+    compose_cmd = _compose_base_command(use_prod)
+    dump_name = dump_path.name
+    container_dump_path = f"/var/lib/postgresql/data/_dump_validate_{dump_name}"
+
+    copy_cmd = (
+        f"{compose_cmd} cp {shlex.quote(str(dump_path))} "
+        f"postgres:{shlex.quote(container_dump_path)}"
+    )
+    copy_result = subprocess.run(copy_cmd, shell=True, cwd=root_dir)  # nosec B602
+    if copy_result.returncode != 0:
+        raise RuntimeError(
+            "Postgres dump validation failed: could not copy dump into container."
+        )
+
+    try:
+        validate_cmd = (
+            f"{compose_cmd} exec -T postgres "
+            f"pg_restore -l {shlex.quote(container_dump_path)}"
+        )
+        validate_result = subprocess.run(
+            validate_cmd,
+            shell=True,
+            cwd=root_dir,
+            capture_output=True,
+            text=True,
+        )  # nosec B602
+        if validate_result.returncode != 0:
+            stderr = (validate_result.stderr or "").strip()
+            raise RuntimeError(
+                "Postgres dump validation failed: pg_restore could not read "
+                f"archive. {stderr}"
+            )
+    finally:
+        cleanup_cmd = (
+            f"{compose_cmd} exec -T postgres "
+            f"rm -f {shlex.quote(container_dump_path)}"
+        )
+        subprocess.run(cleanup_cmd, shell=True, cwd=root_dir)  # nosec B602
+
+
 def dump_postgres(
     *,
     root_dir: Path,
@@ -97,6 +155,13 @@ def dump_postgres(
 
     if dump_path.stat().st_size == 0:
         raise RuntimeError("Postgres dump is empty.")
+
+    logger.info("Validating dump archive readability with pg_restore...")
+    _validate_dump_archive(
+        root_dir=root_dir,
+        use_prod=use_prod,
+        dump_path=dump_path,
+    )
 
     logger.info("Backup location: %s", backup_dir)
     return backup_dir

--- a/tests/unit/test_dump_postgres_validation.py
+++ b/tests/unit/test_dump_postgres_validation.py
@@ -1,0 +1,118 @@
+"""Unit tests for ``_validate_dump_archive`` in scripts/sync/db/dump_postgres.py.
+
+The function copies a dump into the postgres container, runs ``pg_restore -l``
+against it, and cleans up — even on failure. Tests stub ``subprocess.run`` so
+they execute without a real docker compose stack.
+"""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "sync" / "db" / "dump_postgres.py"
+)
+_spec = importlib.util.spec_from_file_location("dump_postgres", _SCRIPT_PATH)
+dump_postgres = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dump_postgres)
+
+
+def _ok(_returncode: int = 0):
+    """Helper: build a CompletedProcess that succeeded."""
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def _fail(stderr: str = "boom"):
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+@pytest.mark.unit
+class TestValidateDumpArchive:
+    def test_passes_when_copy_and_pg_restore_both_succeed(self, tmp_path):
+        dump = tmp_path / "postgres.dump"
+        dump.write_bytes(b"placeholder")
+
+        with patch.object(dump_postgres.subprocess, "run") as run:
+            run.side_effect = [_ok(), _ok(), _ok()]  # copy, pg_restore -l, cleanup
+            dump_postgres._validate_dump_archive(
+                root_dir=tmp_path, use_prod=False, dump_path=dump
+            )
+        assert run.call_count == 3
+
+    def test_uses_data_dir_scratch_path_not_tmp(self, tmp_path):
+        """Bandit B108 flags /tmp/ paths even inside containers; the
+        validator must use a writable non-tmp path so the public repo
+        doesn't carry a # nosec suppression."""
+        dump = tmp_path / "postgres.dump"
+        dump.write_bytes(b"placeholder")
+        with patch.object(dump_postgres.subprocess, "run") as run:
+            run.side_effect = [_ok(), _ok(), _ok()]
+            dump_postgres._validate_dump_archive(
+                root_dir=tmp_path, use_prod=False, dump_path=dump
+            )
+        # First call is the docker compose cp; assert the IN-CONTAINER
+        # destination is the data dir, not /tmp/. The host source path
+        # may legitimately be /tmp/* (pytest's tmp_path), so we only
+        # check the part after the ``postgres:`` container prefix.
+        first_cmd = run.call_args_list[0].args[0]
+        assert "/var/lib/postgresql/data/_dump_validate_postgres.dump" in first_cmd
+        container_dest = first_cmd.split("postgres:", 1)[1]
+        assert not container_dest.startswith("/tmp/")
+
+    def test_raises_when_copy_into_container_fails(self, tmp_path):
+        dump = tmp_path / "postgres.dump"
+        dump.write_bytes(b"placeholder")
+        with patch.object(dump_postgres.subprocess, "run") as run:
+            run.side_effect = [_fail("docker daemon down")]
+            with pytest.raises(
+                RuntimeError, match="could not copy dump into container"
+            ):
+                dump_postgres._validate_dump_archive(
+                    root_dir=tmp_path, use_prod=False, dump_path=dump
+                )
+
+    def test_raises_when_pg_restore_rejects_archive(self, tmp_path):
+        dump = tmp_path / "postgres.dump"
+        dump.write_bytes(b"placeholder")
+        with patch.object(dump_postgres.subprocess, "run") as run:
+            run.side_effect = [
+                _ok(),  # copy
+                _fail("pg_restore: [archiver] unexpected end of file"),
+                _ok(),  # cleanup still runs in finally
+            ]
+            with pytest.raises(RuntimeError, match="pg_restore could not read"):
+                dump_postgres._validate_dump_archive(
+                    root_dir=tmp_path, use_prod=False, dump_path=dump
+                )
+        # Cleanup MUST run even on validation failure — three calls total.
+        assert run.call_count == 3
+        cleanup_cmd = run.call_args_list[2].args[0]
+        assert "rm -f" in cleanup_cmd
+        assert "_dump_validate_postgres.dump" in cleanup_cmd
+
+    def test_cleanup_runs_even_when_pg_restore_raises(self, tmp_path):
+        """An exception during the pg_restore subprocess (not a non-zero
+        exit) still needs the cleanup step to fire — the finally block
+        must always run."""
+        dump = tmp_path / "postgres.dump"
+        dump.write_bytes(b"placeholder")
+        calls = []
+
+        def fake_run(cmd, *_args, **_kwargs):
+            calls.append(cmd)
+            if len(calls) == 1:
+                return _ok()  # copy
+            if len(calls) == 2:
+                raise OSError("pg_restore went sideways")
+            return _ok()  # cleanup
+
+        with patch.object(dump_postgres.subprocess, "run", side_effect=fake_run):
+            with pytest.raises(OSError, match="pg_restore went sideways"):
+                dump_postgres._validate_dump_archive(
+                    root_dir=tmp_path, use_prod=False, dump_path=dump
+                )
+        assert len(calls) == 3
+        assert "rm -f" in calls[2]


### PR DESCRIPTION
## Why

\`pg_dump\` can exit cleanly while having produced a truncated or otherwise unreadable custom-format archive — most commonly when the stdout pipe to the host backup file is broken mid-write. The current \`dump_postgres\` only catches the obvious failure modes (non-zero exit, empty file), so a silently-corrupted dump can sit in the backup dir until a restore tries to read it and fails.

## What

New \`_validate_dump_archive\` step runs immediately after the dump:

1. \`docker compose cp\` the dump into the postgres container at \`/var/lib/postgresql/data/_dump_validate_<name>\`. The data-dir scratch path is writable by the postgres user *and* not under \`/tmp/\` — avoids bandit B108 without resorting to a \`# nosec\` suppression.
2. \`pg_restore -l <path>\` reads the archive header and TOC. Truncated dumps fail loudly here.
3. In-container scratch copy is removed in a \`finally\` block so failed validation still cleans up.

A \`RuntimeError\` from validation propagates to the caller — corrupt dumps surface at backup time, not restore time.

## Test plan

- [x] \`pytest tests/unit/test_dump_postgres_validation.py\` — 5 passed:
  - Happy path (copy → validate → cleanup, 3 subprocess calls in order)
  - In-container destination is the data dir, not \`/tmp/\` (regression guard for bandit B108)
  - Copy failure raises with a clear message
  - \`pg_restore\` rejection raises with stderr included **and** cleanup still runs
  - Exception during \`pg_restore\` still triggers the cleanup step (finally semantics)
- [x] pre-commit clean (black, isort, flake8, bandit, code-metrics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)