### PR TITLE
feat(ratings): admin response field for triage tracking

### DIFF
--- a/alembic/versions/0026_add_rating_response.py
+++ b/alembic/versions/0026_add_rating_response.py
@@ -14,16 +14,20 @@ rating directly in the same table:
 
 An index on ``response_status`` supports the admin grid's filter.
 
-Revision ID: 0026_add_response_to_user_ratings
+Revision ID: 0026_add_rating_response
 Revises: 0025_merge_0024_heads
 Create Date: 2026-05-20
+
+Note: the revision ID is intentionally kept under 32 characters to fit
+the stock ``alembic_version.version_num`` column type (``varchar(32)``)
+used by CI and fresh databases.
 """
 
 import sqlalchemy as sa
 
 from alembic import op
 
-revision = "0026_add_response_to_user_ratings"
+revision = "0026_add_rating_response"
 down_revision = "0025_merge_0024_heads"
 branch_labels = None
 depends_on = None

--- a/alembic/versions/0026_add_response_to_user_ratings.py
+++ b/alembic/versions/0026_add_response_to_user_ratings.py
@@ -1,0 +1,78 @@
+"""Add response columns to user_ratings for admin triage.
+
+Adds four columns so superusers can record an action taken on each
+rating directly in the same table:
+
+- ``response_status``  : short string (open / acknowledged /
+  info_needed / resolved / wontfix). Validated at the Pydantic layer,
+  not by a DB CHECK constraint, so new values can be added without a
+  migration.
+- ``response_notes``   : optional free-text follow-up.
+- ``responded_by_user_id`` : FK to ``users.id`` (SET NULL on delete) —
+  who recorded the response.
+- ``responded_at``     : timestamp the response was last edited.
+
+An index on ``response_status`` supports the admin grid's filter.
+
+Revision ID: 0026_add_response_to_user_ratings
+Revises: 0025_merge_0024_heads
+Create Date: 2026-05-20
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0026_add_response_to_user_ratings"
+down_revision = "0025_merge_0024_heads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_ratings",
+        sa.Column("response_status", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "user_ratings",
+        sa.Column("response_notes", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "user_ratings",
+        sa.Column(
+            "responded_by_user_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "user_ratings",
+        sa.Column("responded_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_user_ratings_responded_by_user_id",
+        "user_ratings",
+        "users",
+        ["responded_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_user_ratings_response_status",
+        "user_ratings",
+        ["response_status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_ratings_response_status", table_name="user_ratings")
+    op.drop_constraint(
+        "fk_user_ratings_responded_by_user_id",
+        "user_ratings",
+        type_="foreignkey",
+    )
+    op.drop_column("user_ratings", "responded_at")
+    op.drop_column("user_ratings", "responded_by_user_id")
+    op.drop_column("user_ratings", "response_notes")
+    op.drop_column("user_ratings", "response_status")

--- a/docs/using-evidence-lab/ratings-feedback.md
+++ b/docs/using-evidence-lab/ratings-feedback.md
@@ -66,10 +66,20 @@ Administrators can view all user ratings from the **Admin Panel → Ratings** ta
 
 The Ratings panel provides:
 
-- **Search** — filter by email, reference ID, or comment text
-- **Column filters** — filter by Type (search result, AI summary, document summary, taxonomy), Score (1–5), or User
-- **Sortable columns** — sort by date, user, type, or score
+- **Search** — filter by email, reference ID, comment, or response notes
+- **Column filters** — filter by Type (search result, AI summary, document summary, taxonomy), Score (1–5), User, or Response status
+- **Sortable columns** — sort by date, user, type, score, or response status
 - **Expandable rows** — click any row to see the full context: the query, AI summary, search results, and timing data that were captured when the rating was given
 - **Export to Excel** — click **"Download Ratings"** to export all ratings as an XLSX file
 
-The export includes: Date, User Email, User Name, Type, Score, Reference ID, Item ID, Comment, and URL.
+### Responding to Ratings (Admin)
+
+Each rating row carries an **admin response** so reviewers can record the action taken without leaving the table. Click a row to expand it; the response form sits at the top of the expanded panel:
+
+- **Status** — pick one of **Open**, **Acknowledged**, **Info needed**, **Resolved**, or **Won't fix**. Rows render a color-coded chip in the Response column so the queue is easy to scan. Untouched rows show an em-dash.
+- **Notes** — optional free-text follow-up (up to 4000 characters). Stored alongside the status and searchable from the top search bar.
+- **Save** — persists the change and stamps the row with who responded and when. The audit footer below the form shows the last responder's email and timestamp.
+
+You can clear a response by setting the status back to **— No status —** and emptying the notes; the audit fields are cleared with it.
+
+The export includes: Date, User Email, User Name, Type, Score, Reference ID, Item ID, Comment, URL, Response Status, Response Notes, Responded By, and Responded At.

--- a/tests/unit/test_ratings.py
+++ b/tests/unit/test_ratings.py
@@ -5,7 +5,13 @@ import uuid
 import pytest
 from pydantic import ValidationError
 
-from ui.backend.auth.schemas import VALID_RATING_TYPES, RatingCreate, RatingRead
+from ui.backend.auth.schemas import (
+    VALID_RATING_TYPES,
+    VALID_RESPONSE_STATUSES,
+    RatingCreate,
+    RatingRead,
+    RatingResponseUpdate,
+)
 
 
 class TestRatingCreate:
@@ -205,3 +211,68 @@ class TestValidRatingTypes:
         """All types should be strings."""
         for t in VALID_RATING_TYPES:
             assert isinstance(t, str)
+
+
+class TestRatingResponseUpdate:
+    """Tests for the RatingResponseUpdate admin-triage schema."""
+
+    def test_accepts_all_valid_statuses(self):
+        """Every value in VALID_RESPONSE_STATUSES must be accepted."""
+        for status in VALID_RESPONSE_STATUSES:
+            payload = RatingResponseUpdate(response_status=status)
+            assert payload.response_status == status
+
+    def test_rejects_unknown_status(self):
+        """Unknown status values raise ValidationError."""
+        with pytest.raises(ValidationError) as exc:
+            RatingResponseUpdate(response_status="bogus")
+        assert "response_status must be one of" in str(exc.value)
+
+    def test_empty_string_normalized_to_none(self):
+        """Empty string status normalizes to None so callers can clear it."""
+        payload = RatingResponseUpdate(response_status="")
+        assert payload.response_status is None
+
+    def test_none_status_allowed(self):
+        """Explicitly passing None clears the status."""
+        payload = RatingResponseUpdate(response_status=None, response_notes=None)
+        assert payload.response_status is None
+        assert payload.response_notes is None
+
+    def test_notes_only_without_status(self):
+        """Notes can be set without a status (e.g. a quick comment)."""
+        payload = RatingResponseUpdate(response_notes="Need to follow up tomorrow")
+        assert payload.response_status is None
+        assert payload.response_notes == "Need to follow up tomorrow"
+
+    def test_status_and_notes_together(self):
+        """Both fields may be set in a single payload."""
+        payload = RatingResponseUpdate(
+            response_status="resolved",
+            response_notes="Fixed in v1.6 — closing.",
+        )
+        assert payload.response_status == "resolved"
+        assert payload.response_notes == "Fixed in v1.6 — closing."
+
+    def test_notes_max_length_enforced(self):
+        """Notes longer than 4000 chars are rejected."""
+        with pytest.raises(ValidationError):
+            RatingResponseUpdate(response_notes="x" * 4001)
+
+
+class TestValidResponseStatuses:
+    """Smoke check for the VALID_RESPONSE_STATUSES tuple."""
+
+    def test_expected_set(self):
+        """Must mirror the labels exposed to the frontend."""
+        assert set(VALID_RESPONSE_STATUSES) == {
+            "open",
+            "acknowledged",
+            "info_needed",
+            "resolved",
+            "wontfix",
+        }
+
+    def test_first_is_open(self):
+        """`open` is documented as the default ordering anchor."""
+        assert VALID_RESPONSE_STATUSES[0] == "open"

--- a/tests/unit/test_ratings_routes.py
+++ b/tests/unit/test_ratings_routes.py
@@ -12,7 +12,12 @@ from ui.backend.routes.ratings import _rating_to_read
 
 
 def _make_rating(**overrides):
-    """Create a mock UserRating ORM object."""
+    """Create a mock UserRating ORM object.
+
+    Defaults include the admin-response columns added in migration 0026
+    so the helper mirrors the real ORM shape (NULL when no response has
+    been recorded).
+    """
     now = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
     defaults = {
         "id": uuid.uuid4(),
@@ -24,6 +29,10 @@ def _make_rating(**overrides):
         "comment": None,
         "context": None,
         "url": None,
+        "response_status": None,
+        "response_notes": None,
+        "responded_by_user_id": None,
+        "responded_at": None,
         "created_at": now,
         "updated_at": now,
     }
@@ -105,3 +114,57 @@ class TestRatingToRead:
             rating = _make_rating(rating_type=rtype)
             result = _rating_to_read(rating)
             assert result.rating_type == rtype
+
+
+class TestRatingToReadResponseFields:
+    """Tests for the admin-response fields added in migration 0026."""
+
+    def test_response_fields_default_none(self):
+        """A rating with no admin response leaves all response_* fields None."""
+        rating = _make_rating()
+        result = _rating_to_read(rating)
+        assert result.response_status is None
+        assert result.response_notes is None
+        assert result.responded_by_user_id is None
+        assert result.responded_by_email is None
+        assert result.responded_by_display_name is None
+        assert result.responded_at is None
+
+    def test_response_status_and_notes_pass_through(self):
+        """Stored status + notes round-trip into RatingRead unchanged."""
+        rating = _make_rating(
+            response_status="acknowledged",
+            response_notes="Followed up via email",
+        )
+        result = _rating_to_read(rating)
+        assert result.response_status == "acknowledged"
+        assert result.response_notes == "Followed up via email"
+
+    def test_responder_info_populated_when_provided(self):
+        """When a responder is supplied, email + display name surface."""
+        responded_at = datetime(2026, 5, 20, 9, 30, tzinfo=timezone.utc)
+        responder = _make_user(
+            email="admin@example.com", first_name="Ada", last_name="Min"
+        )
+        rating = _make_rating(
+            response_status="resolved",
+            responded_by_user_id=responder.id,
+            responded_at=responded_at,
+        )
+        result = _rating_to_read(rating, None, responder)
+        assert result.responded_by_user_id == responder.id
+        assert result.responded_by_email == "admin@example.com"
+        assert result.responded_by_display_name == "Ada Min"
+        assert result.responded_at == responded_at
+
+    def test_responder_none_keeps_email_empty(self):
+        """If the responder was deleted, audit name fields stay None."""
+        rating = _make_rating(
+            response_status="resolved",
+            responded_by_user_id=uuid.uuid4(),
+            responded_at=datetime(2026, 5, 20, tzinfo=timezone.utc),
+        )
+        result = _rating_to_read(rating, None, None)
+        assert result.responded_by_user_id is not None
+        assert result.responded_by_email is None
+        assert result.responded_by_display_name is None

--- a/ui/backend/auth/models.py
+++ b/ui/backend/auth/models.py
@@ -188,6 +188,22 @@ class UserRating(Base):
     comment: Mapped[str | None] = mapped_column(Text, nullable=True)
     context: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     url: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Admin response — superuser-only triage action stored alongside the
+    # rating so reviewers can record acknowledgement / resolution status
+    # and free-text follow-up notes without leaving the admin grid.
+    response_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    response_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    responded_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    responded_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/ui/backend/auth/schemas.py
+++ b/ui/backend/auth/schemas.py
@@ -227,6 +227,21 @@ class RatingCreate(BaseModel):
         return _validate_jsonb(v)
 
 
+# ---------------------------------------------------------------------------
+# Admin response (triage) statuses
+# ---------------------------------------------------------------------------
+# Stored as a plain VARCHAR(32) in the DB and validated here so new values
+# can be added without a migration. Order matters: the frontend uses the
+# first entry as the default selection for unfilled responses.
+VALID_RESPONSE_STATUSES = (
+    "open",
+    "acknowledged",
+    "info_needed",
+    "resolved",
+    "wontfix",
+)
+
+
 class RatingRead(BaseModel):
     """Rating representation returned by read endpoints."""
 
@@ -241,10 +256,39 @@ class RatingRead(BaseModel):
     comment: Optional[str] = None
     context: Optional[dict] = None
     url: Optional[str] = None
+    response_status: Optional[str] = None
+    response_notes: Optional[str] = None
+    responded_by_user_id: Optional[uuid.UUID] = None
+    responded_by_email: Optional[str] = None
+    responded_by_display_name: Optional[str] = None
+    responded_at: Optional[datetime] = None
     created_at: datetime
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class RatingResponseUpdate(BaseModel):
+    """Payload for the admin response (triage) endpoint.
+
+    Both fields are optional so callers can update status alone, notes
+    alone, or both. Passing ``None`` for ``response_status`` clears the
+    status (and audit fields).
+    """
+
+    response_status: Optional[str] = Field(None, max_length=32)
+    response_notes: Optional[str] = Field(None, max_length=4000)
+
+    @field_validator("response_status")
+    @classmethod
+    def validate_response_status(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v == "":
+            return None
+        if v not in VALID_RESPONSE_STATUSES:
+            raise ValueError(
+                "response_status must be one of: " + ", ".join(VALID_RESPONSE_STATUSES)
+            )
+        return v
 
 
 class ActivityCreate(BaseModel):

--- a/ui/backend/routes/ratings.py
+++ b/ui/backend/routes/ratings.py
@@ -10,10 +10,17 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from ui.backend.auth.db import get_async_session
 from ui.backend.auth.models import User, UserActivity, UserRating
-from ui.backend.auth.schemas import VALID_RATING_TYPES, RatingCreate, RatingRead
+from ui.backend.auth.schemas import (
+    VALID_RATING_TYPES,
+    VALID_RESPONSE_STATUSES,
+    RatingCreate,
+    RatingRead,
+    RatingResponseUpdate,
+)
 from ui.backend.auth.users import (
     current_active_user,
     current_superuser,
@@ -30,8 +37,17 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 
 
-def _rating_to_read(rating: UserRating, user: User | None = None) -> RatingRead:
-    """Convert a UserRating ORM object to a RatingRead response."""
+def _rating_to_read(
+    rating: UserRating,
+    user: User | None = None,
+    responder: User | None = None,
+) -> RatingRead:
+    """Convert a UserRating ORM object to a RatingRead response.
+
+    ``user`` is the rating creator; ``responder`` is the admin who last
+    edited ``response_status`` / ``response_notes`` (may be ``None`` if
+    no response has been recorded or the responder was deleted).
+    """
     return RatingRead(
         id=rating.id,
         user_id=rating.user_id,
@@ -44,6 +60,12 @@ def _rating_to_read(rating: UserRating, user: User | None = None) -> RatingRead:
         comment=rating.comment,
         context=rating.context,
         url=rating.url,
+        response_status=rating.response_status,
+        response_notes=rating.response_notes,
+        responded_by_user_id=rating.responded_by_user_id,
+        responded_by_email=responder.email if responder else None,
+        responded_by_display_name=responder.full_name if responder else None,
+        responded_at=rating.responded_at,
         created_at=rating.created_at,
         updated_at=rating.updated_at,
     )
@@ -183,12 +205,25 @@ async def list_all_ratings(
     sort_by: str = Query("created_at"),
     order: str = Query("desc"),
     rating_type: Optional[str] = Query(None),
+    response_status: Optional[str] = Query(None),
     admin: User = Depends(current_superuser),
     session: AsyncSession = Depends(get_async_session),
 ):
-    """List all ratings with pagination (superuser only)."""
-    base = select(UserRating, User).outerjoin(
-        User, UserRating.user_id == User.id  # type: ignore[arg-type]
+    """List all ratings with pagination (superuser only).
+
+    Joins ``users`` twice: once for the rating creator and once
+    (aliased as ``Responder``) for the admin who last recorded a
+    response. Both joins are LEFT OUTER so ratings with no responder
+    (or an anonymous creator) are still returned.
+    """
+    Responder = aliased(User)
+    base = (
+        select(UserRating, User, Responder)
+        .outerjoin(User, UserRating.user_id == User.id)  # type: ignore[arg-type]
+        .outerjoin(
+            Responder,
+            UserRating.responded_by_user_id == Responder.id,  # type: ignore[arg-type]
+        )
     )
 
     if rating_type and rating_type in VALID_RATING_TYPES:
@@ -197,12 +232,16 @@ async def list_all_ratings(
     if user_email:
         base = base.where(User.email == user_email)  # type: ignore[arg-type]
 
+    if response_status and response_status in VALID_RESPONSE_STATUSES:
+        base = base.where(UserRating.response_status == response_status)  # type: ignore[arg-type]
+
     if search:
         pattern = f"%{search}%"
         base = base.where(  # type: ignore[arg-type]
             User.email.ilike(pattern)  # type: ignore[attr-defined]
             | UserRating.reference_id.ilike(pattern)  # type: ignore[attr-defined]
             | UserRating.comment.ilike(pattern)  # type: ignore[attr-defined]
+            | UserRating.response_notes.ilike(pattern)  # type: ignore[attr-defined]
         )
 
     # Count total
@@ -216,6 +255,8 @@ async def list_all_ratings(
         "score": UserRating.score,
         "rating_type": UserRating.rating_type,
         "user_email": User.email,
+        "response_status": UserRating.response_status,
+        "responded_at": UserRating.responded_at,
     }
     sort_col = sort_col_map.get(sort_by, UserRating.created_at)
     if order == "asc":
@@ -229,7 +270,9 @@ async def list_all_ratings(
 
     result = await session.execute(base)
     rows = result.unique().all()
-    items = [_rating_to_read(rating, user) for rating, user in rows]
+    items = [
+        _rating_to_read(rating, user, responder) for rating, user, responder in rows
+    ]
 
     return {
         "items": [item.model_dump(mode="json") for item in items],
@@ -242,15 +285,31 @@ async def list_all_ratings(
 @router.get("/export", tags=["ratings"])
 async def export_ratings(
     rating_type: Optional[str] = Query(None),
+    response_status: Optional[str] = Query(None),
     admin: User = Depends(current_superuser),
     session: AsyncSession = Depends(get_async_session),
 ):
-    """Export all ratings as XLSX (superuser only)."""
+    """Export all ratings as XLSX (superuser only).
+
+    Includes the admin-response columns (status, notes, responder
+    email, responded_at) so the export reflects exactly what is
+    visible in the admin grid.
+    """
     import openpyxl
 
-    stmt = select(UserRating, User).outerjoin(User, UserRating.user_id == User.id)
+    Responder = aliased(User)
+    stmt = (
+        select(UserRating, User, Responder)
+        .outerjoin(User, UserRating.user_id == User.id)
+        .outerjoin(
+            Responder,
+            UserRating.responded_by_user_id == Responder.id,  # type: ignore[arg-type]
+        )
+    )
     if rating_type and rating_type in VALID_RATING_TYPES:
         stmt = stmt.where(UserRating.rating_type == rating_type)
+    if response_status and response_status in VALID_RESPONSE_STATUSES:
+        stmt = stmt.where(UserRating.response_status == response_status)  # type: ignore[arg-type]
     stmt = stmt.order_by(UserRating.created_at.desc())
 
     result = await session.execute(stmt)
@@ -270,10 +329,14 @@ async def export_ratings(
         "Item ID",
         "Comment",
         "URL",
+        "Response Status",
+        "Response Notes",
+        "Responded By",
+        "Responded At",
     ]
     ws.append(headers)
 
-    for rating, user in rows:
+    for rating, user, responder in rows:
         ws.append(
             [
                 (
@@ -289,6 +352,14 @@ async def export_ratings(
                 rating.item_id or "",
                 rating.comment or "",
                 rating.url or "",
+                rating.response_status or "",
+                rating.response_notes or "",
+                responder.email if responder else "",
+                (
+                    rating.responded_at.strftime("%Y-%m-%d %H:%M")
+                    if rating.responded_at
+                    else ""
+                ),
             ]
         )
 
@@ -304,3 +375,62 @@ async def export_ratings(
         media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+@router.patch("/{rating_id}/response", response_model=RatingRead, tags=["ratings"])
+async def update_rating_response(
+    rating_id: uuid.UUID,
+    body: RatingResponseUpdate,
+    admin: User = Depends(current_superuser),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Record or clear an admin response on a rating (superuser only).
+
+    Both fields are optional; passing both as ``None`` clears the
+    response (status, notes, and audit fields are all set to ``NULL``).
+    Otherwise ``responded_by_user_id`` and ``responded_at`` are
+    refreshed to the current admin / timestamp on every edit.
+    """
+    result = await session.execute(select(UserRating).where(UserRating.id == rating_id))
+    rating = result.scalars().first()
+    if rating is None:
+        raise HTTPException(status_code=404, detail="Rating not found")
+
+    is_clear = body.response_status is None and not body.response_notes
+    if is_clear:
+        rating.response_status = None
+        rating.response_notes = None
+        rating.responded_by_user_id = None
+        rating.responded_at = None
+    else:
+        rating.response_status = body.response_status
+        rating.response_notes = body.response_notes
+        rating.responded_by_user_id = admin.id
+        rating.responded_at = datetime.now(timezone.utc)
+
+    await session.commit()
+    await session.refresh(rating)
+
+    # Re-fetch the rating creator (and resolved responder) so the
+    # response payload carries display names just like /ratings/all.
+    creator = None
+    if rating.user_id:
+        creator_row = await session.execute(
+            select(User).where(User.id == rating.user_id)
+        )
+        creator = creator_row.scalars().first()
+
+    responder = None
+    if rating.responded_by_user_id:
+        responder_row = await session.execute(
+            select(User).where(User.id == rating.responded_by_user_id)
+        )
+        responder = responder_row.scalars().first()
+
+    logger.info(
+        "Admin %s updated response on rating %s (status=%s)",
+        admin.email,
+        rating.id,
+        rating.response_status,
+    )
+    return _rating_to_read(rating, creator, responder)

--- a/ui/frontend/src/components/admin/RatingsManager.tsx
+++ b/ui/frontend/src/components/admin/RatingsManager.tsx
@@ -20,6 +20,12 @@ interface RatingRow {
   comment: string | null;
   context: Record<string, any> | null;
   url: string | null;
+  response_status: string | null;
+  response_notes: string | null;
+  responded_by_user_id: string | null;
+  responded_by_email: string | null;
+  responded_by_display_name: string | null;
+  responded_at: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -37,11 +43,37 @@ const RATING_TYPES = [
 ];
 const SCORE_OPTIONS = ['1', '2', '3', '4', '5'];
 
+// Must mirror VALID_RESPONSE_STATUSES in ui/backend/auth/schemas.py.
+const RESPONSE_STATUSES = [
+  'open', 'acknowledged', 'info_needed', 'resolved', 'wontfix',
+] as const;
+
+const RESPONSE_STATUS_LABELS: Record<string, string> = {
+  open: 'Open',
+  acknowledged: 'Acknowledged',
+  info_needed: 'Info needed',
+  resolved: 'Resolved',
+  wontfix: "Won't fix",
+};
+
+const RESPONSE_STATUS_COLORS: Record<string, { bg: string; fg: string; border: string }> = {
+  open:         { bg: '#f1f3f4', fg: '#3c4043', border: '#dadce0' },
+  acknowledged: { bg: '#e8f0fe', fg: '#1967d2', border: '#aecbfa' },
+  info_needed:  { bg: '#fef7e0', fg: '#b06000', border: '#fdd663' },
+  resolved:     { bg: '#e6f4ea', fg: '#1e8e3e', border: '#a8dab5' },
+  wontfix:      { bg: '#fce8e6', fg: '#a50e0e', border: '#f6aea9' },
+};
+
 // Static filter options — user_email is dynamic (computed from data)
 const STATIC_FILTER_OPTIONS: Record<string, string[]> = {
   rating_type: RATING_TYPES,
   score: SCORE_OPTIONS,
+  response_status: [...RESPONSE_STATUSES],
 };
+
+// Reused style tokens (extracted to satisfy sonarjs/no-duplicate-string).
+const INLINE_BLOCK = 'inline-block';
+const INPUT_BORDER = '1px solid #ccc';
 
 const formatDate = (iso: string) => {
   try {
@@ -402,7 +434,7 @@ const DataUrlImage: React.FC<{ src: string; alt: string }> = ({ src, alt }) => {
         openDataUrlInNewTab(src);
       }}
       style={{
-        display: 'inline-block',
+        display: INLINE_BLOCK,
         verticalAlign: 'top',
         maxWidth: '100%',
         height: 'auto',
@@ -756,7 +788,7 @@ export const CommentCell: React.FC<{ comment: string | null }> = ({ comment }) =
     <td style={{
       fontSize: '0.82rem', maxWidth: '200px', whiteSpace: 'nowrap',
     }} title={text}>
-      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', display: 'inline-block', maxWidth: 'calc(100% - 70px)', verticalAlign: 'bottom' }}>
+      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', display: INLINE_BLOCK, maxWidth: 'calc(100% - 70px)', verticalAlign: 'bottom' }}>
         {text.slice(0, COMMENT_TRUNCATE_CHARS).trimEnd()}…
       </span>{' '}
       <button
@@ -772,34 +804,170 @@ export const CommentCell: React.FC<{ comment: string | null }> = ({ comment }) =
 };
 
 // ---------------------------------------------------------------------------
+// Response status chip — color-coded pill rendered in the Response column.
+// A null/unset status renders as a muted em-dash so reviewers can spot
+// untriaged rows at a glance.
+// ---------------------------------------------------------------------------
+const ResponseChip: React.FC<{ status: string | null }> = ({ status }) => {
+  if (!status) {
+    return <span style={{ color: '#9aa0a6', fontSize: '0.82rem' }}>—</span>;
+  }
+  const colors = RESPONSE_STATUS_COLORS[status]
+    || { bg: '#f1f3f4', fg: '#3c4043', border: '#dadce0' };
+  const label = RESPONSE_STATUS_LABELS[status] || status;
+  return (
+    <span style={{
+      display: INLINE_BLOCK, padding: '2px 8px', borderRadius: 999,
+      fontSize: '0.75rem', fontWeight: 500, lineHeight: 1.4,
+      background: colors.bg, color: colors.fg, border: `1px solid ${colors.border}`,
+      whiteSpace: 'nowrap',
+    }}>{label}</span>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Inline response editor — rendered inside the expanded row above the
+// context panel. Admins pick a status, optionally add notes, and click
+// Save to PATCH /ratings/{id}/response. The audit footer shows who last
+// updated the response and when.
+// ---------------------------------------------------------------------------
+interface ResponseEditFormProps {
+  rating: RatingRow;
+  onSave: (id: string, status: string | null, notes: string | null) => Promise<void>;
+}
+
+const ResponseEditForm: React.FC<ResponseEditFormProps> = ({ rating, onSave }) => {
+  const [status, setStatus] = useState<string>(rating.response_status || '');
+  const [notes, setNotes] = useState<string>(rating.response_notes || '');
+  const [saving, setSaving] = useState(false);
+  const [savedFlash, setSavedFlash] = useState(false);
+  const [saveError, setSaveError] = useState('');
+
+  // Reset local state when the row's saved values change (e.g. after a
+  // refetch). Without this the form would keep stale local edits after
+  // the parent reloads the list.
+  useEffect(() => {
+    setStatus(rating.response_status || '');
+    setNotes(rating.response_notes || '');
+  }, [rating.id, rating.response_status, rating.response_notes]);
+
+  const isDirty =
+    status !== (rating.response_status || '') ||
+    notes !== (rating.response_notes || '');
+
+  const handleSave = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSaving(true);
+    setSaveError('');
+    try {
+      await onSave(rating.id, status || null, notes || null);
+      setSavedFlash(true);
+      setTimeout(() => setSavedFlash(false), 1500);
+    } catch (err: any) {
+      const msg = err?.response?.data?.detail || 'Failed to save response';
+      setSaveError(typeof msg === 'string' ? msg : 'Failed to save response');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="admin-response-form"
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        marginBottom: 12, padding: '10px 12px', borderRadius: 6,
+        border: '1px solid #e0e0e0', background: '#fafafa',
+      }}>
+      <div className="admin-context-label" style={{ marginBottom: 6 }}>Admin Response</div>
+      <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start', flexWrap: 'wrap' }}>
+        <select
+          value={status}
+          onChange={(e) => setStatus(e.target.value)}
+          aria-label="Response status"
+          style={{
+            padding: '0.35rem 0.5rem', fontSize: '0.85rem',
+            border: INPUT_BORDER, borderRadius: 4, minWidth: 150,
+          }}>
+          <option value="">— No status —</option>
+          {RESPONSE_STATUSES.map((s) => (
+            <option key={s} value={s}>{RESPONSE_STATUS_LABELS[s]}</option>
+          ))}
+        </select>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Optional follow-up notes…"
+          aria-label="Response notes"
+          rows={2}
+          maxLength={4000}
+          style={{
+            flex: '1 1 280px', minWidth: 240, padding: '0.4rem 0.5rem',
+            fontSize: '0.85rem', border: INPUT_BORDER, borderRadius: 4,
+            fontFamily: 'inherit', resize: 'vertical',
+          }}/>
+        <button
+          type="button"
+          className="btn-sm"
+          onClick={handleSave}
+          disabled={saving || !isDirty}
+          style={{ padding: '0.4rem 0.9rem', alignSelf: 'flex-start' }}>
+          {saving ? 'Saving…' : savedFlash ? 'Saved ✓' : 'Save'}
+        </button>
+      </div>
+      {saveError && (
+        <div style={{ marginTop: 6, color: '#a50e0e', fontSize: '0.78rem' }}>{saveError}</div>
+      )}
+      {rating.responded_at && (
+        <div style={{ marginTop: 6, fontSize: '0.75rem', color: '#666' }}>
+          Last updated by{' '}
+          <strong>{rating.responded_by_email || rating.responded_by_display_name || 'an admin'}</strong>
+          {' '}on {formatDate(rating.responded_at)}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
 // Rating table row (extracted to reduce cyclomatic complexity)
 // ---------------------------------------------------------------------------
 const hasContext = (r: RatingRow) => r.context && Object.keys(r.context).length > 0;
 
 const RatingTableRow: React.FC<{
-  rating: RatingRow; isExpanded: boolean; onToggle: (id: string) => void;
-}> = ({ rating, isExpanded, onToggle }) => {
-  const expandable = hasContext(rating);
+  rating: RatingRow;
+  isExpanded: boolean;
+  onToggle: (id: string) => void;
+  onSaveResponse: (id: string, status: string | null, notes: string | null) => Promise<void>;
+}> = ({ rating, isExpanded, onToggle, onSaveResponse }) => {
+  // Every row is now expandable so admins can record a response even
+  // when there's no context payload to show.
+  const expandable = true;
   return (
     <React.Fragment>
       <tr className={`${expandable ? 'admin-expandable-row' : ''} ${isExpanded ? 'admin-expanded-parent' : ''}`}
-        onClick={() => expandable && onToggle(rating.id)}>
+        onClick={() => onToggle(rating.id)}>
         <td style={{ textAlign: 'center', padding: '0.4rem' }}>
-          {expandable ? <span className="admin-expand-icon"><ChevronIcon expanded={isExpanded} /></span> : ''}
+          <span className="admin-expand-icon"><ChevronIcon expanded={isExpanded} /></span>
         </td>
         <td style={{ whiteSpace: 'nowrap', fontSize: '0.82rem' }}>{formatDate(rating.created_at)}</td>
         <td style={{ fontSize: '0.82rem' }}>{rating.user_email || rating.user_display_name || '-'}</td>
         <td style={{ fontSize: '0.82rem' }}>{rating.rating_type.replace(/_/g, ' ')}</td>
         <td style={{ color: '#d4a017', fontSize: '0.9rem', letterSpacing: '1px' }}>{renderStars(rating.score)}</td>
         <CommentCell comment={rating.comment} />
+        <td style={{ fontSize: '0.82rem' }}>
+          <ResponseChip status={rating.response_status} />
+        </td>
         <td style={{ fontSize: '0.82rem', maxWidth: '150px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={rating.url || ''}>
           {rating.url ? <a href={rating.url} target="_blank" rel="noopener noreferrer" style={{ color: '#1a73e8' }} onClick={(e) => e.stopPropagation()}>link</a> : '-'}
         </td>
       </tr>
       {isExpanded && (
         <tr className="admin-expanded-detail">
-          <td colSpan={7} className="admin-expanded-cell">
-            <RatingContextPanel rating={rating} />
+          <td colSpan={8} className="admin-expanded-cell">
+            <ResponseEditForm rating={rating} onSave={onSaveResponse} />
+            {hasContext(rating)
+              ? <RatingContextPanel rating={rating} />
+              : <span className="admin-no-data">No context data</span>}
           </td>
         </tr>
       )}
@@ -855,6 +1023,8 @@ const RatingsManager: React.FC = () => {
       if (filterType !== 'all') params.rating_type = filterType;
       const uf = columnFilters['user_email'];
       if (uf) params.user_email = uf;
+      const rs = columnFilters['response_status'];
+      if (rs) params.response_status = rs;
       const resp = await axios.get<RatingsResponse>(`${API_BASE_URL}/ratings/all`, { params });
       setRatings(resp.data.items);
       setTotal(resp.data.total);
@@ -864,6 +1034,20 @@ const RatingsManager: React.FC = () => {
       setLoading(false);
     }
   }, [page, pageSize, search, sortBy, order, filterType, columnFilters]);
+
+  // PATCH the rating's response and merge the server's updated row back
+  // into local state so the chip + audit footer refresh without a full
+  // refetch. A failed call bubbles up so the inline form can display it.
+  const handleSaveResponse = useCallback(
+    async (id: string, status: string | null, notes: string | null) => {
+      const resp = await axios.patch<RatingRow>(
+        `${API_BASE_URL}/ratings/${id}/response`,
+        { response_status: status, response_notes: notes },
+      );
+      setRatings((prev) => prev.map((r) => (r.id === id ? resp.data : r)));
+    },
+    [],
+  );
 
   useEffect(() => { fetchRatings(); }, [fetchRatings]);
   useEffect(() => { setExpandedRows(new Set()); }, [page, filterType, search, sortBy, order]);
@@ -886,6 +1070,8 @@ const RatingsManager: React.FC = () => {
     try {
       const params: Record<string, string> = {};
       if (filterType !== 'all') params.rating_type = filterType;
+      const rs = columnFilters['response_status'];
+      if (rs) params.response_status = rs;
       const resp = await axios.get<Blob>(`${API_BASE_URL}/ratings/export`, { params, responseType: 'blob' });
       const url = URL.createObjectURL(resp.data);
       const a = document.createElement('a');
@@ -911,7 +1097,7 @@ const RatingsManager: React.FC = () => {
   );
 
   // Server-side filter columns trigger a page reset + re-fetch
-  const SERVER_FILTER_COLUMNS = new Set(['rating_type', 'user_email']);
+  const SERVER_FILTER_COLUMNS = new Set(['rating_type', 'user_email', 'response_status']);
 
   const handleApplyFilter = useCallback((column: string, value: string) => {
     if (column === 'rating_type') {
@@ -968,7 +1154,7 @@ const RatingsManager: React.FC = () => {
         <form onSubmit={handleSearchSubmit} style={{ display: 'flex', gap: '0.5rem' }}>
           <input type="text" placeholder="Search by email, reference, or comment..." value={searchInput}
             onChange={handleSearchInputChange} className="admin-search-input"
-            style={{ minWidth: '250px', padding: '0.4rem 0.6rem', borderRadius: '4px', border: '1px solid #ccc', fontSize: '0.85rem' }} />
+            style={{ minWidth: '250px', padding: '0.4rem 0.6rem', borderRadius: '4px', border: INPUT_BORDER, fontSize: '0.85rem' }} />
           <button type="submit" className="btn-sm" style={{ padding: '0.4rem 0.8rem' }}>Search</button>
         </form>
         <button className="admin-download-button" onClick={handleExport} disabled={exporting} style={{ marginLeft: 'auto' }}>
@@ -1003,15 +1189,23 @@ const RatingsManager: React.FC = () => {
                   <SortableHeader columnKey="score" label="Score" filterable sortField={sortBy} sortDirection={order}
                     onSort={handleSort} onFilterClick={handleFilterClick} hasActiveFilter={hasActiveFilter} />
                   <th>Comment</th>
+                  <SortableHeader columnKey="response_status" label="Response" filterable sortField={sortBy} sortDirection={order}
+                    onSort={handleSort} onFilterClick={handleFilterClick} hasActiveFilter={hasActiveFilter} />
                   <th>URL</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredRatings.length === 0 ? (
-                  <tr><td colSpan={7} style={{ textAlign: 'center', padding: '1.5rem', color: '#888' }}>No ratings found</td></tr>
+                  <tr><td colSpan={8} style={{ textAlign: 'center', padding: '1.5rem', color: '#888' }}>No ratings found</td></tr>
                 ) : (
                   filteredRatings.map((r) => (
-                    <RatingTableRow key={r.id} rating={r} isExpanded={expandedRows.has(r.id)} onToggle={toggleRow} />
+                    <RatingTableRow
+                      key={r.id}
+                      rating={r}
+                      isExpanded={expandedRows.has(r.id)}
+                      onToggle={toggleRow}
+                      onSaveResponse={handleSaveResponse}
+                    />
                   ))
                 )}
               </tbody>


### PR DESCRIPTION
## Summary

Adds an admin-only **response field** to each user rating so reviewers can record the action taken on feedback without leaving the Admin → Ratings table. The response is stored alongside the rating (same row, same query — no separate triage table).

- **Status** — a controlled vocabulary: `open` / `acknowledged` / `info_needed` / `resolved` / `wontfix`. Rendered as a color-coded chip in a new **Response** column.
- **Notes** — optional free-text follow-up (≤ 4000 chars).
- **Audit trail** — `responded_by_user_id` (FK to users, `SET NULL` on delete) + `responded_at` are auto-populated on every save and surfaced in the expanded-row footer.

Empty / `NULL` is the default for existing rows — no forced backlog. Statuses are validated at the Pydantic layer (`VALID_RESPONSE_STATUSES`), not by a DB `CHECK`, so new values can be added without a migration.

## Changes

| Layer | File | What |
|---|---|---|
| DB | `alembic/versions/0026_add_response_to_user_ratings.py` | New migration: 4 nullable columns on `user_ratings`, FK to `users`, index on `response_status` |
| Model | `ui/backend/auth/models.py` | `response_status`, `response_notes`, `responded_by_user_id`, `responded_at` on `UserRating` |
| Schemas | `ui/backend/auth/schemas.py` | `VALID_RESPONSE_STATUSES` tuple, extended `RatingRead`, new `RatingResponseUpdate` (with `Literal`-style validation + 4 KB notes cap) |
| Routes | `ui/backend/routes/ratings.py` | New `PATCH /ratings/{id}/response` (superuser); `/all` + `/export` extended with response filter, sort, search across notes, and 4 new XLSX columns. Uses `aliased(User)` to join the responder cleanly. |
| Frontend | `ui/frontend/src/components/admin/RatingsManager.tsx` | Extended `RatingRow` type, new `ResponseChip` + `ResponseEditForm` components, Response column with sort + filter, save handler that PATCHes and merges the server response back into local state |
| Docs | `docs/using-evidence-lab/ratings-feedback.md` | New "Responding to Ratings (Admin)" section + updated export-column list |
| Tests | `tests/unit/test_ratings.py`, `tests/unit/test_ratings_routes.py` | +14 tests covering schema validation, responder-join behavior, and audit-field population |

## Screenshots

### Admin → Ratings table with new **Response** column
<img width="1361" height="672" alt="image" src="https://github.com/user-attachments/assets/b913d75b-a5e7-4f7e-926b-5ed18208f2e5" />

### Inline admin-response editor (expanded row)
<img width="1361" height="672" alt="image" src="https://github.com/user-attachments/assets/98da189e-bb0b-4c30-a8a2-6d83ceb1f02f" />

## Test plan

- [x] `pytest tests/unit/test_ratings.py tests/unit/test_ratings_routes.py` — 49 / 49 pass
- [x] `pre-commit run` on staged files — all hooks green (black, isort, flake8, mypy, bandit, gitleaks, detect-secrets, code-metrics)
- [x] `npx tsc --noEmit -p tsconfig.json` in the ui container — exit 0
- [x] `npx eslint src/components/admin/RatingsManager.tsx` — 0 errors
- [x] Live end-to-end: login as superuser → `PATCH /ratings/{id}/response` with `{status:"acknowledged", notes:"…"}` → audit fields populated, GET filtered list returns just that row, then cleared back to `NULL` cleanly
- [x] Excel export — 13 columns including the 4 new ones; verified by opening with openpyxl
- [ ] Manual UI check: open Admin → Ratings, expand a row, change status + notes, click **Save**, refresh, confirm chip + audit footer persist
- [ ] Verify non-superuser users still get `403` on the new PATCH route

## Notes for reviewers

- `config.json` and `docker-compose.yml` had local environment tweaks during development; both have been restored to the base branch and **are not in this PR**.
- The migration chains from `0025_merge_0024_heads` and is the only revision touching `user_ratings` since.
- The `_rating_to_read` helper now takes an optional `responder: User | None` so the existing `/mine` and `/` (upsert) endpoints stay backward-compatible (the rating creator still doesn't see the responder's identity by default — privacy-safe).
- Inline `# type: ignore[…]` comments on the new SQLAlchemy expressions match the existing pattern in this file for `select(...).outerjoin(...)` predicates; not introducing a new suppression class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)