### PR TITLE
ci: update dependabot target-branch from rc/v1.4.0 to rc/v1.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "rc/v1.4.0"
+    target-branch: "rc/v1.5.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -21,7 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.4.0"
+    target-branch: "rc/v1.5.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -36,7 +36,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "rc/v1.4.0"
+    target-branch: "rc/v1.5.0"
     schedule:
       interval: "monthly"
     labels:
@@ -49,7 +49,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
-    target-branch: "rc/v1.4.0"
+    target-branch: "rc/v1.5.0"
     schedule:
       interval: "monthly"
     labels:
@@ -62,7 +62,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.4.0"
+    target-branch: "rc/v1.5.0"
     schedule:
       interval: "monthly"
     labels:
@@ -75,7 +75,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "rc/v1.4.0"
+    target-branch: "rc/v1.5.0"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
## Summary

Updates `.github/dependabot.yml` target-branch from `rc/v1.4.0` to `rc/v1.5.0` on all six ecosystems (pip, npm, docker × 3, github-actions).

## Why this needs to land on main

Dependabot reads its configuration from the **default branch**, not from the target branch. `rc/v1.5.0` already had this change applied (commit `7fbf80f` on 2026-04-12), but Dependabot doesn't honour it because `main` still points to `rc/v1.4.0`. Result: new Dependabot PRs (#311–#321) keep getting opened against `rc/v1.4.0`, requiring manual retargeting each time.

Per CONTRIBUTING.md, PRs target `rc/vX.Y.Z` for features/fixes and `main` for hotfixes. This is a CI/config hotfix that has to be on the default branch to take effect.

## Test plan

- [ ] Confirm Dependabot's next scheduled run (or a manually-triggered one) opens PRs against `rc/v1.5.0`, not `rc/v1.4.0`.

https://claude.ai/code/session_01BTcNpWp6JEMaNecBztHVYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTcNpWp6JEMaNecBztHVYK)_