### PR TITLE
ci: auto-merge Dependabot patch and minor bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch and minor bumps
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a `pull_request_target` workflow that enables GitHub's native auto-merge (squash) on Dependabot PRs once branch protection is satisfied — for **patch and minor bumps only**. Major bumps still require manual review, and are already filtered out by the `dependabot.yml` `ignore` rules.

## How it works

1. Workflow fires on `pull_request_target` (so it has write permission and access to secrets).
2. Runs only when `github.actor == 'dependabot[bot]'`.
3. `dependabot/fetch-metadata@v2` classifies the update type.
4. If patch or minor, runs `gh pr merge --auto --squash` — GitHub then merges automatically once all required status checks pass on the PR (i.e., your existing `code-quality`, `tests`, `ui-tests`, `security-scan`, `sbom`, `container-scan`, `integration-tests` checks).

Nothing changes for PRs whose CI is red — those just sit and wait for someone to address them.

## Prerequisites

For auto-merge to actually fire, the repo needs **GitHub's auto-merge feature enabled** at the repo level (Settings → General → Pull Requests → "Allow auto-merge") and branch protection on `rc/v1.5.0` with the required status checks listed. If either isn't configured, the workflow will run but auto-merge won't trigger — no harm done, just a no-op.

## Test plan

- [ ] Confirm repo setting **Allow auto-merge** is on for `dividor/evidencelab`.
- [ ] Confirm branch protection on `rc/v1.5.0` lists the CI checks as required.
- [ ] After merge, next Dependabot patch/minor PR should show "Auto-merge enabled" without manual intervention and merge itself once CI is green.

https://claude.ai/code/session_01BTcNpWp6JEMaNecBztHVYK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTcNpWp6JEMaNecBztHVYK)_