### PR TITLE
feat(auth): sliding session refresh to prevent premature logouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -225,7 +225,17 @@ AUTH_RATE_LIMIT_WINDOW=60
 AUTH_LOCKOUT_THRESHOLD=5
 AUTH_LOCKOUT_DURATION_MINUTES=15
 
-# Token lifetimes (seconds). Separate from the 1-hour JWT access token.
+# Session timing (seconds).
+# AUTH_TOKEN_LIFETIME — JWT access-token / auth-cookie lifetime. The frontend
+# slides the session by re-issuing the cookie (POST /auth/refresh) every
+# half-lifetime while the user is active, so active users are never logged out
+# mid-session; an idle user's cookie lapses at this lifetime. Default 3600 (1h).
+# AUTH_TOKEN_LIFETIME=3600
+# AUTH_IDLE_TIMEOUT — frontend idle-logout window; should be >= AUTH_TOKEN_LIFETIME
+# so the two caps stay aligned. Default 3600 (1h).
+# AUTH_IDLE_TIMEOUT=3600
+
+# Token lifetimes (seconds). Separate from the JWT access token above.
 # Reset password token default: 3600 (1 hour, per ASVS V2.5.2)
 # AUTH_RESET_TOKEN_LIFETIME=3600
 # Email verification token default: 86400 (24 hours, per ASVS V2.3.2)

--- a/tests/unit/test_auth_refresh.py
+++ b/tests/unit/test_auth_refresh.py
@@ -1,0 +1,63 @@
+"""Unit tests for the sliding-session refresh endpoint (POST /auth/refresh)."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+COOKIE_NAME = "evidencelab_auth"
+
+
+class _FakeStrategy:
+    """Minimal JWT strategy stub — writes a deterministic token."""
+
+    async def write_token(self, user) -> str:
+        """Return a fixed token regardless of the user."""
+        return "fresh-token"
+
+
+def _build_app(*, authenticated: bool) -> FastAPI:
+    """Build a FastAPI app mounting the real auth router.
+
+    Args:
+        authenticated: When True, override the auth dependencies so the
+            request is treated as an authenticated user.
+
+    Returns:
+        FastAPI: The configured application.
+    """
+    from ui.backend.auth.users import cookie_backend, current_active_user
+    from ui.backend.routes import auth as auth_routes
+
+    app = FastAPI()
+    app.include_router(auth_routes.router, prefix="/auth")
+
+    if authenticated:
+        app.dependency_overrides[current_active_user] = lambda: SimpleNamespace(
+            id="user-1"
+        )
+        app.dependency_overrides[cookie_backend.get_strategy] = _FakeStrategy
+    return app
+
+
+@pytest.mark.unit
+def test_refresh_when_authenticated_reissues_cookie():
+    """An authenticated refresh returns 204 and a fresh auth cookie."""
+    client = TestClient(_build_app(authenticated=True))
+
+    resp = client.post("/auth/refresh")
+
+    assert resp.status_code == 204
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert f"{COOKIE_NAME}=fresh-token" in set_cookie
+
+
+@pytest.mark.unit
+def test_refresh_when_unauthenticated_returns_401():
+    """Refresh without a valid session is rejected (cannot bootstrap)."""
+    client = TestClient(_build_app(authenticated=False))
+
+    resp = client.post("/auth/refresh")
+
+    assert resp.status_code == 401

--- a/tests/unit/test_auth_status.py
+++ b/tests/unit/test_auth_status.py
@@ -1,0 +1,33 @@
+"""Unit tests for the session-timing fields on GET /config/auth-status."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.unit
+def test_auth_status_exposes_session_timing_overrides():
+    """auth-status returns the configured token lifetime and idle timeout."""
+    from ui.backend.routes import config as config_mod
+
+    env = {"AUTH_TOKEN_LIFETIME": "1800", "AUTH_IDLE_TIMEOUT": "2400"}
+    with patch.dict(os.environ, env, clear=False):
+        result = config_mod.get_auth_status()
+
+    assert result["token_lifetime_seconds"] == 1800
+    assert result["session_idle_timeout_seconds"] == 2400
+
+
+@pytest.mark.unit
+def test_auth_status_session_timing_defaults():
+    """Session timing defaults to 3600 seconds when env is unset."""
+    from ui.backend.routes import config as config_mod
+
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("AUTH_TOKEN_LIFETIME", None)
+        os.environ.pop("AUTH_IDLE_TIMEOUT", None)
+        result = config_mod.get_auth_status()
+
+    assert result["token_lifetime_seconds"] == 3600
+    assert result["session_idle_timeout_seconds"] == 3600

--- a/tests/unit/test_token_lifetime.py
+++ b/tests/unit/test_token_lifetime.py
@@ -1,0 +1,44 @@
+"""Unit tests for the env-configurable access-token lifetime."""
+
+import importlib
+import os
+from unittest.mock import patch
+
+import pytest
+
+# A valid (>=32 char) secret so reloading users.py does not fall back to an
+# ephemeral random secret (which only logs a warning, but keeps output clean).
+_TEST_SECRET = "x" * 48  # pragma: allowlist secret
+
+
+@pytest.mark.unit
+def test_token_lifetime_defaults_to_one_hour():
+    """Without AUTH_TOKEN_LIFETIME set, the lifetime is 3600 seconds."""
+    with patch.dict(os.environ, {"AUTH_SECRET_KEY": _TEST_SECRET}, clear=False):
+        # patch.dict restores the original environment on exit, so this
+        # deletion is reverted afterwards.
+        os.environ.pop("AUTH_TOKEN_LIFETIME", None)
+        import ui.backend.auth.users as users
+
+        importlib.reload(users)
+        try:
+            assert users.TOKEN_LIFETIME_SECONDS == 3600
+        finally:
+            importlib.reload(users)
+
+
+@pytest.mark.unit
+def test_token_lifetime_reads_env_override():
+    """AUTH_TOKEN_LIFETIME drives the JWT strategy and cookie max-age."""
+    env = {"AUTH_SECRET_KEY": _TEST_SECRET, "AUTH_TOKEN_LIFETIME": "7200"}
+    with patch.dict(os.environ, env, clear=False):
+        import ui.backend.auth.users as users
+
+        importlib.reload(users)
+        try:
+            assert users.TOKEN_LIFETIME_SECONDS == 7200
+            assert users.get_jwt_strategy().lifetime_seconds == 7200
+            assert users.cookie_transport.cookie_max_age == 7200
+        finally:
+            # Restore module state for other tests in the session.
+            importlib.reload(users)

--- a/ui/backend/auth/users.py
+++ b/ui/backend/auth/users.py
@@ -57,7 +57,12 @@ if AUTH_SECRET in _INSECURE_DEFAULTS or len(AUTH_SECRET) < 32:
     )
     AUTH_SECRET = _generated
 
-TOKEN_LIFETIME_SECONDS = 3600  # 1 hour (short-lived; refresh via cookie)
+# Access-token (and auth-cookie) lifetime. The frontend slides the session by
+# re-issuing the cookie via POST /auth/refresh before it expires while the user
+# is active, so an active user is never logged out mid-session. An idle user's
+# cookie lapses at this lifetime. Configurable to keep the frontend refresh
+# cadence and idle timeout aligned (see AUTH_IDLE_TIMEOUT).
+TOKEN_LIFETIME_SECONDS = int(os.environ.get("AUTH_TOKEN_LIFETIME", "3600"))  # 1 hour
 
 # Registration controls — restrict who can sign up.
 # Comma-separated list of allowed email domains (e.g. "example.com,corp.org").

--- a/ui/backend/routes/auth.py
+++ b/ui/backend/routes/auth.py
@@ -5,12 +5,14 @@ import os
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import RedirectResponse
 
+from ui.backend.auth.models import User
 from ui.backend.auth.oauth import google_oauth_client, microsoft_oauth_client
 from ui.backend.auth.schemas import UserCreate, UserRead
 from ui.backend.auth.users import (
     AUTH_SECRET,
     bearer_backend,
     cookie_backend,
+    current_active_user,
     fastapi_users,
     get_user_manager,
 )
@@ -64,6 +66,39 @@ router.include_router(
     fastapi_users.get_reset_password_router(),
     tags=["auth"],
 )
+
+
+# ---------------------------------------------------------------------------
+# Sliding-session refresh
+#
+# Re-issues the httpOnly auth cookie (and a fresh JWT) for the currently
+# authenticated user. The frontend calls this on an interval while the user is
+# active, so the access token's expiry always stays ahead of "now" and an
+# active user is never logged out mid-session. An idle user makes no refresh
+# call, so their cookie lapses at the configured lifetime — an intentional
+# idle logout. Mounted unconditionally so both email and OAuth sessions slide.
+#
+# A valid session cookie is required (current_active_user returns 401
+# otherwise), so this cannot bootstrap a session — only extend an existing one.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/refresh", tags=["auth"])
+async def refresh_session(
+    user: User = Depends(current_active_user),
+    strategy=Depends(cookie_backend.get_strategy),
+):
+    """Re-issue the auth cookie for the current user (sliding session).
+
+    Args:
+        user: The authenticated user, resolved from the existing auth cookie.
+        strategy: The cookie backend's JWT strategy.
+
+    Returns:
+        Response: A 204 response carrying a refreshed ``Set-Cookie`` header.
+    """
+    return await cookie_backend.login(strategy, user)
+
 
 # ---------------------------------------------------------------------------
 # OAuth providers (only registered when credentials are configured)

--- a/ui/backend/routes/config.py
+++ b/ui/backend/routes/config.py
@@ -290,12 +290,19 @@ def get_auth_status():
         os.environ.get("OAUTH_MICROSOFT_CLIENT_ID")
         and os.environ.get("OAUTH_MICROSOFT_CLIENT_SECRET")
     )
+    # Session timing — exposed so the frontend can size its sliding-refresh
+    # cadence and idle timeout from the same source of truth as the backend,
+    # keeping the two caps aligned without a frontend rebuild.
+    token_lifetime = int(os.environ.get("AUTH_TOKEN_LIFETIME", "3600"))
+    idle_timeout = int(os.environ.get("AUTH_IDLE_TIMEOUT", "3600"))
     return {
         "user_module_enabled": _USER_MODULE,
         "user_module_mode": _USER_MODULE_MODE,
         "email_login_disabled": email_disabled,
         "google_oauth_enabled": google_enabled,
         "microsoft_oauth_enabled": microsoft_enabled,
+        "token_lifetime_seconds": token_lifetime,
+        "session_idle_timeout_seconds": idle_timeout,
     }
 
 

--- a/ui/frontend/src/hooks/useAuth.ts
+++ b/ui/frontend/src/hooks/useAuth.ts
@@ -62,8 +62,18 @@ export function useAuth(): AuthContextValue {
   return useContext(AuthContext);
 }
 
-/** Inactivity timeout — 1 hour. */
-const INACTIVITY_TIMEOUT_MS = 60 * 60 * 1000;
+/**
+ * Session timing defaults — used until the backend's /config/auth-status
+ * values arrive. The backend is the source of truth so the sliding-refresh
+ * cadence and idle timeout stay aligned with the server token lifetime.
+ */
+const DEFAULT_TOKEN_LIFETIME_MS = 60 * 60 * 1000; // 1 hour
+const DEFAULT_IDLE_TIMEOUT_MS = 60 * 60 * 1000; // 1 hour
+/** Floor on the refresh cadence so we never hammer the endpoint. */
+const MIN_REFRESH_INTERVAL_MS = 60 * 1000; // 1 minute
+
+/** Events that count as "the user is still active". */
+const ACTIVITY_EVENTS = ['mousedown', 'keydown', 'scroll', 'touchstart'] as const;
 
 /** Custom hook that provides auth state management. Use inside AuthProvider. */
 export function useAuthState(): AuthContextValue {
@@ -72,9 +82,20 @@ export function useAuthState(): AuthContextValue {
   const [verificationMessage, setVerificationMessage] = useState<string | null>(null);
   const [resetPasswordToken, setResetPasswordToken] = useState<string | null>(null);
 
+  // Session timing, sourced from the backend (kept in sync with the server
+  // token lifetime). Seeded with defaults until /config/auth-status responds.
+  const [sessionConfig, setSessionConfig] = useState({
+    tokenLifetimeMs: DEFAULT_TOKEN_LIFETIME_MS,
+    idleTimeoutMs: DEFAULT_IDLE_TIMEOUT_MS,
+  });
+
   // Track current auth state for use inside the interceptor closure
   const stateRef = useRef(state);
   useEffect(() => { stateRef.current = state; }, [state]);
+
+  // Timestamp of the user's last interaction — drives both the sliding
+  // refresh and the idle-logout timer.
+  const lastActivityRef = useRef<number>(Date.now());
 
   // Promise-based coordination: when a 401 is caught, pending requests wait
   // on this promise until the user re-authenticates.
@@ -143,9 +164,11 @@ export function useAuthState(): AuthContextValue {
     };
   }, [getAuthPromise]);
 
-  // ---- Inactivity timeout (1 hour) ------------------------------------
-  // After 1 hour of no user interaction, expire the session and show the
-  // login modal.  The server-side cookie is also cleared (best-effort).
+  // ---- Idle logout ----------------------------------------------------
+  // After `idleTimeoutMs` with no user interaction, expire the session and
+  // show the login modal.  The server-side cookie is also cleared (best-
+  // effort).  Active users never reach this — the sliding-refresh effect
+  // below keeps their token fresh.
   useEffect(() => {
     if (!USER_MODULE || !state.isAuthenticated) return;
 
@@ -168,11 +191,11 @@ export function useAuthState(): AuthContextValue {
     };
 
     const resetTimer = () => {
+      lastActivityRef.current = Date.now();
       clearTimeout(timeoutId);
-      timeoutId = setTimeout(handleTimeout, INACTIVITY_TIMEOUT_MS);
+      timeoutId = setTimeout(handleTimeout, sessionConfig.idleTimeoutMs);
     };
 
-    const ACTIVITY_EVENTS = ['mousedown', 'keydown', 'scroll', 'touchstart'] as const;
     for (const evt of ACTIVITY_EVENTS) {
       window.addEventListener(evt, resetTimer, { passive: true });
     }
@@ -184,7 +207,37 @@ export function useAuthState(): AuthContextValue {
         window.removeEventListener(evt, resetTimer);
       }
     };
-  }, [state.isAuthenticated]);
+  }, [state.isAuthenticated, sessionConfig.idleTimeoutMs]);
+
+  // ---- Sliding-session refresh ----------------------------------------
+  // While authenticated, periodically re-issue the auth cookie so an active
+  // user's token never expires mid-session.  We only refresh when the user
+  // interacted within the last interval, so a genuinely idle session still
+  // lapses (and the idle-logout effect above clears it).  The interval is
+  // half the server token lifetime, guaranteeing a refresh before expiry.
+  useEffect(() => {
+    if (!USER_MODULE || !state.isAuthenticated) return;
+
+    const intervalMs = Math.max(
+      MIN_REFRESH_INTERVAL_MS,
+      Math.floor(sessionConfig.tokenLifetimeMs / 2)
+    );
+
+    const tick = async () => {
+      // Skip when idle (no activity within the last interval) — let the cookie
+      // lapse and the idle-logout fire.
+      if (Date.now() - lastActivityRef.current >= intervalMs) return;
+      try {
+        await axios.post(`${API_BASE_URL}/auth/refresh`);
+      } catch {
+        // Refresh failed (e.g. session already expired) — the 401 interceptor
+        // and idle-logout effect handle ending the session.
+      }
+    };
+
+    const intervalId = setInterval(tick, intervalMs);
+    return () => clearInterval(intervalId);
+  }, [state.isAuthenticated, sessionConfig.tokenLifetimeMs]);
 
   const clearVerificationMessage = useCallback(() => {
     setVerificationMessage(null);
@@ -208,6 +261,32 @@ export function useAuthState(): AuthContextValue {
   useEffect(() => {
     refreshUser();
   }, [refreshUser]);
+
+  // Load session timing from the backend so the refresh cadence and idle
+  // timeout match the server token lifetime. Keeps defaults if unavailable.
+  useEffect(() => {
+    let cancelled = false;
+    axios
+      .get<{ token_lifetime_seconds?: number; session_idle_timeout_seconds?: number }>(
+        `${API_BASE_URL}/config/auth-status`
+      )
+      .then((res) => {
+        if (cancelled) return;
+        const lifetime = Number(res.data?.token_lifetime_seconds);
+        const idle = Number(res.data?.session_idle_timeout_seconds);
+        setSessionConfig({
+          tokenLifetimeMs:
+            lifetime > 0 ? lifetime * 1000 : DEFAULT_TOKEN_LIFETIME_MS,
+          idleTimeoutMs: idle > 0 ? idle * 1000 : DEFAULT_IDLE_TIMEOUT_MS,
+        });
+      })
+      .catch(() => {
+        // Keep defaults — timing config is best-effort.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   // Handle ?verify=TOKEN from email verification links
   useEffect(() => {

--- a/ui/frontend/src/tests/useAuthSession.test.tsx
+++ b/ui/frontend/src/tests/useAuthSession.test.tsx
@@ -315,6 +315,57 @@ describe('useAuthState — inactivity timeout', () => {
 });
 
 /* ------------------------------------------------------------------ */
+/*  Tests — sliding-session refresh                                    */
+/* ------------------------------------------------------------------ */
+
+describe('useAuthState — sliding-session refresh', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setupInterceptorMock();
+    (axios.get as jest.Mock).mockResolvedValue({ data: mockUser });
+    (axios.post as jest.Mock).mockResolvedValue({ data: {} });
+  });
+
+  it('posts /auth/refresh while the user is active', async () => {
+    jest.useFakeTimers();
+    render(<AuthTestHarness />);
+    await flushPromises();
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+    (axios.post as jest.Mock).mockClear();
+
+    // Keep the session active just before the refresh interval fires.
+    act(() => { jest.advanceTimersByTime(20 * 60 * 1000); });
+    act(() => { window.dispatchEvent(new MouseEvent('mousedown')); });
+    // Cross the 30-minute refresh interval (half the 1h default lifetime).
+    await act(async () => { jest.advanceTimersByTime(15 * 60 * 1000); });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/refresh'),
+    );
+    jest.useRealTimers();
+  });
+
+  it('does NOT post /auth/refresh when the user is idle', async () => {
+    jest.useFakeTimers();
+    render(<AuthTestHarness />);
+    await flushPromises();
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+    (axios.post as jest.Mock).mockClear();
+
+    // No activity at all — advance across two refresh intervals.
+    await act(async () => { jest.advanceTimersByTime(59 * 60 * 1000); });
+
+    const refreshCalls = (axios.post as jest.Mock).mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('/auth/refresh'),
+    );
+    expect(refreshCalls).toHaveLength(0);
+    jest.useRealTimers();
+  });
+});
+
+/* ------------------------------------------------------------------ */
 /*  Tests — login/logout session state                                 */
 /* ------------------------------------------------------------------ */
 


### PR DESCRIPTION
## Description
Active users were being logged out at the fixed 1-hour JWT/cookie lifetime: the expiry was anchored to login time with **no refresh and no sliding window**, so the logout landed at an arbitrary point in the session (sometimes mid-use, sometimes after a short pause). This introduces a sliding session so an active user is never logged out mid-session, while genuinely idle sessions still expire.

### How it works
- The JWT/cookie keeps a moderate lifetime (default 1h, now env-configurable).
- While the user is active, the frontend silently re-issues the cookie via a new `POST /auth/refresh` every half-lifetime — so the token `exp` always stays ahead of "now".
- If the user goes idle, no refresh fires and the cookie lapses at the idle cap → a clean, intentional idle logout.
- The frontend reads `token_lifetime_seconds` + `session_idle_timeout_seconds` from `/config/auth-status`, so the refresh cadence and idle timeout stay aligned with the server config (no frontend rebuild needed to retune).

### Backend
- `POST /auth/refresh` — re-issues the auth cookie for the current user; mounted unconditionally (email + OAuth); returns 401 without a valid session (cannot bootstrap).
- `AUTH_TOKEN_LIFETIME` env var drives the JWT strategy and cookie max-age.
- `/config/auth-status` now returns `token_lifetime_seconds` and `session_idle_timeout_seconds` (`AUTH_IDLE_TIMEOUT`, default 3600).

### Frontend
- `useAuth` loads session timing from the backend, adds a sliding-refresh interval (active-only), and drives the idle-logout window from the fetched value.

### Config
- `.env.example` documents `AUTH_TOKEN_LIFETIME` and `AUTH_IDLE_TIMEOUT`.

## Type of Change
- [x] Bug fix

## Testing
- [x] Tests pass locally
- [x] New tests added for new functionality
- [x] Manual testing completed

Backend unit tests: refresh endpoint (authenticated 204 + fresh `Set-Cookie`; unauthenticated 401), env-driven token lifetime, auth-status fields. Frontend tests: refresh fires while active, no refresh when idle. Broader auth suite: 140 passed, no regressions. Pre-commit (black/isort/flake8/mypy/bandit/detect-secrets/gitleaks/code-metrics) passes. Manually verified end-to-end against the running stack: auth-status fields present, unauthenticated refresh → 401, login → refresh → 204 with a JWT carrying a fresh `exp = now + 3600`.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] No breaking changes (defaults preserve the prior 1h behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)