### PR TITLE
fix(ui): align on-screen AI summary citations with export

### DIFF
--- a/ui/frontend/src/components/AiSummaryPanel.tsx
+++ b/ui/frontend/src/components/AiSummaryPanel.tsx
@@ -99,7 +99,7 @@ const AiSummaryLoading = ({ expanded, summary }: { expanded: boolean; summary: s
 const AiSummaryBody = ({
   expanded,
   summary,
-  filteredResults,
+  summaryResults,
   onResultClick,
   contentRef,
   onDrilldown,
@@ -110,7 +110,7 @@ const AiSummaryBody = ({
 }: {
   expanded: boolean;
   summary: string;
-  filteredResults: SearchResult[];
+  summaryResults: SearchResult[];
   onResultClick: (result: SearchResult) => void;
   contentRef?: React.RefObject<HTMLDivElement | null>;
   onDrilldown?: (text: string, mode: DrilldownMode) => void;
@@ -127,7 +127,7 @@ const AiSummaryBody = ({
     <div className="ai-summary-markdown">
       <AiSummaryWithCitations
         summaryText={summary}
-        searchResults={filteredResults}
+        searchResults={summaryResults}
         onResultClick={onResultClick}
         onFindOutMore={onFindOutMore}
         findOutMoreLoading={findOutMoreLoading}
@@ -136,7 +136,7 @@ const AiSummaryBody = ({
     </div>
     <AiSummaryReferences
       summaryText={summary}
-      results={filteredResults}
+      results={summaryResults}
       onResultClick={onResultClick}
     />
     {onDrilldown && contentRef && !loading && (
@@ -153,7 +153,7 @@ const AiSummaryContent = ({
   expanded,
   loading,
   summary,
-  filteredResults,
+  summaryResults,
   onResultClick,
   contentRef,
   onDrilldown,
@@ -165,7 +165,7 @@ const AiSummaryContent = ({
   expanded: boolean;
   loading: boolean;
   summary: string;
-  filteredResults: SearchResult[];
+  summaryResults: SearchResult[];
   onResultClick: (result: SearchResult) => void;
   contentRef?: React.RefObject<HTMLDivElement | null>;
   onDrilldown?: (text: string, mode: DrilldownMode) => void;
@@ -181,7 +181,7 @@ const AiSummaryContent = ({
     <AiSummaryBody
       expanded={expanded}
       summary={summary}
-      filteredResults={filteredResults}
+      summaryResults={summaryResults}
       onResultClick={onResultClick}
       contentRef={contentRef}
       onDrilldown={onDrilldown}
@@ -708,7 +708,9 @@ export const AiSummaryPanel = ({
   aiSummaryExpanded,
   aiSummaryLoading,
   aiSummary,
-  minScore,
+  // `minScore` is part of the public props (callers still pass it) but is no longer
+  // used to filter the summary's result array — see the comment in the body below.
+  // It is intentionally left out of the destructuring to avoid an unused local.
   results,
   aiPrompt,
   showPromptModal,
@@ -837,7 +839,14 @@ export const AiSummaryPanel = ({
 
   if (!enabled) return null;
 
-  const filteredResults = results.filter((result) => result.score >= minScore);
+  // Citations in the summary text are 1-based indices into the exact result array
+  // that was sent to the LLM (`results`). The summary and references must therefore
+  // be resolved against that same array — identical to how the export resolves them
+  // (see exportResearch.ts) — so on-screen and downloaded citations always match.
+  // `minScore` is intentionally NOT applied here: filtering this array would shift the
+  // indices and break the citation mapping. Relevance filtering will be reintroduced
+  // upstream of summary generation in a follow-up (the `minScore` prop is retained for
+  // that work and for the results-list filtering owned by the parent).
   const displaySummary = translatedSummary || aiSummary;
   const selectedLang = translatedLang || 'en';
   const isDrilldown = (drilldownStackDepth || 0) > 0;
@@ -942,7 +951,7 @@ export const AiSummaryPanel = ({
               expanded={aiSummaryExpanded}
               loading={aiSummaryLoading}
               summary={displaySummary}
-              filteredResults={filteredResults}
+              summaryResults={results}
               onResultClick={onResultClick}
               contentRef={summaryContentRef}
               onDrilldown={onDrilldown}

--- a/ui/frontend/src/components/AiSummaryReferences.tsx
+++ b/ui/frontend/src/components/AiSummaryReferences.tsx
@@ -1,28 +1,12 @@
 import React from 'react';
 import { SearchResult } from '../types/api';
+import { buildCitationSequenceMap, extractCitedNumbers } from '../utils/citations';
 
 interface AiSummaryReferencesProps {
   summaryText: string;
   results: SearchResult[];
   onResultClick: (result: SearchResult) => void;
 }
-
-const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
-
-const parseCitationNumbers = (rawNumbers: string): number[] =>
-  rawNumbers.split(',').map((item) => parseInt(item.trim(), 10));
-
-const extractCitationNumbers = (summaryText: string): number[] => {
-  const citedNumbers = new Set<number>();
-  let match;
-
-  while ((match = CITATION_REGEX.exec(summaryText)) !== null) {
-    const numbers = parseCitationNumbers(match[1]);
-    numbers.forEach((num) => citedNumbers.add(num));
-  }
-
-  return Array.from(citedNumbers).sort((a, b) => a - b);
-};
 
 interface CitedRef {
   sequential: number;
@@ -40,11 +24,12 @@ export const buildGroupedReferences = (
   summaryText: string,
   results: SearchResult[]
 ): DocumentGroup[] => {
-  const sortedCitations = extractCitationNumbers(summaryText);
+  const sortedCitations = extractCitedNumbers(summaryText);
+  const sequenceMap = buildCitationSequenceMap(summaryText);
   const groupMap = new Map<string, DocumentGroup>();
   const groupOrder: string[] = [];
 
-  sortedCitations.forEach((origNum, seqIdx) => {
+  sortedCitations.forEach((origNum) => {
     const resultIndex = origNum - 1;
     if (resultIndex < 0 || resultIndex >= results.length) return;
 
@@ -62,7 +47,7 @@ export const buildGroupedReferences = (
     }
 
     groupMap.get(key)!.refs.push({
-      sequential: seqIdx + 1,
+      sequential: sequenceMap.get(origNum)!,
       result,
     });
   });

--- a/ui/frontend/src/components/AiSummaryWithCitations.tsx
+++ b/ui/frontend/src/components/AiSummaryWithCitations.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { SearchResult } from '../types/api';
 import { renderMarkdownText } from '../utils/textHighlighting';
+import {
+  buildCitationSequenceMap,
+  createCitationRegex,
+  parseCitationNumbers,
+} from '../utils/citations';
 
 interface AiSummaryWithCitationsProps {
   summaryText: string;
@@ -11,16 +16,14 @@ interface AiSummaryWithCitationsProps {
   findOutMoreActiveFact?: string | null;
 }
 
-const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
+// Used for splitting/stripping citation markers from text (stateless ops only).
+const CITATION_REGEX = createCitationRegex();
 const CITATION_ONLY_LINE = /^\[[\d,\s]+\]$/;
 const NUMBERED_LIST_REGEX = /^\d+[\.)]\s/;
 const BULLET_LIST_REGEX = /^[-*]\s/;
 const HEADING_REGEX = /^(#{1,4})\s+(.+)$/;
 const BOLD_HEADING_REGEX = /^\*\*(.+?)\*\*:?\s*$/;
 const PLAIN_HEADING_REGEX = /^([A-Z][A-Za-z\s]+):?\s*$/;
-
-const parseCitationNumbers = (rawNumbers: string): number[] =>
-  rawNumbers.split(',').map((item) => parseInt(item.trim(), 10));
 
 const extractKeyFacts = (summary: string): string[] => {
   const lines = summary.split('\n');
@@ -63,23 +66,6 @@ const extractSubHeadings = (summary: string): string[] => {
     }
   }
   return subHeadings;
-};
-
-const buildCitationMapping = (summaryText: string): Map<number, number> => {
-  const citedNumbers = new Set<number>();
-  let match;
-
-  while ((match = CITATION_REGEX.exec(summaryText)) !== null) {
-    const numbers = parseCitationNumbers(match[1]);
-    numbers.forEach((num) => citedNumbers.add(num));
-  }
-
-  const citationMapping = new Map<number, number>();
-  const sortedCitations = Array.from(citedNumbers).sort((a, b) => a - b);
-  sortedCitations.forEach((origNum, seqIdx) => {
-    citationMapping.set(origNum, seqIdx + 1);
-  });
-  return citationMapping;
 };
 
 /** Strip trailing Conclusion / Summary sections the LLM sometimes adds despite prompt instructions. */
@@ -327,7 +313,7 @@ export const AiSummaryWithCitations: React.FC<AiSummaryWithCitationsProps> = ({
   findOutMoreActiveFact,
 }) => {
   const cleanedText = stripTrailingBoilerplate(summaryText);
-  const citationMapping = buildCitationMapping(cleanedText);
+  const citationMapping = buildCitationSequenceMap(cleanedText);
   const blocks = splitSummaryBlocks(cleanedText);
   // Track across all blocks so only the very first heading gets the button
   let isFirstHeadingGlobal = true;

--- a/ui/frontend/src/tests/citations.test.ts
+++ b/ui/frontend/src/tests/citations.test.ts
@@ -1,0 +1,160 @@
+import {
+  buildCitationSequenceMap,
+  extractCitedNumbers,
+  parseCitationNumbers,
+} from '../utils/citations';
+import { buildGroupedReferences } from '../components/AiSummaryReferences';
+import { SearchResult } from '../types/api';
+
+const makeResult = (over: Partial<SearchResult>): SearchResult => ({
+  chunk_id: 'chunk',
+  doc_id: 'doc',
+  text: '',
+  page_num: 0,
+  headings: [],
+  score: 1,
+  title: 'Untitled',
+  metadata: {},
+  ...over,
+});
+
+describe('citations util', () => {
+  describe('parseCitationNumbers', () => {
+    it('parses_a_single_number', () => {
+      expect(parseCitationNumbers('3')).toEqual([3]);
+    });
+
+    it('parses_a_comma_separated_group_with_spaces', () => {
+      expect(parseCitationNumbers('2, 5,7')).toEqual([2, 5, 7]);
+    });
+  });
+
+  describe('extractCitedNumbers', () => {
+    it('returns_unique_numbers_sorted_ascending', () => {
+      const summary = 'Alpha [3] beta [1] gamma [3].';
+      expect(extractCitedNumbers(summary)).toEqual([1, 3]);
+    });
+
+    it('expands_multi_number_markers', () => {
+      const summary = 'Finding one [2, 5] and finding two [1].';
+      expect(extractCitedNumbers(summary)).toEqual([1, 2, 5]);
+    });
+
+    it('returns_empty_array_when_no_citations_present', () => {
+      expect(extractCitedNumbers('No citations here.')).toEqual([]);
+    });
+  });
+
+  describe('buildCitationSequenceMap', () => {
+    it('maps_original_numbers_to_1_based_sequence_in_ascending_order', () => {
+      const summary = 'See [7] and [3] and again [3] plus [1].';
+      const map = buildCitationSequenceMap(summary);
+      expect(Array.from(map.entries())).toEqual([
+        [1, 1],
+        [3, 2],
+        [7, 3],
+      ]);
+    });
+
+    it('does_not_share_regex_state_between_calls', () => {
+      const summary = 'Repeated [1] usage [2].';
+      // Calling twice must yield identical results (guards against shared
+      // RegExp lastIndex state leaking across invocations).
+      expect(Array.from(buildCitationSequenceMap(summary).entries())).toEqual(
+        Array.from(buildCitationSequenceMap(summary).entries())
+      );
+    });
+  });
+});
+
+describe('buildGroupedReferences', () => {
+  it('resolves_citation_N_to_the_Nth_result_one_based', () => {
+    const results = [
+      makeResult({ title: 'First Doc', organization: 'Org A', year: '2020', page_num: 4 }),
+      makeResult({ title: 'Second Doc', organization: 'Org B', year: '2021', page_num: 9 }),
+    ];
+    const groups = buildGroupedReferences('Claim one [1]. Claim two [2].', results);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ title: 'First Doc', organization: 'Org A', year: '2020' });
+    expect(groups[0].refs[0]).toMatchObject({ sequential: 1 });
+    expect(groups[0].refs[0].result.page_num).toBe(4);
+    expect(groups[1]).toMatchObject({ title: 'Second Doc', organization: 'Org B', year: '2021' });
+    expect(groups[1].refs[0]).toMatchObject({ sequential: 2 });
+  });
+
+  it('groups_multiple_citations_of_the_same_document_together', () => {
+    const results = [
+      makeResult({ title: 'Shared Doc', page_num: 1 }),
+      makeResult({ title: 'Shared Doc', page_num: 2 }),
+      makeResult({ title: 'Other Doc', page_num: 3 }),
+    ];
+    const groups = buildGroupedReferences('A [1] B [2] C [3].', results);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].title).toBe('Shared Doc');
+    expect(groups[0].refs.map((r) => r.sequential)).toEqual([1, 2]);
+    expect(groups[1].title).toBe('Other Doc');
+    expect(groups[1].refs.map((r) => r.sequential)).toEqual([3]);
+  });
+
+  it('skips_out_of_range_citation_numbers_without_throwing', () => {
+    const results = [makeResult({ title: 'Only Doc' })];
+    const groups = buildGroupedReferences('Valid [1] but dangling [5].', results);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].title).toBe('Only Doc');
+    expect(groups[0].refs[0].sequential).toBe(1);
+  });
+
+  it('reference_sequentials_match_the_shared_sequence_map', () => {
+    // Inline citations (AiSummaryWithCitations / exportResearch) and the reference
+    // list (buildGroupedReferences) must agree on the displayed number for every
+    // citation, on screen and in the export.
+    const results = [
+      makeResult({ title: 'Doc 1' }),
+      makeResult({ title: 'Doc 2' }),
+      makeResult({ title: 'Doc 3' }),
+    ];
+    const summary = 'X [3] Y [1] Z [2].';
+    const sequenceMap = buildCitationSequenceMap(summary);
+
+    const groups = buildGroupedReferences(summary, results);
+    for (const group of groups) {
+      for (const ref of group.refs) {
+        // result lives at index (origNum - 1); recover origNum from its position.
+        const origNum = results.indexOf(ref.result) + 1;
+        expect(ref.sequential).toBe(sequenceMap.get(origNum));
+      }
+    }
+  });
+});
+
+describe('citation discrepancy regression (#337080)', () => {
+  it('resolves_citations_against_the_full_result_array_not_a_score_filtered_one', () => {
+    // The summary text is generated against the FULL result array sent to the LLM,
+    // where citation [2] indexes the second result. The on-screen summary previously
+    // re-indexed citations into a minScore-filtered array, so [2] resolved to the
+    // wrong document (or was dropped). This asserts the correct, full-array mapping
+    // and demonstrates why the filtered array must NOT be used.
+    const fullResults = [
+      makeResult({ title: 'Low Relevance Doc', score: 0.1 }),
+      makeResult({ title: 'Cited Doc', score: 0.9 }),
+    ];
+    const summary = 'Key finding [2].';
+
+    // Correct behaviour (post-fix): resolve against the full array.
+    const correct = buildGroupedReferences(summary, fullResults);
+    expect(correct).toHaveLength(1);
+    expect(correct[0].title).toBe('Cited Doc');
+
+    // Old behaviour: filtering by score first shifts indices so [2] no longer maps
+    // to "Cited Doc" — proving the bug the fix removes.
+    const minScore = 0.5;
+    const filtered = fullResults.filter((r) => r.score >= minScore);
+    const buggy = buildGroupedReferences(summary, filtered);
+    // "Cited Doc" is now at index 0, so citation [2] points past the array and is
+    // dropped — the on-screen references diverged from the export.
+    expect(buggy.some((g) => g.title === 'Cited Doc')).toBe(false);
+  });
+});

--- a/ui/frontend/src/utils/__tests__/exportResultsToDocx.test.ts
+++ b/ui/frontend/src/utils/__tests__/exportResultsToDocx.test.ts
@@ -17,10 +17,11 @@ import {
   buildExportFilename,
   buildReferenceGroups,
   exportResultsToDocxBlob,
-  extractCitationNumbers,
   markdownToParagraphs,
   resolveResultLink,
 } from '../exportResultsToDocx';
+import type { CitationContext } from '../exportResultsToDocx';
+import { buildCitationSequenceMap } from '../citations';
 import type { SearchResult } from '../../types/api';
 
 const makeResult = (overrides: Partial<SearchResult> = {}): SearchResult => ({
@@ -118,15 +119,29 @@ describe('resolveResultLink', () => {
   });
 });
 
-describe('extractCitationNumbers', () => {
-  test('returns sorted unique numbers', () => {
-    expect(extractCitationNumbers('a [3] b [1] c [3] d [2,1]')).toEqual([1, 2, 3]);
-  });
-  test('handles multi-citation brackets with whitespace', () => {
-    expect(extractCitationNumbers('See [1, 4, 7].')).toEqual([1, 4, 7]);
-  });
-  test('returns [] when no citations present', () => {
-    expect(extractCitationNumbers('plain text with no marks')).toEqual([]);
+// Note: citation number parsing/extraction now lives in the shared
+// `utils/citations` module and is covered by `tests/citations.test.ts`.
+
+describe('inline citation rendering', () => {
+  test('renders the sequential number, not the original, so it matches the references', () => {
+    // doc_ids avoid the digits 1/3 so the only place those can appear in the
+    // serialised paragraph is the rendered citation itself.
+    const results = [
+      makeResult({ doc_id: 'docA', title: 'Alpha', year: undefined, page_num: undefined, text: 'x' }),
+      makeResult({ doc_id: 'docB', title: 'Beta', year: undefined, page_num: undefined, text: 'y' }),
+      makeResult({ doc_id: 'docC', title: 'Gamma', year: undefined, page_num: undefined, text: 'z' }),
+    ];
+    // Only [3] is cited, so it renumbers to a sequential 1.
+    const summary = 'The third source proves the point [3].';
+    const ctx: CitationContext = {
+      results,
+      siteOrigin: 'https://x.test',
+      sequence: buildCitationSequenceMap(summary),
+    };
+    const [paragraph] = markdownToParagraphs(summary, 1, ctx);
+    const json = JSON.stringify(paragraph);
+    expect(json).toContain('1'); // sequential number is rendered
+    expect(json).not.toContain('3'); // original number is never shown
   });
 });
 

--- a/ui/frontend/src/utils/citations.ts
+++ b/ui/frontend/src/utils/citations.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared helpers for parsing and numbering inline citations (e.g. `[1]`, `[2, 5]`)
+ * in AI summary text.
+ *
+ * Both the on-screen summary (`AiSummaryWithCitations`, `AiSummaryReferences`) and
+ * the export (`exportResearch`) must renumber citations identically, otherwise the
+ * same summary shows different reference numbers on screen versus in the downloaded
+ * document. Keeping the numbering logic in one place guarantees they cannot drift.
+ *
+ * A citation number `[N]` is a 1-based index into the result array that was sent to
+ * the LLM. Callers are responsible for resolving `N` against that same array.
+ */
+
+/** Source pattern for an inline citation marker such as `[1]` or `[2, 5]`. */
+export const CITATION_PATTERN = '\\[(\\d+(?:,\\s*\\d+)*)\\]';
+
+/**
+ * Create a fresh global `RegExp` for matching citation markers.
+ *
+ * A new instance is returned on every call so that callers using `.exec()` do not
+ * share mutable `lastIndex` state across modules.
+ */
+export const createCitationRegex = (): RegExp => new RegExp(CITATION_PATTERN, 'g');
+
+/** Parse the inner numbers of a citation marker, e.g. `"2, 5"` -> `[2, 5]`. */
+export const parseCitationNumbers = (rawNumbers: string): number[] =>
+  rawNumbers.split(',').map((item) => parseInt(item.trim(), 10));
+
+/** Extract every unique citation number from summary text, sorted ascending. */
+export const extractCitedNumbers = (summaryText: string): number[] => {
+  const cited = new Set<number>();
+  const regex = createCitationRegex();
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(summaryText)) !== null) {
+    parseCitationNumbers(match[1]).forEach((num) => cited.add(num));
+  }
+  return Array.from(cited).sort((a, b) => a - b);
+};
+
+/**
+ * Build a map from each original citation number to its sequential (1-based) display
+ * number, ordered by ascending original number.
+ *
+ * This is the single source of truth for citation numbering, shared by the on-screen
+ * summary and the export.
+ */
+export const buildCitationSequenceMap = (summaryText: string): Map<number, number> => {
+  const map = new Map<number, number>();
+  extractCitedNumbers(summaryText).forEach((origNum, idx) => {
+    map.set(origNum, idx + 1);
+  });
+  return map;
+};

--- a/ui/frontend/src/utils/exportResearch.ts
+++ b/ui/frontend/src/utils/exportResearch.ts
@@ -1,5 +1,6 @@
 import { DrilldownNode, SearchResult } from '../types/api';
 import { buildGroupedReferences, DocumentGroup } from '../components/AiSummaryReferences';
+import { buildCitationSequenceMap } from './citations';
 
 /** Escape HTML special characters */
 const esc = (text: string): string =>
@@ -25,27 +26,25 @@ const resolveSourceUrl = (result: SearchResult): string =>
   result.metadata?.src_doc_raw_metadata?.pdf_url ||
   '';
 
-/** Build a map from original citation number to { url, sequential } */
+/**
+ * Build a map from original citation number to `{ url, seq }`.
+ *
+ * Sequential numbering is delegated to the shared `buildCitationSequenceMap` so the
+ * export renumbers citations identically to the on-screen summary. The URL is
+ * resolved here (export-specific) against the same result array the LLM was given.
+ */
 const buildCitationLinks = (
   summary: string,
   results: SearchResult[]
 ): Map<number, { url: string; seq: number }> => {
-  const cited = new Set<number>();
-  const regex = /\[(\d+(?:,\s*\d+)*)\]/g;
-  let match;
-  while ((match = regex.exec(summary)) !== null) {
-    match[1].split(',').forEach((n) => {
-      const num = parseInt(n.trim(), 10);
-      if (num >= 1 && num <= results.length) cited.add(num);
-    });
-  }
-  const sorted = Array.from(cited).sort((a, b) => a - b);
+  const sequenceMap = buildCitationSequenceMap(summary);
   const map = new Map<number, { url: string; seq: number }>();
-  sorted.forEach((origNum, idx) => {
+  sequenceMap.forEach((seq, origNum) => {
     const r = results[origNum - 1];
+    if (!r) return;
     let url = resolveSourceUrl(r);
     if (url && r.page_num) url += `#page=${r.page_num}`;
-    map.set(origNum, { url, seq: idx + 1 });
+    map.set(origNum, { url, seq });
   });
   return map;
 };

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -28,6 +28,11 @@ import {
   convertInchesToTwip,
 } from 'docx';
 import type { SearchResult } from '../types/api';
+import {
+  buildCitationSequenceMap,
+  extractCitedNumbers,
+  parseCitationNumbers,
+} from './citations';
 
 export interface ExportOptions {
   query: string;
@@ -129,6 +134,11 @@ export interface CitationContext {
   results: SearchResult[];
   siteOrigin: string;
   dataSource?: string;
+  /** Maps each original citation number to its sequential (1-based) display
+   *  number. Shared with the on-screen summary and PDF export (via
+   *  `buildCitationSequenceMap`) so all three surfaces renumber citations
+   *  identically. */
+  sequence: Map<number, number>;
 }
 
 /** Build the inline children for a `[N]` / `[N, M]` citation marker. Each
@@ -140,23 +150,24 @@ const buildCitationRuns = (
   base: { size?: number },
   ctx: CitationContext,
 ): InlineChild[] => {
-  const nums = matched
-    .split(',')
-    .map((s) => parseInt(s.trim(), 10))
-    .filter((n) => Number.isFinite(n));
+  const nums = parseCitationNumbers(matched).filter((n) => Number.isFinite(n));
   const out: InlineChild[] = [new TextRun({ text: '[', size: base.size })];
   nums.forEach((n, idx) => {
     if (idx > 0) out.push(new TextRun({ text: ', ', size: base.size }));
     const result = ctx.results[n - 1];
+    // Render the sequential (renumbered) value so inline markers match the
+    // References list and the on-screen / PDF surfaces. The hyperlink still
+    // targets the original result (index n - 1).
+    const display = String(ctx.sequence.get(n) ?? n);
     if (!result) {
-      out.push(new TextRun({ text: String(n), size: base.size }));
+      out.push(new TextRun({ text: display, size: base.size }));
       return;
     }
     out.push(
       new ExternalHyperlink({
         link: resolveResultLink(result, ctx.siteOrigin, ctx.dataSource),
         children: [
-          new TextRun({ text: String(n), style: 'Hyperlink', size: base.size }),
+          new TextRun({ text: display, style: 'Hyperlink', size: base.size }),
         ],
       }),
     );
@@ -313,22 +324,6 @@ export const markdownToParagraphs = (
 // References (citations parsed out of the AI summary)
 // ---------------------------------------------------------------------------
 
-/** Matches inline citations like `[1]`, `[1, 3]`, `[1,3,5]`. */
-const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
-
-/** Parse the unique, sorted citation numbers referenced in the AI summary. */
-export const extractCitationNumbers = (summaryText: string): number[] => {
-  const cited = new Set<number>();
-  let m: RegExpExecArray | null;
-  while ((m = CITATION_REGEX.exec(summaryText)) !== null) {
-    for (const part of m[1].split(',')) {
-      const n = parseInt(part.trim(), 10);
-      if (Number.isFinite(n)) cited.add(n);
-    }
-  }
-  return Array.from(cited).sort((a, b) => a - b);
-};
-
 interface CitedRef {
   sequential: number;
   result: SearchResult;
@@ -343,18 +338,21 @@ export interface ReferenceGroup {
 
 /** Build a list of grouped references from the AI summary citations.
  *
- *  Mirrors the in-app ``buildGroupedReferences`` (in ``AiSummaryReferences``):
- *  citations are renumbered into citation order, then grouped by document
- *  title so a single document appears once with all its cited pages listed. */
+ *  Uses the shared citation helpers (`extractCitedNumbers` /
+ *  `buildCitationSequenceMap`) so the renumbering matches the on-screen
+ *  references (`AiSummaryReferences.buildGroupedReferences`) and the PDF export
+ *  exactly. Citations are renumbered into citation order, then grouped by
+ *  document title so a single document appears once with all its cited pages. */
 export const buildReferenceGroups = (
   summaryText: string,
   results: SearchResult[],
 ): ReferenceGroup[] => {
-  const sortedCitations = extractCitationNumbers(summaryText);
+  const sortedCitations = extractCitedNumbers(summaryText);
+  const sequence = buildCitationSequenceMap(summaryText);
   const groupMap = new Map<string, ReferenceGroup>();
   const groupOrder: string[] = [];
 
-  sortedCitations.forEach((origNum, seqIdx) => {
+  sortedCitations.forEach((origNum) => {
     const idx = origNum - 1;
     if (idx < 0 || idx >= results.length) return;
     const result = results[idx];
@@ -368,7 +366,7 @@ export const buildReferenceGroups = (
       });
       groupOrder.push(key);
     }
-    groupMap.get(key)!.refs.push({ sequential: seqIdx + 1, result });
+    groupMap.get(key)!.refs.push({ sequential: sequence.get(origNum)!, result });
   });
 
   return groupOrder.map((key) => groupMap.get(key)!);
@@ -474,7 +472,12 @@ const buildSummarySection = (
       spacing: { before: 240, after: 120 },
     }),
   );
-  const citations: CitationContext = { results, siteOrigin, dataSource };
+  const citations: CitationContext = {
+    results,
+    siteOrigin,
+    dataSource,
+    sequence: buildCitationSequenceMap(summary),
+  };
   // Demote any markdown headings inside the summary by 1 so the section's
   // own H1 stays unique. Pass the citation context so [N] markers in the
   // body become clickable links.


### PR DESCRIPTION
## Description

Makes the citations/references shown in the **on-screen AI Summary**, the **PDF "Export research"**, and the **Word "Export to Word" (`.docx`)** all agree — driven by a single shared numbering module.

### Root cause
A citation marker in the summary text (e.g. `[2]`) is a **1-based index into the exact result array sent to the LLM**. Three surfaces resolved/renumbered citations with three independent copies of the logic:

1. **On-screen** (`AiSummaryWithCitations` / `AiSummaryReferences`) resolved `[N]` against a `minScore`-**filtered, re-indexed** array → whenever `minScore` removed a result, citations shifted to the wrong document or were dropped.
2. **PDF export** (`exportResearch`) used the **full** array (correct), but with its own numbering copy.
3. **Word export** (`exportResultsToDocx`) used the full array for its **reference list** (sequential numbering) but rendered **inline** `[N]` markers with the **original** number — internally inconsistent, and different again from the other two.

### Changes
- **Shared `utils/citations.ts`** — one source of truth for parsing, extracting and sequencing citation numbers, consumed by all three surfaces so they can never drift again.
- **On-screen** now resolves citations against the same full LLM array the exports use (no more `minScore` re-indexing).
- **Word export** routes its parsing/numbering through the shared util, and renders inline `[N]` markers using the **sequential** number (hyperlink still targets the original result) so inline markers match its own References list and the other surfaces.
- **Tests**: `citations.test.ts` (util + reference grouping + a regression for the screen/export discrepancy); a new docx test pinning the inline sequential rendering; the docx exporter's duplicated `extractCitationNumbers` removed (now covered by the shared util's tests).

### ⚠️ Note on the retained `minScore` prop
`minScore` is intentionally **kept** on `AiSummaryPanel`'s public props (the parent still passes it for the results-list filtering it owns) but is no longer used to filter the summary's result array — filtering it shifts indices and breaks the citation mapping. It is omitted from the component's destructuring to avoid an unused-local lint error, and documented inline. Relevance filtering will be reintroduced **upstream of summary generation** in a follow-up, after which all surfaces inherit it automatically.

### Behavioural consequence
The on-screen summary now shows **all cited references** (matching both exports) instead of hiding low-`minScore` ones. Choosing which documents are "relevant enough" is the deferred upstream-filter work.

## Type of Change
- [x] Bug fix

## Testing
- [x] `npm test -- --watchAll=false --runInBand` — 48 suites / 433 tests pass
- [x] `tsc --noEmit` clean
- [x] `pre-commit` hooks pass on changed files
- [x] Local `ui` container rebuilt (installed `docx`/`file-saver`); app compiles and serves; the "Export to Word" button is present
- [x] Manual end-to-end check pending: run a search where `minScore > 0` would hide a cited doc; confirm on-screen, PDF and Word citations all match one-for-one

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added for the fix
- [x] Rebased onto current `rc/v1.5.0`
