### PR TITLE
ci: update dependabot target-branch from rc/v1.5.0 to rc/v1.6.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -21,7 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -36,7 +36,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:
@@ -49,7 +49,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:
@@ -62,7 +62,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:
@@ -75,7 +75,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
v1.5.0 is released and merged to `main`. Point Dependabot at the new release-candidate line `rc/v1.6.0` (created off `main`) so dependency PRs land on the next RC instead of the now-released `rc/v1.5.0`.

- Updates all 6 ecosystem blocks (pip, npm, 3× docker, github-actions) `target-branch` → `rc/v1.6.0`.
- `rc/v1.6.0` branch already exists (created off `main`), so Dependabot has a valid target.

Mirrors #322 (rc/v1.4.0 → rc/v1.5.0) from the previous release cycle.

The two open Dependabot PRs against `rc/v1.5.0` (axios, langchain) will be recreated against `rc/v1.6.0` on the next run.