### PR TITLE
revert: undo langgraph-prebuilt 1.0.8→1.1.0 (restore deliberate pin)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ google-cloud-discoveryengine>=0.13.0
 # breaking CI. Keep these in lockstep with the working runtime versions.
 deepagents>=0.4.0
 langgraph==1.2.4
-langgraph-prebuilt==1.1.0
+langgraph-prebuilt==1.0.8
 langgraph-checkpoint-postgres>=2.0.25
 
 # Task queue


### PR DESCRIPTION
Reverts #315, which auto-merged `langgraph-prebuilt 1.0.8 → 1.1.0` into `rc/v1.6.0`.

`requirements.txt` deliberately pins `langgraph-prebuilt==1.0.8` (commit ceab7ed):

> Pinned: newer langgraph-prebuilt releases import ExecutionInfo from langgraph.runtime which the matching langgraph version does not expose, breaking CI. Keep these in lockstep with the working runtime versions.

#315 was auto-merged before its `tests` job completed (the rc branch had no required status checks at the time), bypassing the pin. This restores 1.0.8.

Note: the `tests`/`sbom` jobs on this PR fail for an unrelated, pre-existing reason — the base has `langchain==1.3.7` pinned against `langchain-core==1.2.19` (needs >=1.4.0), tracked separately.