### PR TITLE
fix(demo): repair host-mode demo (v1.5.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Evidence Lab will be documented in this file.
 
+## [1.5.1] - 2026-06-11
+
+Evidence Lab v1.5.1 is a hotfix release that repairs the host-mode demo (`scripts/demo/run_demo.py --mode host`) following the README quickstart. Two bugs made a vanilla host run fail before any documents were indexed; both are now fixed and covered by regression tests.
+
+### Fixed
+- **Summarizer no longer requires a HuggingFace token for non-HuggingFace providers.** `SummarizeProcessor.setup()` demanded `HUGGINGFACE_API_KEY` unconditionally, even though the token is unused unless the LLM provider is HuggingFace. This blocked the demo's default **Azure Foundry** provider (and Google Vertex) for users supplying only their provider's own credentials. The requirement is now scoped to `provider == "huggingface"`.
+- **Empty `DATA_MOUNT_PATH` no longer breaks host-mode document scanning.** `.env.example` ships `DATA_MOUNT_PATH=` (empty); in host mode `os.getenv("DATA_MOUNT_PATH", "./data")` returned `""` (a present-but-empty var defeats the default), collapsing the scan path to an absolute `/<source>/pdfs` so no documents were found. Added `resolve_data_mount_path()` (treats empty as the `./data` default) and routed all host path-resolution sites through it. Docker mode was unaffected (it sets `DATA_MOUNT_PATH=/app/data` explicitly).
+
+### Tests
+- Added regression tests for `resolve_data_mount_path()` (empty/unset/set) and for the summarizer's provider-scoped HuggingFace requirement.
+
+**Full diff:** https://github.com/dividor/evidencelab/compare/v1.5.0...v1.5.1
+
+---
+
 ## [1.5.0] - 2026-06-11
 
 Evidence Lab v1.5.0 is a feature release focused on admin observability, research and assistant quality, and operational tooling. It adds LLM token/cost tracking and an admin usage dashboard, a page feedback button with screenshot capture, a polished Word export, sliding auth sessions, and a number of search/facet/research fixes.

--- a/pipeline/orchestrator/core_impl.py
+++ b/pipeline/orchestrator/core_impl.py
@@ -21,6 +21,7 @@ from pipeline.orchestrator.core_docs import (
 from pipeline.orchestrator.core_processing import mark_as_stopped, run_processing
 from pipeline.orchestrator.log_config import setup_logging
 from pipeline.processors import ScanProcessor
+from pipeline.processors.parsing.parser_constants import resolve_data_mount_path
 from pipeline.utilities.embedding_server import EmbeddingServerManager
 
 logger = setup_logging()
@@ -59,7 +60,7 @@ class PipelineOrchestrator:
         self.data_source = data_source
         self.doc_id = doc_id
         self.ocr_fallback = ocr_fallback
-        base_data_dir = os.getenv("DATA_MOUNT_PATH", "./data")
+        base_data_dir = resolve_data_mount_path()
         self.data_dir = f"{base_data_dir}/{data_source}"
         self.skip_download = skip_download
         self.skip_scan = skip_scan

--- a/pipeline/orchestrator/worker.py
+++ b/pipeline/orchestrator/worker.py
@@ -20,6 +20,7 @@ from pipeline.processors import (
     SummarizeProcessor,
     TaggerProcessor,
 )
+from pipeline.processors.parsing.parser_constants import resolve_data_mount_path
 from pipeline.utilities.embedding_service import EmbeddingService
 from pipeline.utilities.logging_utils import _log_context
 
@@ -218,7 +219,7 @@ def _generate_processing_log(doc_id: str, parsed_folder: Optional[str]) -> None:
         return
 
     try:
-        data_mount_path = os.getenv("DATA_MOUNT_PATH", "./data")
+        data_mount_path = resolve_data_mount_path()
         if parsed_folder.startswith("data/"):
             parsed_folder = os.path.join(data_mount_path, parsed_folder[5:])
 
@@ -362,7 +363,7 @@ def _init_embedding_service(
 def _init_parser(
     data_source: str, pipeline_config: Dict[str, Any] | None = None
 ) -> None:
-    base_data_dir = os.getenv("DATA_MOUNT_PATH", "./data")
+    base_data_dir = resolve_data_mount_path()
     data_dir = f"{base_data_dir}/{data_source}"
     parsed_dir = f"{data_dir}/parsed"
     parse_config = (pipeline_config or {}).get("parse", {})

--- a/pipeline/processors/indexing/indexer.py
+++ b/pipeline/processors/indexing/indexer.py
@@ -8,7 +8,6 @@ Includes document chunking using Docling's HybridChunker.
 
 import json
 import logging
-import os
 import shutil
 import time
 import uuid
@@ -35,6 +34,7 @@ from pipeline.db import (
 )
 from pipeline.processors.base import BaseProcessor
 from pipeline.processors.indexing.chunker import Chunker
+from pipeline.processors.parsing.parser_constants import resolve_data_mount_path
 from pipeline.utilities.embedding_service import EmbeddingService
 
 load_dotenv()
@@ -346,7 +346,7 @@ class IndexProcessor(BaseProcessor):
         }
 
     def _normalize_parsed_folder(self, parsed_folder: str) -> str:
-        data_mount_path = os.getenv("DATA_MOUNT_PATH", "./data")
+        data_mount_path = resolve_data_mount_path()
         logger.debug(
             "DEBUG_INDEXER: parsed_folder='%s', data_mount_path='%s'",
             parsed_folder,

--- a/pipeline/processors/parsing/parser.py
+++ b/pipeline/processors/parsing/parser.py
@@ -49,8 +49,8 @@ from pipeline.processors.parsing.parser_chunking import (
 )
 from pipeline.processors.parsing.parser_constants import (
     DATA_PATH_PREFIX,
-    DEFAULT_DATA_MOUNT_PATH,
     PAGE_SEPARATOR,
+    resolve_data_mount_path,
 )
 from pipeline.processors.parsing.parser_core import parse_document_internal
 from pipeline.processors.parsing.parser_headings import (
@@ -446,7 +446,7 @@ class ParseProcessor(BaseProcessor):
 
     def _resolve_data_filepath(self, filepath: str) -> str:
         """Resolve stored data paths using DATA_MOUNT_PATH."""
-        data_mount_path = os.getenv("DATA_MOUNT_PATH", DEFAULT_DATA_MOUNT_PATH)
+        data_mount_path = resolve_data_mount_path()
         if filepath.startswith(DATA_PATH_PREFIX):
             return os.path.join(data_mount_path, filepath[len(DATA_PATH_PREFIX) :])
         return filepath

--- a/pipeline/processors/parsing/parser_constants.py
+++ b/pipeline/processors/parsing/parser_constants.py
@@ -1,6 +1,22 @@
 """Shared constants for parsing processors."""
 
+import os
+
 # Page separator pattern for markdown output
 PAGE_SEPARATOR = "\n\n------- Page Break -------\n\n"
 DATA_PATH_PREFIX = "data/"
 DEFAULT_DATA_MOUNT_PATH = "./data"
+
+
+def resolve_data_mount_path() -> str:
+    """Return the configured data mount path, defaulting to ``./data``.
+
+    ``os.getenv("DATA_MOUNT_PATH", DEFAULT_DATA_MOUNT_PATH)`` only falls back to
+    the default when the variable is *absent*. A present-but-empty value — e.g.
+    ``DATA_MOUNT_PATH=`` shipped in ``.env.example`` and loaded by
+    ``run_pipeline_host.sh`` in host mode — makes ``getenv`` return ``""``,
+    which collapses ``f"{base}/{src}/pdfs"`` to an absolute ``/src/pdfs`` and
+    breaks scanning. Treating empty as unset keeps host and Docker runs
+    consistent (Docker sets ``DATA_MOUNT_PATH=/app/data`` explicitly).
+    """
+    return os.getenv("DATA_MOUNT_PATH") or DEFAULT_DATA_MOUNT_PATH

--- a/pipeline/processors/summarization/summarizer.py
+++ b/pipeline/processors/summarization/summarizer.py
@@ -205,9 +205,12 @@ class SummarizeProcessor(BaseProcessor):
                 "Ensure the worker provides an EmbeddingService instance."
             )
 
-        # Get HuggingFace token
+        # HuggingFace token is only required when the LLM provider is
+        # HuggingFace. Other providers (Azure Foundry, Google Vertex) authenticate
+        # with their own credentials, so demanding an HF token here would block
+        # them needlessly (the token is otherwise unused).
         self._hf_token = os.getenv("HUGGINGFACE_API_KEY") or os.getenv("HF_TOKEN")
-        if not self._hf_token:
+        if self.provider == "huggingface" and not self._hf_token:
             raise ValueError(
                 "HUGGINGFACE_API_KEY or HF_TOKEN not found in environment. "
                 "Get your token at https://huggingface.co/settings/tokens"

--- a/tests/unit/test_data_mount_path.py
+++ b/tests/unit/test_data_mount_path.py
@@ -1,0 +1,35 @@
+"""Regression tests for DATA_MOUNT_PATH resolution.
+
+A present-but-empty ``DATA_MOUNT_PATH`` (shipped as ``DATA_MOUNT_PATH=`` in
+``.env.example`` and loaded by ``run_pipeline_host.sh`` in host mode) used to
+collapse the scan/parse path to an absolute ``/<source>/pdfs`` and silently find
+no documents. ``resolve_data_mount_path`` must treat empty as unset.
+"""
+
+import pytest
+
+from pipeline.processors.parsing.parser_constants import (
+    DEFAULT_DATA_MOUNT_PATH,
+    resolve_data_mount_path,
+)
+
+
+@pytest.mark.unit
+def test_resolve_data_mount_path_empty_returns_default(monkeypatch):
+    """An empty env var (host-mode .env) falls back to the default."""
+    monkeypatch.setenv("DATA_MOUNT_PATH", "")
+    assert resolve_data_mount_path() == DEFAULT_DATA_MOUNT_PATH
+
+
+@pytest.mark.unit
+def test_resolve_data_mount_path_unset_returns_default(monkeypatch):
+    """An absent env var falls back to the default."""
+    monkeypatch.delenv("DATA_MOUNT_PATH", raising=False)
+    assert resolve_data_mount_path() == DEFAULT_DATA_MOUNT_PATH
+
+
+@pytest.mark.unit
+def test_resolve_data_mount_path_set_returns_value(monkeypatch):
+    """A configured value is returned verbatim (e.g. Docker's /app/data)."""
+    monkeypatch.setenv("DATA_MOUNT_PATH", "/app/data")
+    assert resolve_data_mount_path() == "/app/data"

--- a/tests/unit/test_summarizer_hf_requirement.py
+++ b/tests/unit/test_summarizer_hf_requirement.py
@@ -1,0 +1,69 @@
+"""Regression tests for the summarizer's HuggingFace token requirement.
+
+The summarizer previously demanded ``HUGGINGFACE_API_KEY`` unconditionally at
+setup, even though the token is only relevant to the HuggingFace provider. That
+blocked the demo's default Azure Foundry provider (and Google Vertex) for any
+user supplying only their provider's own credentials. The requirement must be
+scoped to ``provider == "huggingface"``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipeline.processors.summarization.summarizer import SummarizeProcessor
+
+
+def _make_processor(provider: str) -> SummarizeProcessor:
+    # An unknown model key routes through the backward-compat branch, so the
+    # provider is taken verbatim from config — letting us pin it deterministically.
+    return SummarizeProcessor(
+        config={
+            "llm_model": {"model": "unit-test-model", "provider": provider},
+            "dense_model": "azure_small",
+        }
+    )
+
+
+@pytest.mark.unit
+def test_setup_does_not_require_hf_token_for_azure(monkeypatch):
+    """Azure provider must set up without any HuggingFace token present."""
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+
+    processor = _make_processor("azure_foundry")
+    embedding_service = MagicMock()
+    embedding_service.get_model.return_value = MagicMock()
+
+    processor.setup(embedding_service=embedding_service)  # must not raise
+
+    assert processor.provider == "azure_foundry"
+
+
+@pytest.mark.unit
+def test_setup_requires_hf_token_for_huggingface(monkeypatch):
+    """HuggingFace provider still fails fast when no token is configured."""
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+
+    processor = _make_processor("huggingface")
+    embedding_service = MagicMock()
+    embedding_service.get_model.return_value = MagicMock()
+
+    with pytest.raises(ValueError, match="HUGGINGFACE_API_KEY"):
+        processor.setup(embedding_service=embedding_service)
+
+
+@pytest.mark.unit
+def test_setup_uses_hf_token_for_huggingface_when_present(monkeypatch):
+    """HuggingFace provider sets up cleanly once a token is available."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_unit_test_token")
+
+    processor = _make_processor("huggingface")
+    embedding_service = MagicMock()
+    embedding_service.get_model.return_value = MagicMock()
+
+    processor.setup(embedding_service=embedding_service)  # must not raise
+
+    assert processor._hf_token == "hf_unit_test_token"


### PR DESCRIPTION
## Summary

**Emergency hotfix (v1.5.1) for `main`.** The README host-mode demo (`scripts/demo/run_demo.py --mode host`) fails before indexing any documents in a vanilla run. Two independent bugs, both verified and now fixed with regression tests.

### Bug 1 — summarizer demands an unused HuggingFace token
`SummarizeProcessor.setup()` required `HUGGINGFACE_API_KEY` unconditionally, but `self._hf_token` is **never used** after assignment. This hard-blocked the demo's default **Azure Foundry** provider (and Google Vertex) for users supplying only their provider's credentials. → Requirement scoped to `provider == "huggingface"`.

### Bug 2 — empty `DATA_MOUNT_PATH` breaks host scanning
`.env.example` ships `DATA_MOUNT_PATH=` (empty). In host mode `os.getenv("DATA_MOUNT_PATH", "./data")` returns `""` (a present-but-empty var defeats the default), so the scan path collapses to `/<source>/pdfs` and **zero documents** are found. → Added `resolve_data_mount_path()` (treats empty as `./data`) and routed all five host path sites through it. Docker mode unaffected (sets `DATA_MOUNT_PATH=/app/data` explicitly).

## Why CI didn't catch this
The `Demo E2E` workflow only ever exercises **Docker mode** (`docker compose exec pipeline ...`, where `DATA_MOUNT_PATH=/app/data`) and **always injects `HUGGINGFACE_API_KEY`** as a secret — so it green-lights a configuration no host/Azure-only user runs. Follow-up worth considering: extend Demo E2E with a host-mode / Azure-without-HF leg.

## Verification (run locally, end-to-end)
Vanilla host demo — empty `DATA_MOUNT_PATH`, Azure Foundry, **no HF key**:
- Scanner found all 3 docs (was `/demo/pdfs` → nothing)
- Summarizer ran with no HF token present
- `PIPELINE COMPLETE` in 226.7s; **3/3 docs `indexed`**, Qdrant `documents_demo`=3 / `chunks_demo`=239
- `GET /search?data_source=demo` → 50 results

## Tests
- `tests/unit/test_data_mount_path.py` — empty/unset/set resolution
- `tests/unit/test_summarizer_hf_requirement.py` — Azure sets up without HF; HuggingFace still fails fast without a token

## Release notes
- `CHANGELOG.md` updated with a `[1.5.1]` hotfix entry.

After merge: tag `v1.5.1` + publish GitHub release.
