### PR TITLE
chore: align rc/v1.6.0 with main (adopt main wholesale)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -21,7 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -36,7 +36,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:
@@ -49,7 +49,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:
@@ -62,7 +62,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:
@@ -75,7 +75,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "rc/v1.5.0"
+    target-branch: "rc/v1.6.0"
     schedule:
       interval: "monthly"
     labels:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@v2
 
       - name: Enable auto-merge for patch and minor bumps
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Evidence Lab will be documented in this file.
 
+## [1.5.1] - 2026-06-11
+
+Evidence Lab v1.5.1 is a hotfix release that repairs the host-mode demo (`scripts/demo/run_demo.py --mode host`) following the README quickstart. Two bugs made a vanilla host run fail before any documents were indexed; both are now fixed and covered by regression tests.
+
+### Fixed
+- **Summarizer no longer requires a HuggingFace token for non-HuggingFace providers.** `SummarizeProcessor.setup()` demanded `HUGGINGFACE_API_KEY` unconditionally, even though the token is unused unless the LLM provider is HuggingFace. This blocked the demo's default **Azure Foundry** provider (and Google Vertex) for users supplying only their provider's own credentials. The requirement is now scoped to `provider == "huggingface"`.
+- **Empty `DATA_MOUNT_PATH` no longer breaks host-mode document scanning.** `.env.example` ships `DATA_MOUNT_PATH=` (empty); in host mode `os.getenv("DATA_MOUNT_PATH", "./data")` returned `""` (a present-but-empty var defeats the default), collapsing the scan path to an absolute `/<source>/pdfs` so no documents were found. Added `resolve_data_mount_path()` (treats empty as the `./data` default) and routed all host path-resolution sites through it. Docker mode was unaffected (it sets `DATA_MOUNT_PATH=/app/data` explicitly).
+
+### Tests
+- Added regression tests for `resolve_data_mount_path()` (empty/unset/set) and for the summarizer's provider-scoped HuggingFace requirement.
+
+**Full diff:** https://github.com/dividor/evidencelab/compare/v1.5.0...v1.5.1
+
+---
+
 ## [1.5.0] - 2026-06-11
 
 Evidence Lab v1.5.0 is a feature release focused on admin observability, research and assistant quality, and operational tooling. It adds LLM token/cost tracking and an admin usage dashboard, a page feedback button with screenshot capture, a polished Word export, sliding auth sessions, and a number of search/facet/research fixes.

--- a/pipeline/orchestrator/core_impl.py
+++ b/pipeline/orchestrator/core_impl.py
@@ -21,6 +21,7 @@ from pipeline.orchestrator.core_docs import (
 from pipeline.orchestrator.core_processing import mark_as_stopped, run_processing
 from pipeline.orchestrator.log_config import setup_logging
 from pipeline.processors import ScanProcessor
+from pipeline.processors.parsing.parser_constants import resolve_data_mount_path
 from pipeline.utilities.embedding_server import EmbeddingServerManager
 
 logger = setup_logging()
@@ -59,7 +60,7 @@ class PipelineOrchestrator:
         self.data_source = data_source
         self.doc_id = doc_id
         self.ocr_fallback = ocr_fallback
-        base_data_dir = os.getenv("DATA_MOUNT_PATH", "./data")
+        base_data_dir = resolve_data_mount_path()
         self.data_dir = f"{base_data_dir}/{data_source}"
         self.skip_download = skip_download
         self.skip_scan = skip_scan

--- a/pipeline/orchestrator/worker.py
+++ b/pipeline/orchestrator/worker.py
@@ -20,6 +20,7 @@ from pipeline.processors import (
     SummarizeProcessor,
     TaggerProcessor,
 )
+from pipeline.processors.parsing.parser_constants import resolve_data_mount_path
 from pipeline.utilities.embedding_service import EmbeddingService
 from pipeline.utilities.logging_utils import _log_context
 
@@ -218,7 +219,7 @@ def _generate_processing_log(doc_id: str, parsed_folder: Optional[str]) -> None:
         return
 
     try:
-        data_mount_path = os.getenv("DATA_MOUNT_PATH", "./data")
+        data_mount_path = resolve_data_mount_path()
         if parsed_folder.startswith("data/"):
             parsed_folder = os.path.join(data_mount_path, parsed_folder[5:])
 
@@ -362,7 +363,7 @@ def _init_embedding_service(
 def _init_parser(
     data_source: str, pipeline_config: Dict[str, Any] | None = None
 ) -> None:
-    base_data_dir = os.getenv("DATA_MOUNT_PATH", "./data")
+    base_data_dir = resolve_data_mount_path()
     data_dir = f"{base_data_dir}/{data_source}"
     parsed_dir = f"{data_dir}/parsed"
     parse_config = (pipeline_config or {}).get("parse", {})

--- a/pipeline/processors/indexing/indexer.py
+++ b/pipeline/processors/indexing/indexer.py
@@ -8,7 +8,6 @@ Includes document chunking using Docling's HybridChunker.
 
 import json
 import logging
-import os
 import shutil
 import time
 import uuid
@@ -35,6 +34,7 @@ from pipeline.db import (
 )
 from pipeline.processors.base import BaseProcessor
 from pipeline.processors.indexing.chunker import Chunker
+from pipeline.processors.parsing.parser_constants import resolve_data_mount_path
 from pipeline.utilities.embedding_service import EmbeddingService
 
 load_dotenv()
@@ -346,7 +346,7 @@ class IndexProcessor(BaseProcessor):
         }
 
     def _normalize_parsed_folder(self, parsed_folder: str) -> str:
-        data_mount_path = os.getenv("DATA_MOUNT_PATH", "./data")
+        data_mount_path = resolve_data_mount_path()
         logger.debug(
             "DEBUG_INDEXER: parsed_folder='%s', data_mount_path='%s'",
             parsed_folder,

--- a/pipeline/processors/parsing/parser.py
+++ b/pipeline/processors/parsing/parser.py
@@ -49,8 +49,8 @@ from pipeline.processors.parsing.parser_chunking import (
 )
 from pipeline.processors.parsing.parser_constants import (
     DATA_PATH_PREFIX,
-    DEFAULT_DATA_MOUNT_PATH,
     PAGE_SEPARATOR,
+    resolve_data_mount_path,
 )
 from pipeline.processors.parsing.parser_core import parse_document_internal
 from pipeline.processors.parsing.parser_headings import (
@@ -446,7 +446,7 @@ class ParseProcessor(BaseProcessor):
 
     def _resolve_data_filepath(self, filepath: str) -> str:
         """Resolve stored data paths using DATA_MOUNT_PATH."""
-        data_mount_path = os.getenv("DATA_MOUNT_PATH", DEFAULT_DATA_MOUNT_PATH)
+        data_mount_path = resolve_data_mount_path()
         if filepath.startswith(DATA_PATH_PREFIX):
             return os.path.join(data_mount_path, filepath[len(DATA_PATH_PREFIX) :])
         return filepath

--- a/pipeline/processors/parsing/parser_constants.py
+++ b/pipeline/processors/parsing/parser_constants.py
@@ -1,6 +1,22 @@
 """Shared constants for parsing processors."""
 
+import os
+
 # Page separator pattern for markdown output
 PAGE_SEPARATOR = "\n\n------- Page Break -------\n\n"
 DATA_PATH_PREFIX = "data/"
 DEFAULT_DATA_MOUNT_PATH = "./data"
+
+
+def resolve_data_mount_path() -> str:
+    """Return the configured data mount path, defaulting to ``./data``.
+
+    ``os.getenv("DATA_MOUNT_PATH", DEFAULT_DATA_MOUNT_PATH)`` only falls back to
+    the default when the variable is *absent*. A present-but-empty value — e.g.
+    ``DATA_MOUNT_PATH=`` shipped in ``.env.example`` and loaded by
+    ``run_pipeline_host.sh`` in host mode — makes ``getenv`` return ``""``,
+    which collapses ``f"{base}/{src}/pdfs"`` to an absolute ``/src/pdfs`` and
+    breaks scanning. Treating empty as unset keeps host and Docker runs
+    consistent (Docker sets ``DATA_MOUNT_PATH=/app/data`` explicitly).
+    """
+    return os.getenv("DATA_MOUNT_PATH") or DEFAULT_DATA_MOUNT_PATH

--- a/pipeline/processors/summarization/summarizer.py
+++ b/pipeline/processors/summarization/summarizer.py
@@ -205,9 +205,12 @@ class SummarizeProcessor(BaseProcessor):
                 "Ensure the worker provides an EmbeddingService instance."
             )
 
-        # Get HuggingFace token
+        # HuggingFace token is only required when the LLM provider is
+        # HuggingFace. Other providers (Azure Foundry, Google Vertex) authenticate
+        # with their own credentials, so demanding an HF token here would block
+        # them needlessly (the token is otherwise unused).
         self._hf_token = os.getenv("HUGGINGFACE_API_KEY") or os.getenv("HF_TOKEN")
-        if not self._hf_token:
+        if self.provider == "huggingface" and not self._hf_token:
             raise ValueError(
                 "HUGGINGFACE_API_KEY or HF_TOKEN not found in environment. "
                 "Get your token at https://huggingface.co/settings/tokens"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Web scraping and downloading
 beautifulsoup4==4.14.3
-requests==2.34.2
+requests==2.32.5
 openpyxl==3.1.5
 selenium==4.41.0
 webdriver-manager==4.0.2
@@ -13,7 +13,7 @@ pdfplumber==0.11.9
 
 # Docling for advanced PDF parsing with dependencies
 docling==2.58.0
-docling-core==2.81.0
+docling-core==2.70.1
 docling-hierarchical-pdf==0.1.2
 docling-ibm-models==3.11.0
 docling-parse==4.7.3
@@ -34,7 +34,7 @@ onnxruntime==1.23.2
 
 # Embeddings and vector DB
 sentence-transformers==2.7.0
-psycopg2-binary==2.9.12
+psycopg2-binary==2.9.11
 pgvector==0.4.2
 qdrant-client>=1.12.0
 fastembed==0.7.4
@@ -69,7 +69,7 @@ asyncpg==0.31.0
 aiosmtplib==5.1.0
 
 # LangChain and LLM integration
-langchain==1.3.7
+langchain==1.2.10
 langchain-core==1.2.19
 langchain-community==0.4.1
 langchain-huggingface==1.2.0
@@ -87,7 +87,7 @@ google-cloud-discoveryengine>=0.13.0
 # langgraph.runtime which the matching langgraph version does not expose,
 # breaking CI. Keep these in lockstep with the working runtime versions.
 deepagents>=0.4.0
-langgraph==1.2.4
+langgraph==1.0.10
 langgraph-prebuilt==1.0.8
 langgraph-checkpoint-postgres>=2.0.25
 
@@ -109,7 +109,7 @@ pre-commit==3.8.0
 black==24.10.0
 flake8==7.3.0
 isort==5.13.2
-mypy==1.20.2
+mypy==1.19.1
 mypy-extensions==1.1.0
 pytest==8.4.2
 pytest-cov==5.0.0

--- a/tests/unit/test_data_mount_path.py
+++ b/tests/unit/test_data_mount_path.py
@@ -1,0 +1,35 @@
+"""Regression tests for DATA_MOUNT_PATH resolution.
+
+A present-but-empty ``DATA_MOUNT_PATH`` (shipped as ``DATA_MOUNT_PATH=`` in
+``.env.example`` and loaded by ``run_pipeline_host.sh`` in host mode) used to
+collapse the scan/parse path to an absolute ``/<source>/pdfs`` and silently find
+no documents. ``resolve_data_mount_path`` must treat empty as unset.
+"""
+
+import pytest
+
+from pipeline.processors.parsing.parser_constants import (
+    DEFAULT_DATA_MOUNT_PATH,
+    resolve_data_mount_path,
+)
+
+
+@pytest.mark.unit
+def test_resolve_data_mount_path_empty_returns_default(monkeypatch):
+    """An empty env var (host-mode .env) falls back to the default."""
+    monkeypatch.setenv("DATA_MOUNT_PATH", "")
+    assert resolve_data_mount_path() == DEFAULT_DATA_MOUNT_PATH
+
+
+@pytest.mark.unit
+def test_resolve_data_mount_path_unset_returns_default(monkeypatch):
+    """An absent env var falls back to the default."""
+    monkeypatch.delenv("DATA_MOUNT_PATH", raising=False)
+    assert resolve_data_mount_path() == DEFAULT_DATA_MOUNT_PATH
+
+
+@pytest.mark.unit
+def test_resolve_data_mount_path_set_returns_value(monkeypatch):
+    """A configured value is returned verbatim (e.g. Docker's /app/data)."""
+    monkeypatch.setenv("DATA_MOUNT_PATH", "/app/data")
+    assert resolve_data_mount_path() == "/app/data"

--- a/tests/unit/test_summarizer_hf_requirement.py
+++ b/tests/unit/test_summarizer_hf_requirement.py
@@ -1,0 +1,69 @@
+"""Regression tests for the summarizer's HuggingFace token requirement.
+
+The summarizer previously demanded ``HUGGINGFACE_API_KEY`` unconditionally at
+setup, even though the token is only relevant to the HuggingFace provider. That
+blocked the demo's default Azure Foundry provider (and Google Vertex) for any
+user supplying only their provider's own credentials. The requirement must be
+scoped to ``provider == "huggingface"``.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipeline.processors.summarization.summarizer import SummarizeProcessor
+
+
+def _make_processor(provider: str) -> SummarizeProcessor:
+    # An unknown model key routes through the backward-compat branch, so the
+    # provider is taken verbatim from config — letting us pin it deterministically.
+    return SummarizeProcessor(
+        config={
+            "llm_model": {"model": "unit-test-model", "provider": provider},
+            "dense_model": "azure_small",
+        }
+    )
+
+
+@pytest.mark.unit
+def test_setup_does_not_require_hf_token_for_azure(monkeypatch):
+    """Azure provider must set up without any HuggingFace token present."""
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+
+    processor = _make_processor("azure_foundry")
+    embedding_service = MagicMock()
+    embedding_service.get_model.return_value = MagicMock()
+
+    processor.setup(embedding_service=embedding_service)  # must not raise
+
+    assert processor.provider == "azure_foundry"
+
+
+@pytest.mark.unit
+def test_setup_requires_hf_token_for_huggingface(monkeypatch):
+    """HuggingFace provider still fails fast when no token is configured."""
+    monkeypatch.delenv("HUGGINGFACE_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+
+    processor = _make_processor("huggingface")
+    embedding_service = MagicMock()
+    embedding_service.get_model.return_value = MagicMock()
+
+    with pytest.raises(ValueError, match="HUGGINGFACE_API_KEY"):
+        processor.setup(embedding_service=embedding_service)
+
+
+@pytest.mark.unit
+def test_setup_uses_hf_token_for_huggingface_when_present(monkeypatch):
+    """HuggingFace provider sets up cleanly once a token is available."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.setenv("HUGGINGFACE_API_KEY", "hf_unit_test_token")
+
+    processor = _make_processor("huggingface")
+    embedding_service = MagicMock()
+    embedding_service.get_model.return_value = MagicMock()
+
+    processor.setup(embedding_service=embedding_service)  # must not raise
+
+    assert processor._hf_token == "hf_unit_test_token"

--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "ajv": "^8.20.0",
         "ajv-keywords": "^5.1.0",
-        "axios": "^1.17.0",
-        "docx": "^9.7.1",
+        "axios": "^1.13.6",
+        "docx": "^9.6.1",
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
         "pdfjs-dist": "^3.11.174",
@@ -24,7 +24,7 @@
         "remark-gfm": "^4.0.1",
         "typescript": "^4.9.5",
         "xlsx-js-style": "^1.2.0",
-        "yaml": "^2.9.0"
+        "yaml": "^2.8.2"
       },
       "devDependencies": {
         "@playwright/test": "^1.60.0",
@@ -33,10 +33,10 @@
         "@testing-library/react": "^16.3.0",
         "@types/axios": "^0.9.36",
         "@types/file-saver": "^2.0.7",
-        "@types/node": "^25.9.3",
+        "@types/node": "^25.5.0",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
-        "@typescript-eslint/parser": "^8.61.0",
+        "@typescript-eslint/parser": "^8.60.1",
         "eslint": "^8.57.0",
         "eslint-plugin-security": "^2.1.0",
         "eslint-plugin-sonarjs": "^0.25.1",
@@ -4268,12 +4268,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -4480,16 +4480,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
-      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/typescript-estree": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4505,14 +4505,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
-      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.0",
-        "@typescript-eslint/types": "^8.61.0",
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4527,14 +4527,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
-      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0"
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4545,9 +4545,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
-      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4658,9 +4658,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
-      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4672,16 +4672,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
-      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.0",
-        "@typescript-eslint/tsconfig-utils": "8.61.0",
-        "@typescript-eslint/types": "8.61.0",
-        "@typescript-eslint/visitor-keys": "8.61.0",
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4834,13 +4834,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
-      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/types": "8.60.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5681,15 +5681,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
-      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.16.0",
+        "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "https-proxy-agent": "^5.0.1",
-        "proxy-from-env": "^2.1.0"
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -8219,9 +8218,9 @@
       }
     },
     "node_modules/docx": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
-      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",
@@ -10270,9 +10269,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -18256,13 +18255,10 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",
@@ -21626,9 +21622,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -22963,9 +22959,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -5,8 +5,8 @@
   "dependencies": {
     "ajv": "^8.20.0",
     "ajv-keywords": "^5.1.0",
-    "axios": "^1.17.0",
-    "docx": "^9.7.1",
+    "axios": "^1.13.6",
+    "docx": "^9.6.1",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
     "pdfjs-dist": "^3.11.174",
@@ -19,7 +19,7 @@
     "remark-gfm": "^4.0.1",
     "typescript": "^4.9.5",
     "xlsx-js-style": "^1.2.0",
-    "yaml": "^2.9.0"
+    "yaml": "^2.8.2"
   },
   "scripts": {
     "copy-docs": "node scripts/copy-docs.js",
@@ -69,10 +69,10 @@
     "@testing-library/react": "^16.3.0",
     "@types/axios": "^0.9.36",
     "@types/file-saver": "^2.0.7",
-    "@types/node": "^25.9.3",
+    "@types/node": "^25.5.0",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "@typescript-eslint/parser": "^8.61.0",
+    "@typescript-eslint/parser": "^8.60.1",
     "eslint": "^8.57.0",
     "eslint-plugin-security": "^2.1.0",
     "eslint-plugin-sonarjs": "^0.25.1",


### PR DESCRIPTION
Makes `rc/v1.6.0` identical to `main`. The branch tree is now byte-for-byte `main`.

**Why:** `rc/v1.6.0` was red on its own (3 failing CI runs) — Dependabot had bumped `langchain` to 1.3.7 while `langchain-core` stayed pinned at 1.2.19 (`langchain 1.3.7` requires `langchain-core>=1.4.0` → ResolutionImpossible). Rather than hand-patch pins, this adopts main's known-good set wholesale, which also carries the v1.5.1 demo hotfix.

Net effect after merge: `rc/v1.6.0 == main` (working deps, v1.5.1 fix included). Dependabot can re-propose bumps against the clean branch.