### PR TITLE
fix(search): split multi-value country/region facets in typeahead

### DIFF
--- a/tests/unit/test_ui_backend_search.py
+++ b/tests/unit/test_ui_backend_search.py
@@ -281,6 +281,38 @@ def test_search_facet_values_filters_and_maps(monkeypatch):
     assert results == [{"value": "Org A", "count": 3}]
 
 
+def test_search_facet_values_splits_multivalue(monkeypatch):
+    # A multi-value (e.g. multi-country) document is stored as a single
+    # "; "-joined payload. The typeahead facet endpoint must split it so each
+    # constituent value is its own option, with counts aggregated across
+    # standalone and multi-value documents.
+    class Hit:
+        def __init__(self, value, count):
+            self.value = value
+            self.count = count
+
+    fake_db = _make_fake_db(
+        facet_result=SimpleNamespace(
+            hits=[Hit("Rwanda", 8), Hit("Burundi; Djibouti; Rwanda", 2)]
+        )
+    )
+
+    all_values = search.search_facet_values(
+        field="organization", query="", db=fake_db, data_source="uneg", limit=10
+    )
+    assert {r["value"]: r["count"] for r in all_values} == {
+        "Rwanda": 10,
+        "Burundi": 2,
+        "Djibouti": 2,
+    }
+
+    # Typeahead "rw" returns the split single value, not the combined bucket.
+    filtered = search.search_facet_values(
+        field="organization", query="rw", db=fake_db, data_source="uneg", limit=10
+    )
+    assert filtered == [{"value": "Rwanda", "count": 10}]
+
+
 def test_search_facet_values_returns_empty_on_error(monkeypatch):
     class _Client:
         def facet(self, **_kwargs):

--- a/ui/backend/services/search.py
+++ b/ui/backend/services/search.py
@@ -1331,10 +1331,20 @@ def search_facet_values(
         else:
             hits = result.hits
 
+        # Split '; '-joined multi-value payloads (e.g. multi-country docs) so
+        # each constituent value becomes its own facet option, instead of a
+        # single combined "A; B; C" bucket.
+        from ui.backend.utils.facet_helpers import (  # noqa: PLC0415
+            _accumulate_raw_value,
+        )
+
+        counter: Counter = Counter()
+        for hit in hits:
+            if hit.value in (None, ""):
+                continue
+            _accumulate_raw_value(counter, hit.value, hit.count)
         facets_list = [
-            {"value": str(hit.value), "count": hit.count}
-            for hit in hits
-            if hit.value not in (None, "")
+            {"value": value, "count": count} for value, count in counter.most_common()
         ]
         if not query_value:
             return facets_list


### PR DESCRIPTION
## Problem
In the search filter panel, the **country** typeahead shows combined `"Burundi; Djibouti; Ethiopia; …"` options instead of individual countries. A multi-country document is stored as a single `"; "`-joined `map_country` string, and the typeahead endpoint (`search_facet_values`) returned Qdrant's raw distinct values without splitting them.

## Fix
The main facet list (`build_generic_facets`) already splits multi-values; this aligns the typeahead path by reusing the same count-aware splitter (`_accumulate_raw_value`). Now each country/region is its own facet option, with counts aggregated across standalone and multi-value documents. Applies to any `"; "`-separated field (country, region).

## Testing
- New unit test `test_search_facet_values_splits_multivalue` (split + count aggregation + typeahead filter)
- `pre-commit` green (black, isort, flake8, mypy, bandit, code-metrics)

## Type of Change
- [x] Bug fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)