### PR TITLE
feat(ui): make logo and title link to the home page

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -211,6 +211,13 @@ h6,
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.top-bar-brand:hover .app-title {
+  text-decoration: underline;
 }
 
 .top-bar-controls {

--- a/ui/frontend/src/components/layout/TopBar.test.tsx
+++ b/ui/frontend/src/components/layout/TopBar.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { TopBar } from './TopBar';
+
+// Isolate the brand: stub child components that pull in auth/model context.
+// jest.mock is hoisted above the imports by the transform, so the mocks
+// still apply to the TopBar import above.
+jest.mock('./ModelComboPanel', () => ({ ModelComboPanel: () => null }));
+jest.mock('../auth/UserMenu', () => () => null);
+
+const noop = () => {};
+
+const baseProps: any = {
+  selectedDomain: 'WFP',
+  availableDomains: ['WFP'],
+  datasetTotals: { WFP: 333 },
+  selectedModelCombo: 'default',
+  availableModelCombos: ['default'],
+  modelCombos: {},
+  domainDropdownOpen: false,
+  modelDropdownOpen: false,
+  helpDropdownOpen: false,
+  showDomainTooltip: false,
+  onToggleDomainDropdown: noop,
+  onToggleModelDropdown: noop,
+  onDomainMouseEnter: noop,
+  onDomainMouseLeave: noop,
+  onDomainBlur: noop,
+  onModelBlur: noop,
+  onSelectDomain: noop,
+  onSelectModelCombo: noop,
+  onToggleHelpDropdown: noop,
+  onHelpBlur: noop,
+  onAboutClick: noop,
+  onTechClick: noop,
+  onDataClick: noop,
+  onDocsClick: noop,
+};
+
+describe('TopBar brand link', () => {
+  it('renders the logo and title as a link to the home page', () => {
+    render(<TopBar {...baseProps} />);
+    const link = screen.getByRole('link', { name: /go to home page/i });
+    expect(link.tagName).toBe('A');
+    expect(link.getAttribute('href')).toBe('/');
+    // logo + title live inside the link
+    screen.getByAltText('Evidence Lab Logo');
+    screen.getByText('Evidence Lab');
+  });
+
+  it('navigates home via SPA history on a plain click (no full reload)', () => {
+    const pushState = jest.spyOn(window.history, 'pushState');
+    const dispatch = jest.spyOn(window, 'dispatchEvent');
+    render(<TopBar {...baseProps} />);
+
+    const link = screen.getByRole('link', { name: /go to home page/i });
+    const clickEvent = fireEvent.click(link);
+
+    expect(pushState).toHaveBeenCalledWith(null, '', '/');
+    expect(
+      dispatch.mock.calls.some(([evt]) => (evt as Event).type === 'popstate')
+    ).toBe(true);
+    // default navigation is prevented so the SPA does not do a full reload
+    expect(clickEvent).toBe(false);
+
+    pushState.mockRestore();
+    dispatch.mockRestore();
+  });
+
+  it('does not hijack modified clicks (e.g. open-in-new-tab)', () => {
+    const pushState = jest.spyOn(window.history, 'pushState');
+    render(<TopBar {...baseProps} />);
+
+    const link = screen.getByRole('link', { name: /go to home page/i });
+    fireEvent.click(link, { metaKey: true });
+
+    expect(pushState).not.toHaveBeenCalled();
+    pushState.mockRestore();
+  });
+});

--- a/ui/frontend/src/components/layout/TopBar.tsx
+++ b/ui/frontend/src/components/layout/TopBar.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ModelComboConfig } from '../../types/api';
-import { USER_MODULE } from '../../config';
+import { APP_BASE_PATH, USER_MODULE } from '../../config';
 import UserMenu from '../auth/UserMenu';
 import { ModelComboPanel } from './ModelComboPanel';
 
@@ -124,14 +124,41 @@ export const TopBar = ({
     return `calc(${charCount}ch + 1.5rem)`;
   }, [availableDomains, getDomainLabelText]);
 
+  // Clicking the logo/title returns the user to the home page.
+  const homeHref = `${APP_BASE_PATH}/`;
+  const handleBrandClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    // Let modified clicks (new tab/window) and non-primary buttons behave
+    // natively so the underlying link still works as expected.
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    window.history.pushState(null, '', homeHref);
+    // Reuse the app's existing popstate routing to reset to the home view
+    // without a full page reload.
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  };
+
   return (
     <header className="top-bar">
       <div className="top-bar-content">
         <div className="top-bar-left">
-          <div className="top-bar-brand">
+          <a
+            className="top-bar-brand"
+            href={homeHref}
+            onClick={handleBrandClick}
+            aria-label="Evidence Lab — go to home page"
+          >
             <img src="/logo.png" alt="Evidence Lab Logo" className="app-logo" />
             <h1 className="app-title">Evidence Lab</h1>
-          </div>
+          </a>
           <div className="top-bar-controls">
             <div className="dropdown-container">
             <button


### PR DESCRIPTION
## Description
Makes the **Evidence Lab logo and title** in the top bar clickable — clicking either returns the user to the home page.

## Implementation
- Wrapped the logo + title (`.top-bar-brand`) in an accessible `<a>` link to the app home.
- **Plain left-click** navigates in-app via `pushState` + the app's existing `popstate` routing → **no full reload**.
- **Modified clicks** (cmd/ctrl/shift/alt, middle-click) fall through to native link behavior (open in new tab, etc.).
- Home target respects `APP_BASE_PATH` for prefixed deployments (e.g. `/evidencelab/`).
- Added pointer cursor + hover underline affordance.

## Testing
- New `TopBar.test.tsx` (3 cases): link target, SPA navigation (pushState + popstate, default prevented), and that modified clicks aren't hijacked.
- `tsc --noEmit` clean; ESLint 0 errors; tests pass via `react-scripts test`.

## Type of Change
- [x] New feature (UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)