### PR TITLE
feat(ui): add exact (literal) in-document search mode to the PDF viewer

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -6034,6 +6034,39 @@ li.ai-fact-active::before {
   border-top: 1px solid var(--gray-200);
 }
 
+.pdf-search-mode-toggle {
+  display: inline-flex;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.pdf-search-mode-button {
+  background: var(--white);
+  color: var(--gray-600);
+  border: none;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  font-family: 'Poppins', sans-serif;
+  transition: all 0.2s;
+}
+
+.pdf-search-mode-button:not(:last-child) {
+  border-right: 1px solid var(--gray-300);
+}
+
+.pdf-search-mode-button:hover:not(.active) {
+  background: var(--gray-100);
+}
+
+.pdf-search-mode-button.active {
+  background: var(--primary-blue);
+  color: var(--white);
+}
+
 .pdf-search-input {
   flex: 1;
   min-width: 200px;

--- a/ui/frontend/src/components/PDFViewer.tsx
+++ b/ui/frontend/src/components/PDFViewer.tsx
@@ -363,7 +363,7 @@ const parseBBoxItem = (
   return { page, bbox: { l: coords[0], b: coords[1], r: coords[2], t: coords[3] } };
 };
 
-const findTextMatchesOnPage = (
+export const findTextMatchesOnPage = (
   items: any[],
   searchTerm: string,
   pageNum: number
@@ -405,6 +405,33 @@ const findTextMatchesOnPage = (
 
   return matches;
 };
+
+const searchModePlaceholder = (mode: 'exact' | 'semantic'): string =>
+  mode === 'semantic' ? 'Semantic search in document...' : 'Find in document...';
+
+// Exact | Semantic segmented toggle for the in-document search bar.
+// Kept module-level so its branching does not count toward PDFViewer's complexity.
+const SearchModeToggle: React.FC<{
+  searchMode: 'exact' | 'semantic';
+  onChange: (mode: 'exact' | 'semantic') => void;
+}> = ({ searchMode, onChange }) => (
+  <div className="pdf-search-mode-toggle" role="group" aria-label="Search mode">
+    <button
+      type="button"
+      className={`pdf-search-mode-button${searchMode === 'exact' ? ' active' : ''}`}
+      onClick={() => onChange('exact')}
+    >
+      Exact
+    </button>
+    <button
+      type="button"
+      className={`pdf-search-mode-button${searchMode === 'semantic' ? ' active' : ''}`}
+      onClick={() => onChange('semantic')}
+    >
+      Semantic
+    </button>
+  </div>
+);
 
 export const PDFViewer: React.FC<PDFViewerProps> = ({
   docId,
@@ -458,6 +485,9 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
   const [inPdfSearchResults, setInPdfSearchResults] = useState<HighlightBox[]>([]);
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
   const [isSearching, setIsSearching] = useState(false);
+  // Search mode: exact (client-side literal find) vs semantic (original API + LLM
+  // highlighting). Defaults to semantic to preserve the prior open-from-result behavior.
+  const [searchMode, setSearchMode] = useState<'exact' | 'semantic'>('semantic');
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const pagesContainerRef = useRef<HTMLDivElement>(null);
@@ -489,6 +519,7 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
     setInPdfSearchResults([]);
     setInPdfSearchQuery('');
     setCurrentMatchIndex(0);
+    setSearchMode('semantic');
   }, [docId, chunkId, pageNum]);
 
   // Load PDF
@@ -930,9 +961,10 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
       });
 
       console.log(`[Text Layer]Page ${pageNumber}: searchQuery = '${effectiveSearchQuery}', inPdfSearchQuery = '${inPdfSearchQuery}', highlights = ${pageHighlights.length}`);
-      // Highlight matching text in text layer (if search query exists)
+      // Highlight matching text in text layer (semantic mode only — exact mode
+      // shows the literal-match boxes drawn above, with no LLM highlighting).
       // IMPORTANT: Only highlight text that falls within the chunk bounding boxes
-      if (effectiveSearchQuery && effectiveSearchQuery.trim() && pageHighlights.length > 0) {
+      if (searchMode === 'semantic' && effectiveSearchQuery && effectiveSearchQuery.trim() && pageHighlights.length > 0) {
         console.log(`[Text Layer] Starting text layer highlighting for page ${pageNumber} with query: "${effectiveSearchQuery}"`);
 
         // Get all text spans in the text layer
@@ -1169,7 +1201,43 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
 
   // In-PDF search: semantic search via API filtered to this document,
   // plus local text matches for literal keyword hits
-  const performInPdfSearch = async (query: string) => {
+  // Exact mode: literal text find via the pdf.js text layer. No backend call and
+  // no LLM highlighting — instant, like a native PDF viewer's Find.
+  const runExactInPdfSearch = async (query: string) => {
+    const allHighlights: HighlightBox[] = [];
+    const navPoints: HighlightBox[] = [];
+    if (pdfDoc) {
+      const searchTerm = query.toLowerCase();
+      for (let pageNum = 1; pageNum <= totalPages; pageNum++) {
+        const pg = await pdfDoc.getPage(pageNum);
+        const textContent = await pg.getTextContent();
+        findTextMatchesOnPage(textContent.items, searchTerm, pageNum).forEach(m => {
+          allHighlights.push(m);
+          navPoints.push(m);
+        });
+      }
+    }
+    processedBBoxesRef.current.clear();
+    setInPdfSearchResults(navPoints);
+    setHighlights(mergeSequentialHighlights(allHighlights));
+    setCurrentMatchIndex(0);
+    if (navPoints.length > 0) {
+      hasSnappedToHighlight.current = false;
+      goToPage(navPoints[0].page);
+    }
+  };
+
+  // Switch search mode and re-run the active query under it. The mode is passed
+  // explicitly because the state update is async and would otherwise be stale.
+  const handleSearchModeChange = (mode: 'exact' | 'semantic') => {
+    if (mode === searchMode) return;
+    setSearchMode(mode);
+    if (inPdfSearchQuery.trim()) {
+      performInPdfSearch(inPdfSearchQuery, mode);
+    }
+  };
+
+  const performInPdfSearch = async (query: string, mode: 'exact' | 'semantic' = searchMode) => {
     if (!query.trim()) {
       setInPdfSearchResults([]);
       setCurrentMatchIndex(0);
@@ -1180,6 +1248,10 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
 
     setIsSearching(true);
     try {
+      if (mode === 'exact') {
+        await runExactInPdfSearch(query);
+        return;
+      }
       // --- Semantic search via API ---
       const params: any = {
         q: query,
@@ -1472,9 +1544,10 @@ export const PDFViewer: React.FC<PDFViewerProps> = ({
           </button>
         </div>
         <div className="pdf-search-controls">
+          <SearchModeToggle searchMode={searchMode} onChange={handleSearchModeChange} />
           <input
             type="text"
-            placeholder="Search in document..."
+            placeholder={searchModePlaceholder(searchMode)}
             value={inPdfSearchQuery}
             onChange={(e) => setInPdfSearchQuery(e.target.value)}
             onKeyPress={(e) => {

--- a/ui/frontend/src/tests/pdfExactSearch.test.ts
+++ b/ui/frontend/src/tests/pdfExactSearch.test.ts
@@ -1,0 +1,44 @@
+import { findTextMatchesOnPage } from '../components/PDFViewer';
+
+// Build a minimal pdf.js-style text item. transform = [a,b,c,d,e,f] where
+// e (index 4) is x, f (index 5) is y, and d (index 3) drives the height.
+const item = (str: string, x: number, width: number, height = 12) => ({
+  str,
+  transform: [height, 0, 0, height, x, 700],
+  width,
+  height,
+});
+
+describe('exact in-document search: findTextMatchesOnPage', () => {
+  test('finds a literal match within a text item (case-insensitive)', () => {
+    const items = [item('Ministry of Health', 72, 108)]; // 18 chars, avg width 6
+    const matches = findTextMatchesOnPage(items, 'health', 1);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0].page).toBe(1);
+    expect(matches[0].isTextMatch).toBe(true);
+    expect(matches[0].text).toBe('Health'); // original casing preserved
+    // 'Health' starts at char index 12 -> x = 72 + 12*(108/18) = 144
+    expect(matches[0].bbox.l).toBeCloseTo(144, 1);
+    expect(matches[0].bbox.r).toBeCloseTo(180, 1);
+  });
+
+  test('returns no matches when the term is absent', () => {
+    const items = [item('Ministry of Health', 72, 108)];
+    expect(findTextMatchesOnPage(items, 'finance', 1)).toHaveLength(0);
+  });
+
+  test('does not match across the synthetic gap between adjacent items', () => {
+    // pdf.js often splits runs; a synthetic space is inserted so "of"+"Health"
+    // never falsely matches a term that spans the boundary.
+    const items = [item('of', 50, 14), item('Health', 70, 42)];
+    expect(findTextMatchesOnPage(items, 'f he', 1)).toHaveLength(0);
+  });
+
+  test('still matches a term fully inside the second item', () => {
+    const items = [item('of', 50, 14), item('Health', 70, 42)];
+    const matches = findTextMatchesOnPage(items, 'health', 1);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe('Health');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **Exact** in-document search option to the PDF viewer, selectable via an Exact | Semantic toggle in the search bar. Exact mode performs a client-side literal find in the rendered text — no API call and no LLM.

**Semantic search is unchanged** — it behaves exactly as it did in `rc/v1.6.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
