### PR TITLE
fix(ui): align Word (.docx) export citations with the on-screen summary

### DIFF
--- a/ui/frontend/src/components/AiSummaryReferences.tsx
+++ b/ui/frontend/src/components/AiSummaryReferences.tsx
@@ -1,74 +1,12 @@
 import React from 'react';
 import { SearchResult } from '../types/api';
+import { buildGroupedReferences } from '../utils/citations';
 
 interface AiSummaryReferencesProps {
   summaryText: string;
   results: SearchResult[];
   onResultClick: (result: SearchResult) => void;
 }
-
-const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
-
-const parseCitationNumbers = (rawNumbers: string): number[] =>
-  rawNumbers.split(',').map((item) => parseInt(item.trim(), 10));
-
-const extractCitationNumbers = (summaryText: string): number[] => {
-  const citedNumbers = new Set<number>();
-  let match;
-
-  while ((match = CITATION_REGEX.exec(summaryText)) !== null) {
-    const numbers = parseCitationNumbers(match[1]);
-    numbers.forEach((num) => citedNumbers.add(num));
-  }
-
-  return Array.from(citedNumbers).sort((a, b) => a - b);
-};
-
-interface CitedRef {
-  sequential: number;
-  result: SearchResult;
-}
-
-export interface DocumentGroup {
-  title: string;
-  organization?: string;
-  year?: string;
-  refs: CitedRef[];
-}
-
-export const buildGroupedReferences = (
-  summaryText: string,
-  results: SearchResult[]
-): DocumentGroup[] => {
-  const sortedCitations = extractCitationNumbers(summaryText);
-  const groupMap = new Map<string, DocumentGroup>();
-  const groupOrder: string[] = [];
-
-  sortedCitations.forEach((origNum, seqIdx) => {
-    const resultIndex = origNum - 1;
-    if (resultIndex < 0 || resultIndex >= results.length) return;
-
-    const result = results[resultIndex];
-    const key = result.title;
-
-    if (!groupMap.has(key)) {
-      groupMap.set(key, {
-        title: result.title,
-        organization: result.organization,
-        year: result.year,
-        refs: [],
-      });
-      groupOrder.push(key);
-    }
-
-    groupMap.get(key)!.refs.push({
-      sequential: seqIdx + 1,
-      result,
-    });
-  });
-
-  return groupOrder.map((key) => groupMap.get(key)!);
-};
 
 export const AiSummaryReferences: React.FC<AiSummaryReferencesProps> = ({
   summaryText,

--- a/ui/frontend/src/components/AiSummaryWithCitations.tsx
+++ b/ui/frontend/src/components/AiSummaryWithCitations.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { SearchResult } from '../types/api';
 import { renderMarkdownText } from '../utils/textHighlighting';
+import { buildCitationSequenceMap, parseCitationNumbers } from '../utils/citations';
 
 interface AiSummaryWithCitationsProps {
   summaryText: string;
@@ -18,9 +19,6 @@ const BULLET_LIST_REGEX = /^[-*]\s/;
 const HEADING_REGEX = /^(#{1,4})\s+(.+)$/;
 const BOLD_HEADING_REGEX = /^\*\*(.+?)\*\*:?\s*$/;
 const PLAIN_HEADING_REGEX = /^([A-Z][A-Za-z\s]+):?\s*$/;
-
-const parseCitationNumbers = (rawNumbers: string): number[] =>
-  rawNumbers.split(',').map((item) => parseInt(item.trim(), 10));
 
 const extractKeyFacts = (summary: string): string[] => {
   const lines = summary.split('\n');
@@ -63,23 +61,6 @@ const extractSubHeadings = (summary: string): string[] => {
     }
   }
   return subHeadings;
-};
-
-const buildCitationMapping = (summaryText: string): Map<number, number> => {
-  const citedNumbers = new Set<number>();
-  let match;
-
-  while ((match = CITATION_REGEX.exec(summaryText)) !== null) {
-    const numbers = parseCitationNumbers(match[1]);
-    numbers.forEach((num) => citedNumbers.add(num));
-  }
-
-  const citationMapping = new Map<number, number>();
-  const sortedCitations = Array.from(citedNumbers).sort((a, b) => a - b);
-  sortedCitations.forEach((origNum, seqIdx) => {
-    citationMapping.set(origNum, seqIdx + 1);
-  });
-  return citationMapping;
 };
 
 /** Strip trailing Conclusion / Summary sections the LLM sometimes adds despite prompt instructions. */
@@ -327,7 +308,7 @@ export const AiSummaryWithCitations: React.FC<AiSummaryWithCitationsProps> = ({
   findOutMoreActiveFact,
 }) => {
   const cleanedText = stripTrailingBoilerplate(summaryText);
-  const citationMapping = buildCitationMapping(cleanedText);
+  const citationMapping = buildCitationSequenceMap(cleanedText);
   const blocks = splitSummaryBlocks(cleanedText);
   // Track across all blocks so only the very first heading gets the button
   let isFirstHeadingGlobal = true;

--- a/ui/frontend/src/utils/__tests__/citations.test.ts
+++ b/ui/frontend/src/utils/__tests__/citations.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit tests for the shared citation utility — the single source of truth that
+ * keeps the on-screen AI summary, the References list, and every export
+ * agreeing on how `[N]` markers are parsed and renumbered.
+ */
+import {
+  buildCitationSequenceMap,
+  extractCitedNumbers,
+  parseCitationNumbers,
+} from '../citations';
+
+describe('parseCitationNumbers', () => {
+  test('parses a single number', () => {
+    expect(parseCitationNumbers('3')).toEqual([3]);
+  });
+  test('parses a comma list with surrounding whitespace', () => {
+    expect(parseCitationNumbers('1, 4,7')).toEqual([1, 4, 7]);
+  });
+});
+
+describe('extractCitedNumbers', () => {
+  test('returns unique numbers sorted ascending (citation order)', () => {
+    expect(extractCitedNumbers('see [3], then [1] and [3] and [2, 5]')).toEqual([
+      1, 2, 3, 5,
+    ]);
+  });
+  test('returns [] when there are no markers', () => {
+    expect(extractCitedNumbers('no citations here')).toEqual([]);
+  });
+});
+
+describe('buildCitationSequenceMap', () => {
+  test('maps each original number to its 1-based sequential position', () => {
+    // Non-contiguous indices 2, 5, 9 renumber to 1, 2, 3 — the exact mapping
+    // the on-screen summary applies and the docx export must mirror.
+    const map = buildCitationSequenceMap('a [9] b [2] c [5]');
+    expect(map.get(2)).toBe(1);
+    expect(map.get(5)).toBe(2);
+    expect(map.get(9)).toBe(3);
+    expect(map.size).toBe(3);
+  });
+  test('is an identity map when citations are already contiguous from 1', () => {
+    const map = buildCitationSequenceMap('a [1] b [2] c [3]');
+    expect([...map.entries()]).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
+  });
+  test('returns an empty map when nothing is cited', () => {
+    expect(buildCitationSequenceMap('nothing cited').size).toBe(0);
+  });
+});

--- a/ui/frontend/src/utils/__tests__/exportResultsToDocx.test.ts
+++ b/ui/frontend/src/utils/__tests__/exportResultsToDocx.test.ts
@@ -15,12 +15,11 @@ import { Paragraph } from 'docx';
 import {
   DOCX_MIME,
   buildExportFilename,
-  buildReferenceGroups,
   exportResultsToDocxBlob,
-  extractCitationNumbers,
   markdownToParagraphs,
   resolveResultLink,
 } from '../exportResultsToDocx';
+import { buildGroupedReferences, extractCitedNumbers } from '../citations';
 import type { SearchResult } from '../../types/api';
 
 const makeResult = (overrides: Partial<SearchResult> = {}): SearchResult => ({
@@ -118,19 +117,19 @@ describe('resolveResultLink', () => {
   });
 });
 
-describe('extractCitationNumbers', () => {
+describe('extractCitedNumbers', () => {
   test('returns sorted unique numbers', () => {
-    expect(extractCitationNumbers('a [3] b [1] c [3] d [2,1]')).toEqual([1, 2, 3]);
+    expect(extractCitedNumbers('a [3] b [1] c [3] d [2,1]')).toEqual([1, 2, 3]);
   });
   test('handles multi-citation brackets with whitespace', () => {
-    expect(extractCitationNumbers('See [1, 4, 7].')).toEqual([1, 4, 7]);
+    expect(extractCitedNumbers('See [1, 4, 7].')).toEqual([1, 4, 7]);
   });
   test('returns [] when no citations present', () => {
-    expect(extractCitationNumbers('plain text with no marks')).toEqual([]);
+    expect(extractCitedNumbers('plain text with no marks')).toEqual([]);
   });
 });
 
-describe('buildReferenceGroups', () => {
+describe('buildGroupedReferences', () => {
   test('groups by document title and renumbers in citation order', () => {
     // Mirrors AiSummaryReferences: citations are processed in *sorted
     // numeric* order, then renumbered into that order. So a summary that
@@ -140,7 +139,7 @@ describe('buildReferenceGroups', () => {
       makeResult({ title: 'Doc B', organization: 'OrgB', year: '2021', page_num: 1 }),
       makeResult({ title: 'Doc A', organization: 'OrgA', year: '2020', page_num: 9 }),
     ];
-    const groups = buildReferenceGroups('first [2], then [1] and [3]', results);
+    const groups = buildGroupedReferences('first [2], then [1] and [3]', results);
     expect(groups).toHaveLength(2);
     // Doc A is the first group encountered (citation [1] → results[0])
     expect(groups[0].title).toBe('Doc A');
@@ -152,12 +151,12 @@ describe('buildReferenceGroups', () => {
   });
   test('skips out-of-range citation numbers', () => {
     const results = [makeResult({ title: 'Only Doc' })];
-    const groups = buildReferenceGroups('claim [1] then bogus [99]', results);
+    const groups = buildGroupedReferences('claim [1] then bogus [99]', results);
     expect(groups).toHaveLength(1);
     expect(groups[0].refs).toHaveLength(1);
   });
   test('returns [] when summary has no citations', () => {
-    expect(buildReferenceGroups('no marks here', [makeResult()])).toEqual([]);
+    expect(buildGroupedReferences('no marks here', [makeResult()])).toEqual([]);
   });
 });
 
@@ -394,6 +393,39 @@ describe('exportResultsToDocxBlob', () => {
     expect(refsBlock).toMatch(/>3</);
     expect(refsBlock).toMatch(/p\.5/);
     expect(refsBlock).toMatch(/p\.11/);
+  });
+
+  test('inline [N] markers are renumbered sequentially, matching the screen and References', async () => {
+    // Regression for the citation discrepancy: when a summary cites
+    // non-contiguous result indices (#3 and #7), the on-screen summary
+    // renumbers them to [1] and [2]. The docx export must do the same for its
+    // inline body markers — previously it rendered the original 3 and 7,
+    // disagreeing with both the screen and its own References section.
+    const results = Array.from({ length: 7 }, (_, i) =>
+      makeResult({
+        chunk_id: `c${i + 1}`,
+        doc_id: `doc-${i + 1}`,
+        title: `Doc ${i + 1}`,
+        pdf_url: `https://example.org/doc-${i + 1}.pdf`,
+        page_num: i + 1,
+      }),
+    );
+    const opts = {
+      ...baseOpts,
+      aiSummary: '## Findings\n\nFirst point [3]. Second point [7].',
+      results,
+    };
+    const xml = await unzip(await exportResultsToDocxBlob(opts));
+    // Isolate the AI summary body (between its heading and the References
+    // heading) so we inspect only the inline markers, not page numbers or
+    // result-card numbering elsewhere in the document.
+    const body = xml.slice(xml.indexOf('Findings'), xml.indexOf('>References<'));
+    // Inline markers render the sequential display numbers...
+    expect(body).toMatch(/<w:t[^>]*>1<\/w:t>/);
+    expect(body).toMatch(/<w:t[^>]*>2<\/w:t>/);
+    // ...never the original cited indices.
+    expect(body).not.toMatch(/<w:t[^>]*>3<\/w:t>/);
+    expect(body).not.toMatch(/<w:t[^>]*>7<\/w:t>/);
   });
 
   test('omits References section when the summary has no citations', async () => {

--- a/ui/frontend/src/utils/citations.ts
+++ b/ui/frontend/src/utils/citations.ts
@@ -1,0 +1,99 @@
+/**
+ * Single source of truth for parsing and (re)numbering the `[N]` citation
+ * markers the AI summary endpoint emits.
+ *
+ * The on-screen summary, the on-screen References list, the Word (.docx)
+ * export, and the research HTML export all need to agree on:
+ *   1. which numbers a summary cites,
+ *   2. how those numbers are renumbered into a clean, sequential `1..k`
+ *      run (in citation order), and
+ *   3. how cited results are grouped, by document, into a References list.
+ *
+ * Previously each consumer carried its own copy of this logic. They drifted —
+ * notably the docx export rendered the *original* citation number inline while
+ * renumbering its References section, so the export disagreed with itself and
+ * with the screen. Centralising the logic here guarantees every surface shows
+ * identical citation numbers by construction.
+ */
+import { SearchResult } from '../types/api';
+
+/** Matches inline citations like `[1]`, `[1, 3]`, `[1,3,5]`. */
+export const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
+
+/** Parse the comma-separated numbers inside a single `[...]` marker. */
+export const parseCitationNumbers = (rawNumbers: string): number[] =>
+  rawNumbers.split(',').map((item) => parseInt(item.trim(), 10));
+
+/** The unique citation numbers referenced anywhere in the summary, sorted
+ *  ascending. This ascending order *is* the canonical citation order used for
+ *  renumbering — keep it identical across every consumer. */
+export const extractCitedNumbers = (summaryText: string): number[] => {
+  const cited = new Set<number>();
+  const re = new RegExp(CITATION_REGEX.source, 'g');
+  let match;
+  while ((match = re.exec(summaryText)) !== null) {
+    parseCitationNumbers(match[1]).forEach((num) => cited.add(num));
+  }
+  return Array.from(cited).sort((a, b) => a - b);
+};
+
+/** Map each original citation number to its sequential display number
+ *  (`1..k`, in citation order). This is the renumbering the on-screen summary
+ *  applies to inline `[N]` markers, and the docx/HTML exports must apply the
+ *  same map so their inline markers agree with the screen. */
+export const buildCitationSequenceMap = (
+  summaryText: string,
+): Map<number, number> => {
+  const citationMapping = new Map<number, number>();
+  extractCitedNumbers(summaryText).forEach((origNum, seqIdx) => {
+    citationMapping.set(origNum, seqIdx + 1);
+  });
+  return citationMapping;
+};
+
+export interface CitedRef {
+  /** The renumbered, sequential display number for this citation. */
+  sequential: number;
+  result: SearchResult;
+}
+
+export interface DocumentGroup {
+  title: string;
+  organization?: string;
+  year?: string;
+  refs: CitedRef[];
+}
+
+/** Group the summary's citations by document title, in citation order, with
+ *  each citation carrying its sequential display number. Used to render the
+ *  "References:" list on screen and in every export. */
+export const buildGroupedReferences = (
+  summaryText: string,
+  results: SearchResult[],
+): DocumentGroup[] => {
+  const sortedCitations = extractCitedNumbers(summaryText);
+  const groupMap = new Map<string, DocumentGroup>();
+  const groupOrder: string[] = [];
+
+  sortedCitations.forEach((origNum, seqIdx) => {
+    const resultIndex = origNum - 1;
+    if (resultIndex < 0 || resultIndex >= results.length) return;
+
+    const result = results[resultIndex];
+    const key = result.title;
+
+    if (!groupMap.has(key)) {
+      groupMap.set(key, {
+        title: result.title,
+        organization: result.organization,
+        year: result.year,
+        refs: [],
+      });
+      groupOrder.push(key);
+    }
+
+    groupMap.get(key)!.refs.push({ sequential: seqIdx + 1, result });
+  });
+
+  return groupOrder.map((key) => groupMap.get(key)!);
+};

--- a/ui/frontend/src/utils/exportResearch.ts
+++ b/ui/frontend/src/utils/exportResearch.ts
@@ -1,5 +1,5 @@
 import { DrilldownNode, SearchResult } from '../types/api';
-import { buildGroupedReferences, DocumentGroup } from '../components/AiSummaryReferences';
+import { buildGroupedReferences, DocumentGroup } from './citations';
 
 /** Escape HTML special characters */
 const esc = (text: string): string =>

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -28,6 +28,12 @@ import {
   convertInchesToTwip,
 } from 'docx';
 import type { SearchResult } from '../types/api';
+import {
+  buildCitationSequenceMap,
+  buildGroupedReferences,
+  parseCitationNumbers,
+  type DocumentGroup,
+} from './citations';
 
 export interface ExportOptions {
   query: string;
@@ -129,6 +135,10 @@ export interface CitationContext {
   results: SearchResult[];
   siteOrigin: string;
   dataSource?: string;
+  /** Maps each original `[N]` to its sequential display number, so inline
+   *  citations render the same renumbered value as the on-screen summary and
+   *  the References section. Built once from the full summary text. */
+  sequenceMap: Map<number, number>;
 }
 
 /** Build the inline children for a `[N]` / `[N, M]` citation marker. Each
@@ -140,27 +150,33 @@ const buildCitationRuns = (
   base: { size?: number },
   ctx: CitationContext,
 ): InlineChild[] => {
-  const nums = matched
-    .split(',')
-    .map((s) => parseInt(s.trim(), 10))
-    .filter((n) => Number.isFinite(n));
   const out: InlineChild[] = [new TextRun({ text: '[', size: base.size })];
-  nums.forEach((n, idx) => {
-    if (idx > 0) out.push(new TextRun({ text: ', ', size: base.size }));
+  let rendered = 0;
+  for (const n of parseCitationNumbers(matched)) {
+    // Render the sequential (renumbered) value so the inline marker matches
+    // the on-screen summary and this document's own References section. A
+    // number absent from the sequence map is not a real citation — mirror the
+    // on-screen renderer and drop it rather than show a misleading number.
+    const sequential = ctx.sequenceMap.get(n);
+    if (sequential === undefined) continue;
+    if (rendered > 0) out.push(new TextRun({ text: ', ', size: base.size }));
+    rendered += 1;
+    const display = String(sequential);
     const result = ctx.results[n - 1];
     if (!result) {
-      out.push(new TextRun({ text: String(n), size: base.size }));
-      return;
+      out.push(new TextRun({ text: display, size: base.size }));
+      continue;
     }
+    // The hyperlink still targets the original cited result.
     out.push(
       new ExternalHyperlink({
         link: resolveResultLink(result, ctx.siteOrigin, ctx.dataSource),
         children: [
-          new TextRun({ text: String(n), style: 'Hyperlink', size: base.size }),
+          new TextRun({ text: display, style: 'Hyperlink', size: base.size }),
         ],
       }),
     );
-  });
+  }
   out.push(new TextRun({ text: ']', size: base.size }));
   return out;
 };
@@ -310,71 +326,6 @@ export const markdownToParagraphs = (
 };
 
 // ---------------------------------------------------------------------------
-// References (citations parsed out of the AI summary)
-// ---------------------------------------------------------------------------
-
-/** Matches inline citations like `[1]`, `[1, 3]`, `[1,3,5]`. */
-const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
-
-/** Parse the unique, sorted citation numbers referenced in the AI summary. */
-export const extractCitationNumbers = (summaryText: string): number[] => {
-  const cited = new Set<number>();
-  let m: RegExpExecArray | null;
-  while ((m = CITATION_REGEX.exec(summaryText)) !== null) {
-    for (const part of m[1].split(',')) {
-      const n = parseInt(part.trim(), 10);
-      if (Number.isFinite(n)) cited.add(n);
-    }
-  }
-  return Array.from(cited).sort((a, b) => a - b);
-};
-
-interface CitedRef {
-  sequential: number;
-  result: SearchResult;
-}
-
-export interface ReferenceGroup {
-  title: string;
-  organization?: string;
-  year?: string;
-  refs: CitedRef[];
-}
-
-/** Build a list of grouped references from the AI summary citations.
- *
- *  Mirrors the in-app ``buildGroupedReferences`` (in ``AiSummaryReferences``):
- *  citations are renumbered into citation order, then grouped by document
- *  title so a single document appears once with all its cited pages listed. */
-export const buildReferenceGroups = (
-  summaryText: string,
-  results: SearchResult[],
-): ReferenceGroup[] => {
-  const sortedCitations = extractCitationNumbers(summaryText);
-  const groupMap = new Map<string, ReferenceGroup>();
-  const groupOrder: string[] = [];
-
-  sortedCitations.forEach((origNum, seqIdx) => {
-    const idx = origNum - 1;
-    if (idx < 0 || idx >= results.length) return;
-    const result = results[idx];
-    const key = result.title || `(untitled #${origNum})`;
-    if (!groupMap.has(key)) {
-      groupMap.set(key, {
-        title: key,
-        organization: result.organization,
-        year: result.year,
-        refs: [],
-      });
-      groupOrder.push(key);
-    }
-    groupMap.get(key)!.refs.push({ sequential: seqIdx + 1, result });
-  });
-
-  return groupOrder.map((key) => groupMap.get(key)!);
-};
-
-// ---------------------------------------------------------------------------
 // Builders — one per section of the docx
 // ---------------------------------------------------------------------------
 
@@ -413,7 +364,7 @@ const buildCoverParagraphs = (
 };
 
 const buildReferenceParagraphs = (
-  groups: ReferenceGroup[],
+  groups: DocumentGroup[],
   ctx: CitationContext,
 ): Paragraph[] => {
   if (groups.length === 0) return [];
@@ -474,12 +425,17 @@ const buildSummarySection = (
       spacing: { before: 240, after: 120 },
     }),
   );
-  const citations: CitationContext = { results, siteOrigin, dataSource };
+  const citations: CitationContext = {
+    results,
+    siteOrigin,
+    dataSource,
+    sequenceMap: buildCitationSequenceMap(summary),
+  };
   // Demote any markdown headings inside the summary by 1 so the section's
   // own H1 stays unique. Pass the citation context so [N] markers in the
-  // body become clickable links.
+  // body become clickable links, renumbered to match the screen.
   out.push(...markdownToParagraphs(summary, 1, citations));
-  out.push(...buildReferenceParagraphs(buildReferenceGroups(summary, results), citations));
+  out.push(...buildReferenceParagraphs(buildGroupedReferences(summary, results), citations));
   return out;
 };
 


### PR DESCRIPTION
## Summary

Fixes a citation discrepancy between the **on-screen AI Summary** and the **downloaded Word (.docx)** document. In some cases the citation numbers shown inline in the exported `.docx` did not match the numbers shown on screen (and did not even match the export's own References section).

## Root cause

The citation parse/renumber logic existed in **four** independent copies that had drifted apart:

| Surface | Inline `[N]` | References `[N]` |
|---|---|---|
| On-screen summary body | sequential ✅ | — |
| On-screen References list | — | sequential ✅ |
| Research HTML export | sequential ✅ | sequential ✅ |
| **Word (.docx) export** | **original ❌** | sequential ✅ |

Everywhere on screen, citations are renumbered into a clean sequential `1..k` run in citation order. The Word export's inline renderer (`buildCitationRuns`) emitted the **original** result index instead. So a summary citing non-contiguous results (e.g. #3 and #7) produced `[3]…[7]` inline in the `.docx` but `[1]…[2]` in its References and on screen. It only surfaced intermittently because when cited indices are already contiguous from 1, original == sequential.

## Fix

- **New shared module** `ui/frontend/src/utils/citations.ts` — single source of truth for `parseCitationNumbers`, `extractCitedNumbers`, `buildCitationSequenceMap`, and `buildGroupedReferences`.
- Routed all consumers through it: the on-screen summary, on-screen References, the docx export, and the research HTML export.
- The on-screen extraction is a **behaviour-preserving refactor** — rendering and link/click logic are untouched.
- The docx inline renderer now emits the **sequential** number (and skips unmapped markers, mirroring the on-screen renderer) so every surface shows identical citation numbers by construction.
- Bonus: removed a pre-existing untitled-document grouping divergence between the screen and the export.

## Testing

- New `citations.test.ts` covering the shared util.
- New docx regression test using **non-contiguous** citations (#3/#7) asserting inline markers render `1`/`2`, not `3`/`7` — **verified to fail on the previous behaviour** before the fix.
- `tsc --noEmit` clean; all citation/export/on-screen Jest suites pass.
- Full pre-commit suite passes (code-metrics, detect-secrets, gitleaks); no `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
