### PR TITLE
fix(search): filter by region via doc_id resolution

### DIFF
--- a/pipeline/db/postgres_client_docs.py
+++ b/pipeline/db/postgres_client_docs.py
@@ -505,6 +505,52 @@ class PostgresDocMixin:
                 rows = cur.fetchall()
         return [str(row[0]) for row in rows]
 
+    def fetch_doc_ids_by_region(
+        self, region_selection: str, limit: int = 5000
+    ) -> List[str]:
+        """Fetch doc_ids whose region matches the given filter selection.
+
+        Region is a document-level field (it is not stored on chunks), held as a
+        ``"; "``-joined string of one or more regions, e.g.
+        ``"Asia and the Pacific; Eastern and Southern Africa"``.
+
+        The frontend joins multi-select filter values with commas, but region
+        names themselves contain commas (e.g. ``"Middle East, Northern Africa,
+        and Eastern Europe"``), so the selection cannot be split on commas.
+        Instead each document's individual region segments are matched against
+        the raw selection string by containment. WFP region names are mutually
+        distinct (no name is a substring of another), so this is unambiguous and
+        works for both single- and multi-select.
+
+        Args:
+            region_selection: Raw region filter value from the request.
+            limit: Maximum number of doc_ids to return.
+
+        Returns:
+            List of matching doc_id strings.
+        """
+        selection = (region_selection or "").strip()
+        if not selection:
+            return []
+        query = f"""
+            SELECT doc_id
+            FROM {self.docs_table}
+            WHERE map_region IS NOT NULL
+              AND EXISTS (
+                  SELECT 1
+                  FROM unnest(string_to_array(map_region, '; ')) AS region_segment
+                  WHERE btrim(region_segment) <> ''
+                    AND %s ILIKE '%%' || btrim(region_segment) || '%%'
+              )
+            LIMIT %s
+        """
+        rows: List[tuple] = []
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, [selection, limit])
+                rows = cur.fetchall()
+        return [str(row[0]) for row in rows]
+
     def fetch_doc_ids_by_title(self, title: str, limit: int = 5000) -> List[str]:
         query = f"""
             SELECT doc_id

--- a/tests/unit/test_region_filter.py
+++ b/tests/unit/test_region_filter.py
@@ -1,0 +1,124 @@
+"""Unit tests for the region search filter.
+
+Region is a document-level field (it is not stored on chunks), so a region
+selection must be resolved to a doc_id filter for chunk search — analogous to
+the existing language handling. These tests cover the route-level conversion
+and intersection logic plus the Postgres lookup helper.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipeline.db.postgres_client_docs import PostgresDocMixin
+from ui.backend.routes.search import (
+    _NO_MATCH_DOC_ID,
+    _convert_language_to_doc_ids,
+    _convert_region_to_doc_ids,
+    _intersect_doc_id_filter,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _pg_returning(doc_ids):
+    pg = MagicMock()
+    pg.fetch_doc_ids_by_region.return_value = list(doc_ids)
+    return pg
+
+
+class TestConvertRegionToDocIds:
+    def test_no_region_when_absent_then_filters_unchanged(self):
+        core = {"organization": "WFP"}
+        pg = MagicMock()
+        _convert_region_to_doc_ids(core, pg)
+        assert core == {"organization": "WFP"}
+        pg.fetch_doc_ids_by_region.assert_not_called()
+
+    def test_region_when_set_then_replaced_by_doc_id_filter(self):
+        core = {"region": "Asia and the Pacific"}
+        pg = _pg_returning(["d1", "d2"])
+        _convert_region_to_doc_ids(core, pg)
+        assert "region" not in core
+        assert set(core["doc_id"].split(",")) == {"d1", "d2"}
+        pg.fetch_doc_ids_by_region.assert_called_once_with("Asia and the Pacific")
+
+    def test_region_when_no_docs_match_then_sentinel_doc_id(self):
+        core = {"region": "Nowhere"}
+        _convert_region_to_doc_ids(core, _pg_returning([]))
+        assert core["doc_id"] == _NO_MATCH_DOC_ID
+
+    def test_region_and_language_when_both_set_then_doc_ids_intersected(self):
+        # Language resolves first (mirrors the call order in the search route).
+        core = {"language": "en", "region": "Asia and the Pacific"}
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_language.return_value = ["d1", "d2", "d3"]
+        pg.fetch_doc_ids_by_region.return_value = ["d2", "d3", "d4"]
+        _convert_language_to_doc_ids(core, pg)
+        _convert_region_to_doc_ids(core, pg)
+        assert set(core["doc_id"].split(",")) == {"d2", "d3"}
+
+    def test_region_and_language_when_disjoint_then_sentinel(self):
+        core = {"language": "en", "region": "Asia and the Pacific"}
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_language.return_value = ["d1"]
+        pg.fetch_doc_ids_by_region.return_value = ["d9"]
+        _convert_language_to_doc_ids(core, pg)
+        _convert_region_to_doc_ids(core, pg)
+        assert core["doc_id"] == _NO_MATCH_DOC_ID
+
+
+class TestIntersectDocIdFilter:
+    def test_no_existing_doc_id_then_set_directly(self):
+        core = {}
+        _intersect_doc_id_filter(core, ["a", "b"])
+        assert set(core["doc_id"].split(",")) == {"a", "b"}
+
+    def test_existing_doc_id_then_intersection(self):
+        core = {"doc_id": "a,b,c"}
+        _intersect_doc_id_filter(core, ["b", "c", "d"])
+        assert set(core["doc_id"].split(",")) == {"b", "c"}
+
+    def test_empty_new_ids_then_sentinel(self):
+        core = {"doc_id": "a,b"}
+        _intersect_doc_id_filter(core, [])
+        assert core["doc_id"] == _NO_MATCH_DOC_ID
+
+
+def _make_docs_client(fetch_rows):
+    """Build a PostgresDocMixin with a mocked DB connection returning rows."""
+    client = PostgresDocMixin.__new__(PostgresDocMixin)
+    client.docs_table = "docs_test"
+    cursor = MagicMock()
+    cursor.fetchall.return_value = fetch_rows
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    conn = MagicMock()
+    conn.cursor.return_value = cursor_cm
+    conn_cm = MagicMock()
+    conn_cm.__enter__.return_value = conn
+    client._get_conn = MagicMock(return_value=conn_cm)
+    return client, cursor
+
+
+class TestFetchDocIdsByRegion:
+    def test_blank_selection_then_empty_without_query(self):
+        client, cursor = _make_docs_client([])
+        assert client.fetch_doc_ids_by_region("   ") == []
+        cursor.execute.assert_not_called()
+
+    def test_selection_then_returns_doc_ids(self):
+        client, cursor = _make_docs_client([("d1",), ("d2",)])
+        result = client.fetch_doc_ids_by_region("Asia and the Pacific")
+        assert result == ["d1", "d2"]
+
+    def test_selection_then_query_is_parameterized(self):
+        client, cursor = _make_docs_client([])
+        client.fetch_doc_ids_by_region(
+            "Middle East, Northern Africa, and Eastern Europe"
+        )
+        sql, params = cursor.execute.call_args[0]
+        # The user selection must be a bound parameter, never interpolated.
+        assert "Middle East" not in sql
+        assert params[0] == "Middle East, Northern Africa, and Eastern Europe"
+        assert "%s ILIKE" in sql

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -46,6 +46,27 @@ search_semaphore = asyncio.Semaphore(MAX_CONCURRENT_SEARCHES)
 router = APIRouter()
 
 
+# Sentinel doc_id that matches no document. Used when a document-level filter
+# resolves to an empty set, so the filter yields zero results rather than being
+# silently dropped (which would return everything).
+_NO_MATCH_DOC_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _intersect_doc_id_filter(core_filters: Dict[str, Any], doc_ids: List[str]) -> None:
+    """AND a doc_id constraint into ``core_filters``, intersecting any existing one.
+
+    Multiple document-level filters (e.g. region and language) each resolve to a
+    set of doc_ids; intersecting them makes the filters combine with AND. An
+    empty result collapses to ``_NO_MATCH_DOC_ID`` so no chunks are returned.
+    """
+    new_ids = {str(d) for d in doc_ids if d}
+    existing = core_filters.get("doc_id")
+    if existing is not None:
+        existing_ids = {d for d in str(existing).split(",") if d}
+        new_ids &= existing_ids
+    core_filters["doc_id"] = ",".join(sorted(new_ids)) if new_ids else _NO_MATCH_DOC_ID
+
+
 def _convert_language_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:
     """Replace language filter with doc_id filter (language not on chunks)."""
     lang = core_filters.pop("language", None)
@@ -57,6 +78,22 @@ def _convert_language_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:
     doc_ids = pg.fetch_doc_ids_by_language(lang_code.split(","))
     if doc_ids:
         core_filters["doc_id"] = ",".join(doc_ids)
+
+
+def _convert_region_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:
+    """Replace region filter with a doc_id filter (region is doc-level only).
+
+    Region metadata lives only on documents, not chunks, so a region selection
+    is resolved to its matching documents and applied as a doc_id constraint on
+    the chunk search. The constraint is intersected with any existing doc_id
+    filter (e.g. from a language filter) so document-level filters combine
+    with AND.
+    """
+    region = core_filters.pop("region", None)
+    if not region:
+        return
+    doc_ids = pg.fetch_doc_ids_by_region(region)
+    _intersect_doc_id_filter(core_filters, doc_ids)
 
 
 def _build_core_filters(
@@ -690,8 +727,10 @@ async def search(
             language,
         )
         add_dynamic_filters(core_filters, request.query_params, source)
-        # Language is doc-level only; convert to doc_id filter for chunk search
+        # Language and region are doc-level only; convert to doc_id filters for
+        # chunk search (region intersects with any language-derived doc_ids).
         _convert_language_to_doc_ids(core_filters, pg)
+        _convert_region_to_doc_ids(core_filters, pg)
 
         title_filter = core_filters.get("title")
         early_response = _handle_title_filter(pg, core_filters, q)

--- a/ui/backend/services/search.py
+++ b/ui/backend/services/search.py
@@ -351,7 +351,9 @@ def _build_filter_condition(
     )
 
 
-_DOC_ONLY_FIELDS = {"map_language", "sys_language"}
+# Document-level fields that are not stored on chunks. They are resolved to a
+# doc_id filter upstream (see routes.search), so the chunk filter skips them.
+_DOC_ONLY_FIELDS = {"map_language", "sys_language", "map_region"}
 _TEXT_MATCH_FIELDS = {"map_title"}
 
 


### PR DESCRIPTION
## Description

The **Region** search filter never returned results — selecting any region produced **0 matches**. This fixes region filtering end-to-end.

### Root cause
`region` is a **document-level** field: it is stored on documents (`docs_*` / the `documents_*` Qdrant collection) but **not on chunks**. Search runs over chunks, so a region condition applied to chunk payloads matched nothing and always returned zero results. This is the same situation the codebase already handles for `language` via `_convert_language_to_doc_ids()` — region simply lacked the equivalent treatment.

### Fix
Resolve a region selection to its matching documents and apply it as a `doc_id` constraint on chunk search, mirroring the existing language handling.

- **`PostgresDocMixin.fetch_doc_ids_by_region()`** — resolves a region selection to matching `doc_id`s. Uses **containment matching** against each document's individual region segments, which tolerates region names that contain commas (e.g. `"Middle East, Northern Africa, and Eastern Europe"`) and the frontend's comma-joined multi-select values. Parameterized query (no interpolation of user input).
- **`_convert_region_to_doc_ids()`** in the search route — pops the region filter and converts it to a `doc_id` constraint, **intersecting** with any language-derived `doc_id`s so document-level filters combine with **AND**. An empty result collapses to a sentinel `doc_id` so a region that matches nothing yields **0 results** rather than being silently dropped (which would return everything).
- **`map_region` added to `_DOC_ONLY_FIELDS`** so the chunk filter skips it defensively.

This is **generic**, not WFP-specific: it fixes region filtering for any datasource that configures `region` as a filter — including **World Bank Fraud and Integrity Reports**, which already lists `region` in its committed `default_filter_fields` and would have had the same bug.

> **Note:** The `config.json` change that surfaces the filter (adding `region` to a datasource's `default_filter_fields`) is **deployment-specific and intentionally not included** in this PR. Deployments that already configure `region` (e.g. World Bank) get the working filter purely from this code change.

## Testing

`tests/unit/test_region_filter.py` (11 tests, all green) covers the conversion, the doc_id intersection (region + language, including the disjoint→sentinel case), and the lookup helper (blank input, return shape, and parameterization).

Verified live against the restored WFP dataset (333 docs / 97,519 chunks):

| Case | Result |
|---|---|
| `region=Asia and the Pacific` | 84 docs (matches the facet count) |
| comma-name region (`Middle East, Northern Africa, and Eastern Europe`) | 60 docs |
| multi-select (Asia + Eastern & Southern Africa) | exact **union** (185), deduplicated |
| non-existent region | 0 (sentinel) |
| every filtered result | confirmed within the selected region's doc set |

All pre-commit hooks pass (black, isort, flake8, mypy, bandit, detect-secrets, gitleaks, code-metrics).

## On the region counts — apparent mismatch, actual alignment

While validating, the region facet counts appear not to add up: the UI reports **333 documents**, but the per-region counts sum to **436** (`130 + 94 + 84 + 68 + 60`). This is **expected and correct** — the region facet counts **memberships, not documents**, because region is multi-valued.

Breakdown of the 333 documents in `docs_wfp`:

| Category | Docs | Region memberships |
|---|---|---|
| Single region | 284 | 284 |
| **Multiple regions** | **35** | 152 |
| No region | 14 | 0 |
| **Total** | **333** | **436** |

`284 + 35 + 14 = 333` documents, and the memberships sum to **436** — exactly the facet total. The 35 multi-region documents are each counted once per region they belong to (≈4.3 regions each → +117 over the document count), while 14 documents have no region and appear in no facet. So a document evaluating `"Asia and the Pacific; Eastern and Southern Africa"` legitimately appears under both regions.

This is precisely why the filter uses **containment / OR** matching: selecting one region returns every document that includes it, and selecting multiple regions returns their **union of distinct documents** — not the sum of facet counts.

Refs #342439

🤖 Generated with [Claude Code](https://claude.com/claude-code)