### PR TITLE
fix(ui): enlarge dropdown chevrons; stream AI summary as markdown

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -356,7 +356,8 @@ h6,
 }
 
 .dropdown-arrow {
-  font-size: 0.875rem;
+  font-size: 1.15rem;
+  line-height: 1;
   color: var(--gray-500);
   transition: transform 0.2s;
 }

--- a/ui/frontend/src/components/AiSummaryPanel.tsx
+++ b/ui/frontend/src/components/AiSummaryPanel.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { SearchResult, DrilldownNode, SummaryModelConfig } from '../types/api';
 import API_BASE_URL from '../config';
 import { LANGUAGES } from '../constants';
@@ -92,7 +94,18 @@ const GeneratingText = () => (
 
 const AiSummaryLoading = ({ expanded, summary }: { expanded: boolean; summary: string }) => (
   <div className={`ai-summary-content ${expanded ? 'expanded' : ''}`}>
-    <p className="ai-summary-text">{summary || <GeneratingText />}</p>
+    {summary ? (
+      // Render markdown as the summary streams in (headings, bold, lists)
+      // rather than showing raw text. The citation-aware AiSummaryBody takes
+      // over once streaming completes.
+      <div className="ai-summary-markdown">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{summary}</ReactMarkdown>
+      </div>
+    ) : (
+      <p className="ai-summary-text">
+        <GeneratingText />
+      </p>
+    )}
   </div>
 );
 


### PR DESCRIPTION
## Minor UI cosmetics

### 1. Dropdown chevrons were tiny
The Monitor (NavTabs) and Info (TopBar) menu carets (`▾`, `.dropdown-arrow`) rendered at `0.875rem` and looked very small. Bumped to `1.15rem` with `line-height: 1` so they're a reasonable size. Shared class, so all dropdown carets benefit consistently.

### 2. AI summary now renders markdown as it streams
Previously, while the summary streamed in, `AiSummaryLoading` showed the partial text as **raw plain text** (`<p class="ai-summary-text">`) — so users saw literal `##`, `**`, `-` until streaming finished and the citation-aware renderer kicked in. Now the partial summary is rendered as markdown (headings/bold/lists) during streaming via `ReactMarkdown` + `remark-gfm` (the same pattern the assistant `ChatMessage` already uses), falling back to the "Generating…" animation when empty. The citation-aware `AiSummaryBody` still takes over once streaming completes.

## Testing
- `tsc --noEmit`: clean for changed files.
- `react-scripts test` (searchTabContent / aiSummary / app suites): **21 passed / 21**.
- All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)