### PR TITLE
fix(ui): enlarge dropdown chevrons; stream AI summary as markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -283,3 +283,8 @@ config.json
 /customize/*
 !/customize/README.md
 !/customize/.gitkeep
+
+# Vertex service-account key (deployment secret) — mounted at runtime, never committed.
+/gcp-creds.json
+/gcp.key.json
+/gcp.key.json.vertex

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -373,7 +373,8 @@ h6,
 }
 
 .dropdown-arrow {
-  font-size: 0.875rem;
+  font-size: 1.15rem;
+  line-height: 1;
   color: var(--gray-500);
   transition: transform 0.2s;
 }

--- a/ui/frontend/src/components/AiSummaryPanel.tsx
+++ b/ui/frontend/src/components/AiSummaryPanel.tsx
@@ -92,6 +92,19 @@ const GeneratingText = () => (
   </span>
 );
 
+// Downgrade heading levels to match the final citation-aware render
+// (AiSummaryWithCitations' parseHeading maps `#`..`######` to min(level+2, 6)),
+// so streaming headings render at the SAME size as the completed summary
+// instead of starting large and shrinking when streaming finishes.
+const STREAMING_MD_COMPONENTS = {
+  h1: ({ node, ...props }: any) => <h3 {...props} />,
+  h2: ({ node, ...props }: any) => <h4 {...props} />,
+  h3: ({ node, ...props }: any) => <h5 {...props} />,
+  h4: ({ node, ...props }: any) => <h6 {...props} />,
+  h5: ({ node, ...props }: any) => <h6 {...props} />,
+  h6: ({ node, ...props }: any) => <h6 {...props} />,
+};
+
 const AiSummaryLoading = ({ expanded, summary }: { expanded: boolean; summary: string }) => (
   <div className={`ai-summary-content ${expanded ? 'expanded' : ''}`}>
     {summary ? (
@@ -99,7 +112,9 @@ const AiSummaryLoading = ({ expanded, summary }: { expanded: boolean; summary: s
       // rather than showing raw text. The citation-aware AiSummaryBody takes
       // over once streaming completes.
       <div className="ai-summary-markdown">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{summary}</ReactMarkdown>
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={STREAMING_MD_COMPONENTS}>
+          {summary}
+        </ReactMarkdown>
       </div>
     ) : (
       <p className="ai-summary-text">

--- a/ui/frontend/src/components/AiSummaryPanel.tsx
+++ b/ui/frontend/src/components/AiSummaryPanel.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { SearchResult, DrilldownNode, SummaryModelConfig } from '../types/api';
 import API_BASE_URL from '../config';
 import { LANGUAGES } from '../constants';
@@ -92,7 +94,18 @@ const GeneratingText = () => (
 
 const AiSummaryLoading = ({ expanded, summary }: { expanded: boolean; summary: string }) => (
   <div className={`ai-summary-content ${expanded ? 'expanded' : ''}`}>
-    <p className="ai-summary-text">{summary || <GeneratingText />}</p>
+    {summary ? (
+      // Render markdown as the summary streams in (headings, bold, lists)
+      // rather than showing raw text. The citation-aware AiSummaryBody takes
+      // over once streaming completes.
+      <div className="ai-summary-markdown">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{summary}</ReactMarkdown>
+      </div>
+    ) : (
+      <p className="ai-summary-text">
+        <GeneratingText />
+      </p>
+    )}
   </div>
 );
 


### PR DESCRIPTION
## Minor UI cosmetics (targets rc/v1.6.0 — the deployed release)

### 1. Dropdown chevrons were tiny
The Monitor (NavTabs) and Info (TopBar) menu carets (`▾`, `.dropdown-arrow`) rendered at `0.875rem` and looked very small. Bumped to `1.15rem` with `line-height: 1`. Shared class, so all dropdown carets benefit consistently.

### 2. AI summary now renders markdown as it streams
While the summary streamed in, `AiSummaryLoading` showed the partial text as **raw plain text** — users saw literal `##`, `**`, `-` until streaming finished. Now the partial summary renders as markdown (headings/bold/lists) during streaming via `ReactMarkdown` + `remark-gfm` (same pattern as the assistant `ChatMessage`), falling back to the "Generating…" animation when empty. The citation-aware `AiSummaryBody` still takes over once streaming completes.

## Testing
- `tsc --noEmit`: clean for changed files.
- `react-scripts test` (searchTabContent / aiSummary / app suites): **21 passed / 21**.
- All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)