### PR TITLE
feat(deploy): source config.json/Caddyfile/creds from outside the repo via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -291,3 +291,28 @@ DB_DATA_MOUNT=
 STORAGE_ACCOUNT_NAME=
 STORAGE_SHARE_NAME=
 STORAGE_ACCOUNT_KEY=
+
+# ======================================================================
+#               Deployment overlays (optional customization)
+# ======================================================================
+# Point the build/run at a deployment's own assets that live OUTSIDE this
+# repo (e.g. a separate config/branding repo). Leave ALL of these UNSET for a
+# stock build — defaults below reproduce byte-identical stock behaviour and no
+# external files are used. Only a set variable causes its asset to be used.
+
+# Branding overlay folder (theme.css, logo.png, favicon.ico, footer.md, fonts/).
+# Build context for the UI image. Default: ./customize (stock = no branding).
+CUSTOMIZE_ASSETS=
+
+# config.json source folder. Used as a build context to bake config.json into
+# the UI image, AND (via the deploy override) mounted into the api at runtime
+# as ${CONFIG_SRC}/config.json. Default: . (this repo root = stock config.json).
+CONFIG_SRC=
+
+# Reverse-proxy Caddyfile, bind-mounted by the deploy override.
+# Default: ./Caddyfile (the repo's stock Caddyfile).
+CADDYFILE_PATH=
+
+# Vertex / Google service-account key, bind-mounted read-only into the api by
+# the deploy override at /app/gcp-creds.json. Default: ./gcp-creds.json.
+GCP_CREDS_PATH=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -244,8 +244,13 @@ services:
       dockerfile: ui/frontend/Dockerfile.prod
       # Optional branding overlay. Defaults to the stock ./customize folder;
       # set CUSTOMIZE_ASSETS=/path/to/your-branding to override. No make/diff.
+      #
+      # Optional config overlay. Defaults to this repo root (stock config.json);
+      # set CONFIG_SRC=/path/to/deployment to bake a deployment's config.json
+      # into the UI build instead. Unset => byte-identical to stock.
       additional_contexts:
         customize: ${CUSTOMIZE_ASSETS:-./customize}
+        config: ${CONFIG_SRC:-.}
       args:
         - REACT_APP_AI_SUMMARY_ON=${REACT_APP_AI_SUMMARY_ON:-false}
         - REACT_APP_SEARCH_SEMANTIC_HIGHLIGHTS=${REACT_APP_SEARCH_SEMANTIC_HIGHLIGHTS:-true}

--- a/docs/admin/customization.md
+++ b/docs/admin/customization.md
@@ -8,8 +8,10 @@ folder of static assets. No forking, no diff files, no `make`.
 > this only to restyle a deployment.
 
 > Datasources, models, and search settings are **not** branding — those live in
-> the top-level `config.json`, which a deployment edits directly. This page is
-> only about the visual skin.
+> the top-level `config.json`, which a deployment edits directly (or supplies
+> from outside the repo via `CONFIG_SRC` — see
+> [Deploying config & infra from outside the repo](#deploying-config--infra-from-outside-the-repo)).
+> The rest of this page is about the visual skin.
 
 ## Set it up (Docker-native)
 
@@ -139,3 +141,36 @@ my-branding/
 
 Stock builds (no `CUSTOMIZE_ASSETS`) copy nothing and are byte-identical to plain
 Evidence Lab.
+
+## Deploying config & infra from outside the repo
+
+Branding isn't the only thing a deployment overrides. The datasource/model
+`config.json`, the reverse-proxy `Caddyfile`, and the Vertex/Google service-
+account key are deployment-specific too. Rather than editing them in place (which
+leaves the app repo's working tree dirty), point at copies that live **outside**
+the repo — e.g. in a separate config repo — via env vars. Each defaults to the
+stock in-repo file, so **unset = byte-identical stock build**; a file is only
+used when its variable is set.
+
+| Env var | Asset | How it's consumed | Default (stock) |
+|---------|-------|-------------------|-----------------|
+| `CUSTOMIZE_ASSETS` | `branding/` | UI build context (branding overlay) | `./customize` |
+| `CONFIG_SRC` | folder with `config.json` | UI build context (baked into the bundle) **and** mounted into the api at `/app/config.json` by the deploy override | `.` (repo root) |
+| `CADDYFILE_PATH` | `Caddyfile` | bind-mounted into the reverse proxy by the deploy override | `./Caddyfile` |
+| `GCP_CREDS_PATH` | `gcp-creds.json` | bind-mounted read-only into the api at `/app/gcp-creds.json` by the deploy override | `./gcp-creds.json` |
+
+Set them in `.env` (see `.env.example`), then build/run as usual. The api reads
+`config.json` at runtime, so it's a runtime mount; the UI bakes it at build time,
+so it's a build context — both driven by the single `CONFIG_SRC`. The Caddyfile
+and creds mounts live in the deploy override (`docker-compose.prod.override.yml`),
+which a deployment can keep in its own repo and pass with a second `-f`.
+
+```bash
+# Example: all deployment files in /opt/my-deploy, nothing copied into the repo
+CONFIG_SRC=/opt/my-deploy \
+CUSTOMIZE_ASSETS=/opt/my-deploy/branding \
+CADDYFILE_PATH=/opt/my-deploy/Caddyfile \
+GCP_CREDS_PATH=/opt/my-deploy/gcp-creds.json \
+docker compose -f docker-compose.prod.yml \
+  -f /opt/my-deploy/docker-compose.prod.override.yml up -d --build
+```

--- a/ui/frontend/Dockerfile.prod
+++ b/ui/frontend/Dockerfile.prod
@@ -15,8 +15,13 @@ RUN npm ci --legacy-peer-deps
 # Copy source files from ui/frontend
 COPY ui/frontend/. .
 
-# Copy config.json from root (after source files)
-COPY config.json ./src/config.json
+# config.json from the `config` build context (declared in
+# docker-compose.prod.yml as `config: ${CONFIG_SRC:-.}`). Defaults to this repo
+# root => stock config.json; a deployment sets CONFIG_SRC to bake its own.
+# Uses RUN --mount (like the branding overlay below) so hadolint's DL3022 isn't
+# tripped and a stock build stays byte-identical.
+RUN --mount=type=bind,from=config,target=/config-src \
+    cp /config-src/config.json ./src/config.json
 
 # Copy docs from project root (used by copy-docs script during build)
 COPY docs/ ./docs_source/


### PR DESCRIPTION
## Goal
Stop deployment-specific files (`config.json`, `Caddyfile`, `gcp-creds.json`, the deploy override) from living as untracked/modified edits in the app repo. Instead point at copies that live outside the repo (e.g. a separate config repo) via env vars. **Unset = byte-identical stock build**; an asset is used only when its var is set.

## App-repo changes (this PR)
- `docker-compose.prod.yml`: add a `config` build context `config: ${CONFIG_SRC:-.}` to the UI build (alongside `customize`).
- `ui/frontend/Dockerfile.prod`: bake `config.json` from that context via `RUN --mount=type=bind,from=config` (same style as branding; avoids hadolint DL3022). Default `.` → stock config.
- `.env.example`: document `CONFIG_SRC`, `CADDYFILE_PATH`, `GCP_CREDS_PATH`, `CUSTOMIZE_ASSETS`.
- `docs/admin/customization.md`: new "Deploying config & infra from outside the repo" section.

## Why config.json is split (build vs runtime)
The **UI bakes** config.json at build → build context (`CONFIG_SRC`). The **api reads** it at runtime → it's bind-mounted by the deploy override (`${CONFIG_SRC}/config.json`), so the shared root `Dockerfile` (built by 5 dev+prod services) is untouched and dev/stock builds stay byte-identical.

The matching deploy-override changes (`Caddyfile`/creds via `${CADDYFILE_PATH}`/`${GCP_CREDS_PATH}`, api config mount) live in the deployment's own override file.

## Defaults verified
`docker compose config` with `CONFIG_SRC` unset resolves the `config` context to the repo root (stock); set, it points elsewhere. Full build is validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)