### PR TITLE
ci(demo-e2e): fix alembic_version race by migrating before app services

### DIFF
--- a/.github/workflows/demo-e2e.yml
+++ b/.github/workflows/demo-e2e.yml
@@ -89,12 +89,19 @@ jobs:
       - name: Create data directory
         run: mkdir -p data/demo
 
-      - name: Start all services
-        run: docker compose up -d
+      # ----------------------------------------------------------------
+      # Step 3: Start Postgres and migrate BEFORE the app services.
+      # The api container's start command also runs `alembic upgrade head`.
+      # If it starts concurrently with the host migration below, both call
+      # alembic's _ensure_version_table and race to `CREATE TABLE
+      # alembic_version` — Postgres rejects the loser with a duplicate
+      # pg_type_typname_nsp_index unique violation. Migrating to head while
+      # Postgres is the only running service means api's later upgrade finds
+      # the version table already present and is a clean no-op.
+      # ----------------------------------------------------------------
+      - name: Start Postgres
+        run: docker compose up -d postgres
 
-      # ----------------------------------------------------------------
-      # Step 3: Wait for infrastructure
-      # ----------------------------------------------------------------
       - name: Wait for Postgres
         run: |
           echo "Waiting for Postgres..."
@@ -111,9 +118,14 @@ jobs:
         run: |
           # Run alembic directly on the host — alembic is installed by the
           # "Install Python dependencies" step and postgres is bound to host
-          # port 5432. Running on the host avoids a race condition where the
-          # pipeline container is still waiting for embedding-server health.
+          # port 5432. Running on the host (not in a container) avoids a race
+          # with the pipeline container still waiting for embedding-server
+          # health. Postgres is the only service up at this point, so no
+          # container can race us to create alembic_version.
           POSTGRES_HOST=localhost alembic upgrade heads
+
+      - name: Start all services
+        run: docker compose up -d
 
       - name: Wait for embedding server
         run: |


### PR DESCRIPTION
## Problem

The **Demo E2E** workflow failed on `rc/v1.6.0` at the *Run database migrations* step:

```
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value
violates unique constraint "pg_type_typname_nsp_index"
DETAIL:  Key (typname, typnamespace)=(alembic_version, 2200) already exists.
[SQL: CREATE TABLE alembic_version (...)]
```

## Root cause (from the run log)

The job ran `docker compose up -d` (*Start all services*) and then immediately `alembic upgrade heads` on the host. The **api** container's start command is `alembic upgrade head && uvicorn …`, so two alembic processes ran concurrently. The run log shows the collision directly:

- `23:08:30.358` host `alembic upgrade heads` starts
- `23:08:30.488` host alembic **fails** in `_ensure_version_table` → `CREATE TABLE alembic_version` → `UniqueViolation`
- `23:08:31.15` the **api** container's `alembic upgrade head` succeeds (`Running upgrade  -> 0001_…`)

Both call alembic's `_ensure_version_table`, both see no version table, both `CREATE TABLE alembic_version` — Postgres rejects the loser with a duplicate `pg_type` entry. This is a **latent, pre-existing race** (the step has existed since #242); it is nondeterministic, which is why the prior Demo E2E run passed and this one didn't. Only the api container runs alembic among the compose services.

## Fix

Bring up **only Postgres** first, run the host migration to head while it is the sole running service, then start the app services. The api container's later `alembic upgrade head` finds the version table already present (alembic checks before creating) and is a clean no-op — the concurrency is gone, so the fix is deterministic rather than just "win the race more often."

No application or migration code changes; workflow-only reordering.

## Verification

Triggered the Demo E2E workflow on this branch via `workflow_dispatch` to confirm the *Run database migrations* step (and full E2E) passes in the actual GitHub Actions environment.