### PR TITLE
fix(ui): heatmapper filter modal scroll + full-value hover tooltips

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -7906,6 +7906,9 @@ li.ai-fact-active::before {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .heatmap-filter-select-all {

--- a/ui/frontend/src/components/filters/FilterComponents.tsx
+++ b/ui/frontend/src/components/filters/FilterComponents.tsx
@@ -279,7 +279,7 @@ const FilterCheckboxList = ({
                 }}
               />
               <div className="filter-checkbox-text">
-                <span className="filter-checkbox-label" title={isTag || stacked ? displayValue : undefined}>
+                <span className="filter-checkbox-label" title={displayValue}>
                   {displayValue}
                 </span>
                 {stacked && (item.organization || item.published_year) && (

--- a/ui/frontend/src/tests/filterValueTooltip.test.tsx
+++ b/ui/frontend/src/tests/filterValueTooltip.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { FilterSections } from '../components/filters/FilterComponents';
+import { Facets } from '../types/api';
+
+// Regression test for the filter-value hover tooltips (issue 331944).
+// Truncated filter values must expose their full text via a native `title`
+// attribute so hovering reveals the complete value on every filter screen.
+
+const LONG_COUNTRY = 'Democratic Republic of the Congo (long enough to truncate)';
+
+const buildFacets = (): Facets => ({
+  facets: {
+    country: [{ value: LONG_COUNTRY, count: 7 }],
+    tag_theme: [{ value: 'theme_1 - Food Security and Nutrition', count: 4 }],
+  },
+  filter_fields: {
+    country: 'Country',
+    tag_theme: 'Theme',
+  },
+});
+
+const renderSections = () =>
+  render(
+    <FilterSections
+      facets={buildFacets()}
+      selectedFilters={{}}
+      rangeFilters={{}}
+      // `isCollapsed = !collapsedFilters.has(field)`, so membership means expanded.
+      collapsedFilters={new Set(['country', 'tag_theme'])}
+      expandedFilterLists={new Set()}
+      filterSearchTerms={{}}
+      titleSearchResults={[]}
+      facetSearchResults={{}}
+      onToggleFilter={() => {}}
+      onSearchTermChange={() => {}}
+      onToggleFilterListExpansion={() => {}}
+      onFilterValuesChange={() => {}}
+      onRangeChange={() => {}}
+    />
+  );
+
+describe('FilterSections value tooltips', () => {
+  it('test_standard_filter_value_when_rendered_then_exposes_full_text_title', () => {
+    renderSections();
+    const label = screen.getByText(LONG_COUNTRY);
+    expect(label).toHaveAttribute('title', LONG_COUNTRY);
+  });
+
+  it('test_tag_filter_value_when_rendered_then_title_matches_stripped_label', () => {
+    renderSections();
+    const stripped = 'Food Security and Nutrition';
+    const label = screen.getByText(stripped);
+    expect(label).toHaveAttribute('title', stripped);
+  });
+});


### PR DESCRIPTION
## Description
Two related fixes for the **Heatmapper** filters (issue 331944).

### 1. Filter modal scroll-down
The filter modal (e.g. *Filter Country*) overflowed when its option list was expanded: the list grew past the `85vh` modal and pushed the **Cancel/Done** footer off-screen with no scrollbar.

`.heatmap-filter-modal-body` had `flex: 1` but was missing `min-height: 0` and `overflow-y: auto` — so the flex child could not shrink below its content. Added both (plus an explicit `flex: 1 1 auto`) to make the body a bounded scroll region, matching the sibling `.heatmap-modal-content` pattern. Header and footer now stay pinned while the options scroll.

### 2. Full filter values on hover
Filter values are truncated when the sidebar/modal is narrow, with no way to read the full text. The shared `FilterCheckboxList` only set a native `title` tooltip for tag/stacked filters. It now sets `title={displayValue}` for **every** value, so all filter screens — the search sidebar and the heatmapper modal — reveal the complete value on hover (zero-dependency, native tooltip).

## Type of Change
- [x] Bug fix

## Files
- `ui/frontend/src/App.css` — scrollable filter modal body
- `ui/frontend/src/components/filters/FilterComponents.tsx` — always set value `title`
- `ui/frontend/src/tests/filterValueTooltip.test.tsx` — regression test

## Testing
- [x] New regression test passes (`filterValueTooltip.test.tsx`, 2 tests) asserting filter values expose their full text via `title`.
- [x] Verified locally via the running UI (both changes hot-reloaded; scroll confirmed, tooltips confirmed).
- [x] Pre-commit hooks pass.
- Note: the CSS scroll behaviour is not unit-testable in jsdom (no layout), so it was verified manually in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)