### PR TITLE
feat(testing): assertion modal and live run progress

### DIFF
--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -5,17 +5,29 @@ isolation, pass/fail classification, latency capture, judge wiring — is tested
 without touching the live search/LLM services.
 """
 
+import uuid
+
 import pytest
 
-from ui.backend.auth.testing_models import TestExperiment, TestRun
+import ui.backend.services.test_runner as test_runner
+from ui.backend.auth.testing_models import (
+    TestCase,
+    TestDataset,
+    TestExperiment,
+    TestRun,
+)
 from ui.backend.services.test_runner import (
+    _active_case_plan,
     _build_references,
+    _build_result_row,
     _combo_summary_model,
     _default_summary_model,
+    _execute,
     _format_judge_context,
     _group_settings_to_config,
     _mirror_run_to_experiment,
     _parse_judgement,
+    _progress_stats,
     _references_text,
     _resolve_case_plan,
     _storable_output,
@@ -349,6 +361,149 @@ async def test_evaluate_case_when_no_assertions_then_passes():
 
     outcome = await evaluate_case({}, [], runner)
     assert outcome["status"] == "pass" and outcome["score"] == 1.0
+
+
+async def test_progress_stats_reports_completed_and_total():
+    assert _progress_stats(3, 10) == {"progress": {"completed": 3, "total": 10}}
+
+
+async def test_active_case_plan_keeps_only_active_cases_with_assertions():
+    cases = [
+        TestCase(id=uuid.UUID("00000000-0000-0000-0000-000000000001"), input={}),
+        TestCase(id=uuid.UUID("00000000-0000-0000-0000-000000000002"), input={}),
+        TestCase(id=uuid.UUID("00000000-0000-0000-0000-000000000003"), input={}),
+    ]
+    matrix = {
+        "columns": [{"type": "min_results", "value": 1}],
+        "cases": {
+            "00000000-0000-0000-0000-000000000001": {"active": True, "cols": [True]},
+            "00000000-0000-0000-0000-000000000002": {"active": False, "cols": [True]},
+            # case 3 not in matrix -> inactive
+        },
+    }
+    plan = _active_case_plan(matrix, cases)
+    # Only the active case 1 is planned; total drives the progress denominator.
+    assert len(plan) == 1
+    planned_case, assertions = plan[0]
+    assert planned_case is cases[0]
+    assert assertions == [{"type": "min_results", "value": 1}]
+
+
+async def test_active_case_plan_empty_when_no_cases_active():
+    cases = [TestCase(id=uuid.uuid4(), input={})]
+    assert _active_case_plan({}, cases) == []
+
+
+async def test_build_result_row_compacts_output_and_sets_keys():
+    experiment = TestExperiment(id=uuid.uuid4())
+    run = TestRun(id=uuid.uuid4())
+    case = TestCase(id=uuid.uuid4(), input={"query": "x"})
+    outcome = {
+        "status": "pass",
+        "score": 1.0,
+        "latency_ms": 12,
+        "error_message": None,
+        "actual_output": {"results": [{"id": "1", "text": "y" * 5000}]},
+        "assertion_results": [{"type": "min_results", "passed": True}],
+    }
+    row = _build_result_row(experiment, run, case, outcome)
+    assert row.experiment_id == experiment.id
+    assert row.run_id == run.id
+    assert row.test_case_id == case.id
+    assert row.status == "pass"
+    # Output is compacted: per-result text is trimmed to the storage limit.
+    assert len(row.actual_output["results"][0]["text"]) == 2000
+
+
+class _FakeResult:
+    def scalar(self):
+        return 0
+
+
+class _FakeSession:
+    """Minimal async-session stand-in that records summary_stats at each commit,
+    so a test can assert progress is published incrementally."""
+
+    def __init__(self, dataset):
+        self._dataset = dataset
+        self._run = None
+        self.commits = []  # snapshot of run.summary_stats per commit
+        self.added = []
+
+    async def get(self, _model, _ident):
+        return self._dataset
+
+    async def execute(self, _stmt):
+        return _FakeResult()
+
+    def add(self, obj):
+        self.added.append(obj)
+        if isinstance(obj, TestRun):
+            self._run = obj
+
+    async def commit(self):
+        self.commits.append(self._run.summary_stats if self._run else None)
+
+    async def refresh(self, _obj):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+async def test_execute_publishes_incremental_progress(monkeypatch):
+    async def fake_runner(_case_input):
+        return {"results": [{"id": "A", "doc_id": "A"}], "count": 1}
+
+    async def fake_factory(_output, _expectations):
+        return lambda _text, _rubric: 0.0
+
+    c1, c2 = uuid.uuid4(), uuid.uuid4()
+    cases = [
+        TestCase(id=c1, input={"query": "a"}),
+        TestCase(id=c2, input={"query": "b"}),
+    ]
+
+    monkeypatch.setattr(test_runner, "build_case_runner", lambda *a, **k: fake_runner)
+    monkeypatch.setattr(test_runner, "make_judge_factory", lambda _cfg: fake_factory)
+
+    async def fake_load_cases(_session, _dataset_id):
+        return cases
+
+    monkeypatch.setattr(test_runner, "_load_cases", fake_load_cases)
+
+    dataset_id = uuid.uuid4()
+    dataset = TestDataset(id=dataset_id, capability="search", data_source="uneg")
+    experiment = TestExperiment(
+        id=uuid.uuid4(),
+        dataset_id=dataset_id,
+        status="pending",
+        config=None,
+        case_expectations={
+            "columns": [{"type": "min_results", "value": 1}],
+            "cases": {
+                str(c1): {"active": True, "cols": [True]},
+                str(c2): {"active": True, "cols": [True]},
+            },
+        },
+    )
+    session = _FakeSession(dataset)
+
+    await _execute(session, experiment)
+
+    progress = [c["progress"] for c in session.commits if c and "progress" in c]
+    # 0/2 at start, then 1/2 and 2/2 as each case finishes.
+    assert {"completed": 0, "total": 2} in progress
+    assert {"completed": 1, "total": 2} in progress
+    assert {"completed": 2, "total": 2} in progress
+    # Final commit carries the real aggregate stats, not a progress marker.
+    final = session.commits[-1]
+    assert "progress" not in final
+    assert final["pass_rate"] == 1.0 and final["total"] == 2
+    assert experiment.status == "completed"
+    # One persisted result row per active case.
+    result_rows = [o for o in session.added if o.__class__.__name__ == "TestResult"]
+    assert len(result_rows) == 2
 
 
 async def test_evaluate_case_uses_injected_judge_factory():

--- a/ui/backend/services/test_runner.py
+++ b/ui/backend/services/test_runner.py
@@ -701,6 +701,51 @@ async def _mark_failed(session, experiment: TestExperiment, message: str) -> Non
     await session.commit()
 
 
+def _progress_stats(completed: int, total: int) -> Dict[str, Any]:
+    """A lightweight progress marker stored in a run's ``summary_stats`` while it
+    is in flight, so the polling UI can show "completed of total cases".
+
+    It is replaced by the real aggregate stats (``compute_summary_stats``) once
+    the run finishes, so a running run never carries pass/score numbers.
+    """
+    return {"progress": {"completed": completed, "total": total}}
+
+
+def _active_case_plan(
+    matrix: Dict[str, Any], cases: List[TestCase]
+) -> List[Tuple[TestCase, List[Dict[str, Any]]]]:
+    """Resolve the cases that will actually run and the assertions each needs.
+
+    Building the plan up front lets the runner publish a total case count for
+    progress reporting before it starts executing.
+    """
+    plan: List[Tuple[TestCase, List[Dict[str, Any]]]] = []
+    for case in cases:
+        active, assertions = _resolve_case_plan(matrix, str(case.id))
+        if active:
+            plan.append((case, assertions))
+    return plan
+
+
+def _build_result_row(
+    experiment: TestExperiment, run: TestRun, case: TestCase, outcome: Dict[str, Any]
+) -> TestResult:
+    """Build a compact, JSON-safe ``TestResult`` for one evaluated case.
+
+    The full output can carry datetimes and be megabytes large; assertions have
+    already run against it, so only a trimmed, serialisable copy is persisted.
+    """
+    stored = dict(outcome)
+    stored["actual_output"] = _storable_output(outcome.get("actual_output"))
+    stored["assertion_results"] = _json_safe(outcome.get("assertion_results"))
+    return TestResult(
+        experiment_id=experiment.id,
+        run_id=run.id,
+        test_case_id=case.id,
+        **stored,
+    )
+
+
 async def _execute(session, experiment: TestExperiment) -> None:
     dataset = await session.get(TestDataset, experiment.dataset_id)
     started = time.time()
@@ -734,26 +779,24 @@ async def _execute(session, experiment: TestExperiment) -> None:
         return
     judge_factory = make_judge_factory(config)
     matrix = experiment.case_expectations or {}
+
+    # Resolve the active cases up front so the total is known, then publish
+    # progress (and stream each result) as the run advances. Committing per case
+    # — safe because the session is created with expire_on_commit=False — lets
+    # the polling UI report how far along the run is instead of a blind "running".
+    plan = _active_case_plan(matrix, await _load_cases(session, dataset.id))
+    total = len(plan)
+    run.summary_stats = _progress_stats(0, total)
+    await session.commit()
+
     case_results: List[Dict[str, Any]] = []
-    for case in await _load_cases(session, dataset.id):
-        active, assertions = _resolve_case_plan(matrix, str(case.id))
-        if not active:
-            continue
+    for completed, (case, assertions) in enumerate(plan, start=1):
         outcome = await evaluate_case(case.input, assertions, runner, judge_factory)
         case_results.append(outcome)
-        # Persist a compact, JSON-safe copy (full output can carry datetimes and
-        # be megabytes large); assertions already ran against the full output.
-        stored = dict(outcome)
-        stored["actual_output"] = _storable_output(outcome.get("actual_output"))
-        stored["assertion_results"] = _json_safe(outcome.get("assertion_results"))
-        session.add(
-            TestResult(
-                experiment_id=experiment.id,
-                run_id=run.id,
-                test_case_id=case.id,
-                **stored,
-            )
-        )
+        session.add(_build_result_row(experiment, run, case, outcome))
+        run.summary_stats = _progress_stats(completed, total)
+        await session.commit()
+
     run.summary_stats = compute_summary_stats(
         case_results, int((time.time() - started) * 1000)
     )

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -11553,20 +11553,15 @@ a.admin-citation-clickable:hover {
 }
 
 /* Inline add/edit-a-column form below the matrix. */
-.testing-column-form {
-  margin-top: 0.75rem;
-  border: 1px solid var(--color-border, #d0d7de);
-  border-radius: 6px;
-  padding: 0.75rem;
-  background: var(--color-surface, #fff);
-}
-.testing-column-form-header {
-  margin-bottom: 0.5rem;
+/* Assertion add/edit form is presented in a modal (see AssertionColumnForm). */
+.testing-assertion-modal {
+  max-width: 540px;
 }
 .testing-column-form-actions {
   display: flex;
+  justify-content: flex-end;
   gap: var(--spacing-sm, 0.5rem);
-  margin-top: 0.6rem;
+  margin-top: 1rem;
 }
 
 /* ---- Run history (experiment detail) ---- */
@@ -11731,6 +11726,40 @@ a.admin-citation-clickable:hover {
 }
 .testing-run-body {
   padding: 0.5rem 0.75rem 0.75rem;
+}
+
+/* ---- Live run progress (in-flight runs) ---- */
+.testing-run-progress {
+  margin-bottom: 0.6rem;
+}
+.testing-run-progress-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.85rem;
+  color: var(--color-text-muted, #57606a);
+  margin-bottom: 0.3rem;
+}
+.testing-run-progress-pct {
+  font-weight: 600;
+  color: var(--brand-primary, #5b8fa8);
+}
+.testing-run-progress-track {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--color-surface-alt, #eef1f4);
+  overflow: hidden;
+}
+.testing-run-progress-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--brand-primary, #5b8fa8);
+  transition: width 0.3s ease;
+}
+/* Compact "k/N cases" shown in the run header while it is running. */
+.testing-run-progress-of {
+  color: var(--color-text-muted, #57606a);
+  font-weight: 400;
 }
 
 /* ---- Human-friendly result output ---- */

--- a/ui/frontend/src/components/admin/testing/AssertionColumnForm.tsx
+++ b/ui/frontend/src/components/admin/testing/AssertionColumnForm.tsx
@@ -1,4 +1,4 @@
-// Inline form to define or edit one assertion "column" (type + params) for the
+// Modal form to define or edit one assertion "column" (type + params) for the
 // experiment's assertion matrix. Reuses the per-field inputs and the
 // capability-specific assertion specs.
 
@@ -32,49 +32,61 @@ const AssertionColumnForm: React.FC<AssertionColumnFormProps> = ({
   const setParam = (key: string, value: unknown) =>
     setAssertion((prev) => ({ ...prev, [key]: value }));
 
+  const title = isEdit ? 'Edit assertion' : 'Add assertion column';
+
   return (
-    <div className="testing-column-form">
-      <div className="testing-column-form-header">
-        <strong>{isEdit ? 'Edit assertion' : 'Add assertion column'}</strong>
-      </div>
-      <div className="form-group">
-        <label>Assertion type</label>
-        <select
-          value={assertion.type}
-          onChange={(e) => setType(e.target.value)}
-          disabled={isEdit}
-        >
-          {specs.map((s) => (
-            <option key={s.type} value={s.type}>
-              {s.label}
-            </option>
-          ))}
-        </select>
-      </div>
-      {spec && spec.fields.length > 0 && (
-        <div className="testing-assertion-fields">
-          {spec.fields.map((field) => (
-            <FieldInput
-              key={field.key}
-              field={field}
-              assertion={assertion}
-              onSet={setParam}
-            />
-          ))}
+    <div className="modal-overlay" onClick={onCancel}>
+      <div
+        className="modal-content testing-assertion-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h3>{title}</h3>
+          <button type="button" className="modal-close" onClick={onCancel}>
+            &times;
+          </button>
         </div>
-      )}
-      <div className="testing-column-form-actions">
-        <button type="button" className="btn-sm btn-cancel" onClick={onCancel}>
-          Cancel
-        </button>
-        <button
-          type="button"
-          className="btn-sm btn-primary"
-          onClick={() => onSubmit(assertion)}
-          disabled={!assertion.type}
-        >
-          {isEdit ? 'Save assertion' : 'Add column'}
-        </button>
+        <div className="modal-body">
+          <div className="form-group">
+            <label>Assertion type</label>
+            <select
+              value={assertion.type}
+              onChange={(e) => setType(e.target.value)}
+              disabled={isEdit}
+            >
+              {specs.map((s) => (
+                <option key={s.type} value={s.type}>
+                  {s.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          {spec && spec.fields.length > 0 && (
+            <div className="testing-assertion-fields">
+              {spec.fields.map((field) => (
+                <FieldInput
+                  key={field.key}
+                  field={field}
+                  assertion={assertion}
+                  onSet={setParam}
+                />
+              ))}
+            </div>
+          )}
+          <div className="testing-column-form-actions">
+            <button type="button" className="btn-sm btn-cancel" onClick={onCancel}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn-sm btn-primary"
+              onClick={() => onSubmit(assertion)}
+              disabled={!assertion.type}
+            >
+              {isEdit ? 'Save assertion' : 'Add column'}
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/ui/frontend/src/components/admin/testing/ExperimentDetail.tsx
+++ b/ui/frontend/src/components/admin/testing/ExperimentDetail.tsx
@@ -4,6 +4,7 @@ import API_BASE_URL from '../../../config';
 import type {
   AssertionResult,
   ExperimentDetail as ExperimentDetailType,
+  RunProgress,
   TestCase,
   TestResult,
   TestRun,
@@ -342,6 +343,43 @@ const passRateLevel = (rate?: number | null): string => {
   return 'bad';
 };
 
+/* Live progress for an in-flight run: "k of N cases (z%)" plus a bar. The
+   backend publishes `progress` on summary_stats while running and replaces it
+   with the real stats on completion. */
+const RunProgressBar: React.FC<{ progress?: RunProgress | null }> = ({ progress }) => {
+  if (!progress) {
+    return (
+      <div className="testing-run-progress" role="status">
+        <span className="testing-run-progress-label">Starting…</span>
+      </div>
+    );
+  }
+  const { completed, total } = progress;
+  const fraction = total > 0 ? completed / total : 0;
+  return (
+    <div className="testing-run-progress" role="status">
+      <div className="testing-run-progress-label">
+        <span>
+          {completed} of {total} {total === 1 ? 'case' : 'cases'} processed
+        </span>
+        <span className="testing-run-progress-pct">{formatPercent(fraction)}</span>
+      </div>
+      <div
+        className="testing-run-progress-track"
+        role="progressbar"
+        aria-valuenow={completed}
+        aria-valuemin={0}
+        aria-valuemax={total}
+      >
+        <div
+          className="testing-run-progress-fill"
+          style={{ width: `${Math.round(fraction * 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+};
+
 const RunSection: React.FC<{
   run: TestRun;
   caseInputs: Record<string, Record<string, unknown>>;
@@ -369,22 +407,34 @@ const RunSection: React.FC<{
           {run.status}
         </span>
         {isLatest && <span className="testing-run-latest">Latest</span>}
-        <span className="testing-run-metrics">
-          <span className="testing-run-metric">
-            <strong className={`testing-passrate testing-passrate--${level}`}>
-              {formatPercent(stats?.pass_rate)}
-            </strong>
-            <span className="testing-run-metric-label">pass</span>
+        {active && stats?.progress ? (
+          <span className="testing-run-metrics">
+            <span className="testing-run-metric">
+              <strong>
+                {stats.progress.completed}
+                <span className="testing-run-progress-of">/{stats.progress.total}</span>
+              </strong>
+              <span className="testing-run-metric-label">cases</span>
+            </span>
           </span>
-          <span className="testing-run-metric">
-            <strong>{formatScore(stats?.mean_score)}</strong>
-            <span className="testing-run-metric-label">score</span>
+        ) : (
+          <span className="testing-run-metrics">
+            <span className="testing-run-metric">
+              <strong className={`testing-passrate testing-passrate--${level}`}>
+                {formatPercent(stats?.pass_rate)}
+              </strong>
+              <span className="testing-run-metric-label">pass</span>
+            </span>
+            <span className="testing-run-metric">
+              <strong>{formatScore(stats?.mean_score)}</strong>
+              <span className="testing-run-metric-label">score</span>
+            </span>
+            <span className="testing-run-metric">
+              <strong>{formatMs(stats?.duration_ms)}</strong>
+              <span className="testing-run-metric-label">dur</span>
+            </span>
           </span>
-          <span className="testing-run-metric">
-            <strong>{formatMs(stats?.duration_ms)}</strong>
-            <span className="testing-run-metric-label">dur</span>
-          </span>
-        </span>
+        )}
         <span className="testing-run-time">
           {formatTimestamp(run.finished_at || run.started_at)}
         </span>
@@ -392,6 +442,7 @@ const RunSection: React.FC<{
       {open && (
         <div className="testing-run-body">
           {stats?.error && <div className="auth-error">Run error: {stats.error}</div>}
+          {active && <RunProgressBar progress={stats?.progress} />}
           <RunStats run={run} />
           <table className="admin-table">
             <thead>
@@ -411,7 +462,7 @@ const RunSection: React.FC<{
               {results.length === 0 && (
                 <tr>
                   <td colSpan={6} className="text-muted">
-                    {active ? 'Running — results will appear shortly...' : 'No results.'}
+                    {active ? 'Running — results appear here as each case finishes…' : 'No results.'}
                   </td>
                 </tr>
               )}

--- a/ui/frontend/src/tests/assertionMatrix.test.tsx
+++ b/ui/frontend/src/tests/assertionMatrix.test.tsx
@@ -9,6 +9,8 @@ const cases: TestCase[] = [
   { id: 'c2', dataset_id: 'd1', input: { query: 'beta' }, created_at: '', updated_at: '' },
 ];
 
+const MODAL_OVERLAY = '.modal-overlay';
+
 const Harness: React.FC<{ initial: MatrixValue }> = ({ initial }) => {
   const [value, setValue] = React.useState<MatrixValue>(initial);
   return (
@@ -30,6 +32,36 @@ describe('AssertionMatrix', () => {
     fireEvent.click(screen.getByRole('button', { name: /Add column/i }));
     // The new column's header summarises the assertion type (default first spec).
     expect(screen.getByText(/result_contains_id/)).toBeInTheDocument();
+  });
+
+  test('clicking + Assertion opens the form in a modal', () => {
+    const { container } = render(<Harness initial={{ columns: [], cases: {} }} />);
+    expect(container.querySelector(MODAL_OVERLAY)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /\+ Assertion/i }));
+    // The add form is presented in a modal overlay, not inline in the matrix.
+    expect(container.querySelector(MODAL_OVERLAY)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Add assertion column/i })).toBeInTheDocument();
+  });
+
+  test('cancelling the assertion modal closes it', () => {
+    const { container } = render(<Harness initial={{ columns: [], cases: {} }} />);
+    fireEvent.click(screen.getByRole('button', { name: /\+ Assertion/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+    expect(container.querySelector(MODAL_OVERLAY)).toBeNull();
+  });
+
+  test('editing an existing column opens the modal in edit mode', () => {
+    const initial: MatrixValue = {
+      columns: [{ type: 'min_results', value: 1 }],
+      cases: {
+        c1: { active: true, cols: [true] },
+        c2: { active: true, cols: [true] },
+      },
+    };
+    const { container } = render(<Harness initial={initial} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Edit$/i }));
+    expect(container.querySelector(MODAL_OVERLAY)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Edit assertion/i })).toBeInTheDocument();
   });
 
   test('does not crash on a legacy per-case value shape', () => {

--- a/ui/frontend/src/tests/experimentDetailProgress.test.tsx
+++ b/ui/frontend/src/tests/experimentDetailProgress.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import ExperimentDetail from '../components/admin/testing/ExperimentDetail';
+
+jest.mock('../config', () => ({ __esModule: true, default: '/api' }));
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const TS = '2026-06-25T16:58:28Z';
+
+const runningDetail = {
+  id: 'e1',
+  dataset_id: 'd1',
+  name: 'COVID eval',
+  status: 'running',
+  config: null,
+  case_expectations: null,
+  summary_stats: null,
+  started_at: TS,
+  finished_at: null,
+  created_at: TS,
+  runs: [
+    {
+      id: 'r1',
+      experiment_id: 'e1',
+      run_number: 4,
+      status: 'running',
+      summary_stats: { progress: { completed: 3, total: 5 } },
+      started_at: TS,
+      finished_at: null,
+      created_at: TS,
+      results: [],
+    },
+  ],
+};
+
+const completedDetail = {
+  ...runningDetail,
+  status: 'completed',
+  runs: [
+    {
+      ...runningDetail.runs[0],
+      status: 'completed',
+      summary_stats: {
+        total: 5,
+        passed: 5,
+        failed: 0,
+        errored: 0,
+        pass_rate: 1,
+        mean_score: 0.97,
+        duration_ms: 1234,
+      },
+      finished_at: '2026-06-25T17:00:00Z',
+      results: [],
+    },
+  ],
+};
+
+const mockGet = (detail: unknown) => {
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url.includes('/groups')) return Promise.resolve({ data: [] });
+    if (url.includes('/cases')) return Promise.resolve({ data: [] });
+    if (url.includes('/testing/experiments/')) return Promise.resolve({ data: detail });
+    return Promise.resolve({ data: [] });
+  });
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const noop = () => undefined;
+
+describe('ExperimentDetail run progress', () => {
+  test('shows a live "k of N cases" indicator while a run is in progress', async () => {
+    mockGet(runningDetail);
+    render(<ExperimentDetail experimentId="e1" onBack={noop} onEdit={noop} />);
+
+    // Body progress bar: count, label and percentage (3/5 = 60%).
+    await waitFor(() =>
+      expect(screen.getByText(/3 of 5 cases processed/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText('60%')).toBeInTheDocument();
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '3');
+    expect(bar).toHaveAttribute('aria-valuemax', '5');
+  });
+
+  test('does not show the progress indicator once the run is completed', async () => {
+    mockGet(completedDetail);
+    render(<ExperimentDetail experimentId="e1" onBack={noop} onEdit={noop} />);
+
+    // Completed runs show real stats, not progress.
+    await waitFor(() => expect(screen.getByText('COVID eval')).toBeInTheDocument());
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.queryByText(/cases processed/i)).not.toBeInTheDocument();
+  });
+});

--- a/ui/frontend/src/types/testing.ts
+++ b/ui/frontend/src/types/testing.ts
@@ -63,6 +63,13 @@ export interface AssertionResult {
   judge_prompt?: string;
 }
 
+// Emitted only while a run is in flight, so the UI can show how far it has
+// progressed. Replaced by the aggregate fields below once the run completes.
+export interface RunProgress {
+  completed: number;
+  total: number;
+}
+
 export interface SummaryStats {
   total: number;
   passed: number;
@@ -72,6 +79,7 @@ export interface SummaryStats {
   mean_score?: number | null;
   duration_ms: number;
   error?: string;
+  progress?: RunProgress | null;
 }
 
 export interface TestExperiment {


### PR DESCRIPTION
## Description

Two UX improvements to the admin **evaluation / testing** harness:

1. **Assertion add/edit in a modal.** The form to define or edit an assertion "column" previously rendered inline *below* the cases × assertions matrix, where it was easy to miss. It now opens in a modal (the shared `modal-overlay` / `modal-content` pattern used elsewhere in the testing UI). Same fields, same logic, same submit/cancel behaviour — presentation only.

2. **Live run progress.** When an experiment is running, the detail view previously showed only a static "running" status with no indication of progress until completion. The run engine now:
   - resolves the active-case plan up front (so the total is known),
   - publishes `summary_stats.progress = {completed, total}` and commits **per case** (safe because the session is `expire_on_commit=False`),

   so the polling detail view streams a **"k of N cases (z%)"** progress bar — plus a compact `k/N` in the run header — and per-case results fill in as they finish, instead of a blind "running". On completion the progress marker is replaced by the real aggregate stats.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Performance improvement

## Testing
- [x] Tests pass locally
- [x] New tests added for new functionality
- [x] Manual testing completed (both features verified in the running app)

New/updated tests:
- `tests/unit/test_test_runner.py` — `_progress_stats`, `_active_case_plan`, `_build_result_row`, and an `_execute` test asserting progress is committed incrementally (0/2 → 1/2 → 2/2 → final stats).
- `ui/frontend/src/tests/assertionMatrix.test.tsx` — assertion form opens/closes in a modal (add + edit modes).
- `ui/frontend/src/tests/experimentDetailProgress.test.tsx` — progress bar renders while running and disappears once completed.

Verification run locally: backend unit tests (`pytest tests/unit/test_test_runner.py`), frontend tests (assertionMatrix / experimentDetailProgress / testingManager), `tsc --noEmit`, ESLint on changed files, and the full pre-commit suite (black, isort, flake8, mypy, bandit, detect-secrets, gitleaks, code-metrics) — all green.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [ ] Documentation updated (none needed — internal admin UI, no doc pages affected)
- [x] No breaking changes

## Notes
- Targets `rc/v1.6.0` per the contributing guidelines.
- Pure UX/instrumentation change; no schema migrations (progress rides in the existing `summary_stats` JSONB), no API surface changes.
- Out of scope (intentionally excluded from this branch): a separate reranker resource issue in local deployments (Vertex ranker IAM 403 / local cross-encoder OOM) surfaced during testing — it lives in the search path and is unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
