### PR TITLE
feat(ui): Brief is a core tab — remove brief.enabled feature flag

### DIFF
--- a/ui/frontend/src/components/layout/NavTabs.tsx
+++ b/ui/frontend/src/components/layout/NavTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ASSISTANT_ENABLED, BRIEF_ENABLED } from '../../config';
+import { ASSISTANT_ENABLED } from '../../config';
 
 type TabName = 'search' | 'assistant' | 'brief' | 'heatmap' | 'documents' | 'pipeline' | 'processing' | 'info' | 'tech' | 'data' | 'privacy' | 'terms' | 'stats' | 'admin' | 'docs';
 
@@ -43,14 +43,12 @@ export const NavTabs = ({ activeTab, onTabChange }: NavTabsProps) => {
           Chat
         </button>
       )}
-      {BRIEF_ENABLED && (
-        <button
-          className={`nav-tab ${activeTab === 'brief' ? ACTIVE_CLASS : ''}`}
-          onClick={() => onTabChange('brief')}
-        >
-          Brief
-        </button>
-      )}
+      <button
+        className={`nav-tab ${activeTab === 'brief' ? ACTIVE_CLASS : ''}`}
+        onClick={() => onTabChange('brief')}
+      >
+        Brief
+      </button>
       <button
         className={`nav-tab ${activeTab === 'heatmap' ? ACTIVE_CLASS : ''}`}
         onClick={() => onTabChange('heatmap')}

--- a/ui/frontend/src/config.ts
+++ b/ui/frontend/src/config.ts
@@ -36,9 +36,6 @@ export const ASSISTANT_ENABLED = (config.application as any).assistant?.enabled 
 export const ASSISTANT_MAX_SEARCH_RESULTS = (config.application as any).assistant?.max_search_results ?? 20;
 export const ASSISTANT_MAX_ITERATIONS = (config.application as any).assistant?.max_iterations ?? 3;
 
-// Brief tab feature flag (defaults to false; enable via config.application.brief.enabled)
-export const BRIEF_ENABLED = (config.application as any).brief?.enabled ?? false;
-
 // Search results page size (defaults to 50)
 export const SEARCH_RESULTS_PAGE_SIZE = String(config.application.search.page_size);
 

--- a/ui/frontend/src/tests/briefTab.test.tsx
+++ b/ui/frontend/src/tests/briefTab.test.tsx
@@ -7,7 +7,6 @@ jest.mock('../config', () => ({
   __esModule: true,
   default: '/api',
   API_KEY: undefined,
-  BRIEF_ENABLED: true,
   USER_MODULE: false,
 }));
 


### PR DESCRIPTION
## What

The **Brief** tab was gated behind `config.application.brief.enabled`, so deployments whose config didn't set it (e.g. WFP, whose Azure config omits it) never showed the tab — even though the tab renames (Assistant→Chat, Heatmapper→Map) showed fine because those labels aren't flagged.

Brief is a core feature, so it should render unconditionally like Search and Map.

## Changes
- Remove the `BRIEF_ENABLED` flag from `config.ts` and the gate in `NavTabs` — the Brief tab now always renders.
- Drop the now-unused `BRIEF_ENABLED` prop from the `briefTab` test mock.

The backend brief routes were already registered unconditionally, so no backend change is needed.

## Verification
- Rebuilt the frontend with a config that **omits** `brief.enabled` (simulating the WFP/Azure config) and confirmed the tabs render **Search · Chat · Brief · Map · Monitor** in the live app.
- Prod build clean; `briefTab` unit tests 8/8.

## Deploy note
For WFP: redeploy the frontend with this code — Brief will appear without any config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)