### PR TITLE
feat(ui): citation hover excerpt uses Search's text formatter

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -3815,7 +3815,6 @@ h6,
   font-size: 0.8125rem;
   line-height: 1.5;
   color: var(--gray-700);
-  white-space: pre-wrap;
 }
 
 .citation-doc-group {

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -8,6 +8,7 @@ import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { SourceReference } from '../../types/api';
+import { parseAndRenderSuperscripts } from '../../utils/textHighlighting';
 
 const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
 
@@ -80,7 +81,11 @@ const InlineCitation: React.FC<{
             {typeof source.page === 'number' && (
               <div className="citation-hover-meta">Page {source.page}</div>
             )}
-            {source.text && <div className="citation-hover-excerpt">{source.text}</div>}
+            {source.text && (
+              <div className="citation-hover-excerpt">
+                {parseAndRenderSuperscripts(source.text)}
+              </div>
+            )}
           </div>,
           document.body,
         )}

--- a/ui/frontend/src/tests/citationHoverCard.test.tsx
+++ b/ui/frontend/src/tests/citationHoverCard.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CitedMarkdown } from '../components/citations/CitedContent';
+import { SourceReference } from '../types/api';
+
+const source: SourceReference = {
+  chunkId: 'c1',
+  docId: 'd1',
+  title: 'Doc One',
+  text: 'First line ^1 of the excerpt.\nSecond line continues.',
+  score: 0.5,
+  page: 4,
+  index: 1,
+  headings: [],
+};
+
+describe('inline citation hover card', () => {
+  test('renders the excerpt with the same formatter Search uses', () => {
+    const { container } = render(<CitedMarkdown content="A key finding [1]." sources={[source]} />);
+
+    const badge = container.querySelector('.ai-summary-citation') as HTMLElement;
+    expect(badge).not.toBeNull();
+    fireEvent.mouseEnter(badge);
+
+    // Card shows the document title + page…
+    expect(screen.getByText('Doc One')).toBeInTheDocument();
+    expect(screen.getByText('Page 4')).toBeInTheDocument();
+
+    // …and the excerpt is rendered through Search's parseAndRenderSuperscripts,
+    // which wraps it in a .formatted-text-block (not raw text), so the two match.
+    const excerpt = document.querySelector('.citation-hover-excerpt');
+    expect(excerpt).not.toBeNull();
+    expect(excerpt!.querySelector('.formatted-text-block')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The inline-citation hover card (shown when hovering a `[N]` in the Brief/Assistant) rendered its excerpt as **raw text**, so it looked different from a Search result excerpt.

## Change
Render the excerpt through the **same function Search uses** — `parseAndRenderSuperscripts` (`parseSuperscripts` + `formatLinesWithIndentation` from `utils/textHighlighting`). The excerpt is now a `.formatted-text-block` with superscript footnote markers, line breaks and list indentation handled identically to Search. Dropped the now-redundant `white-space: pre-wrap`.

Keyword/semantic highlighting isn't applied here because a citation has no search query or semantic-match data; with no query the function returns the same formatted output Search would for a non-matching excerpt.

## Verification
- Unit test: hovering a citation renders the excerpt as a `.formatted-text-block` (the Search formatter) with title + page.
- Prod build clean; redeployed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)