### PR TITLE
build(ui): pass REACT_APP_USER_FEEDBACK build arg in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -260,6 +260,7 @@ services:
         - REACT_APP_BASE_PATH=${REACT_APP_BASE_PATH:-}
         - REACT_APP_USER_MODULE=${REACT_APP_USER_MODULE:-off}
         - REACT_APP_API_KEY=${REACT_APP_API_KEY:-}
+        - REACT_APP_USER_FEEDBACK=${REACT_APP_USER_FEEDBACK:-0}
     container_name: ui
     # Only visible inside Docker; Caddy reverse-proxies to this
     expose:


### PR DESCRIPTION
`REACT_APP_USER_FEEDBACK` gates the editable content-category UI in the TOC modal (category `<select>` + drag-reorder), but it wasn't passed into the ui build — `Dockerfile.prod` declares `ARG REACT_APP_USER_FEEDBACK=0` while `docker-compose.prod.yml` didn't forward it, so setting it in `.env` had no effect.

This adds `- REACT_APP_USER_FEEDBACK=${REACT_APP_USER_FEEDBACK:-0}` to the ui `build.args`, matching the other `REACT_APP_*` flags. Default stays `0` (off); a deployment sets `REACT_APP_USER_FEEDBACK=1` in `.env` and rebuilds to enable it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)