### PR TITLE
feat(ui): Brief uses the group's search settings when logged in

### DIFF
--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -2947,6 +2947,18 @@ function App() {
           <BriefTab
             dataSource={dataSource}
             assistantModelConfig={assistantModelConfig}
+            rerankerModel={rerankModel}
+            searchSettings={{
+              denseWeight: searchDenseWeight,
+              recencyBoost: recencyBoostEnabled,
+              recencyWeight,
+              recencyScaleDays,
+              sectionTypes,
+              keywordBoostShortQueries,
+              minChunkSize,
+              fieldBoost: fieldBoostEnabled,
+              fieldBoostFields,
+            }}
             onResultClick={handleResultClick}
           />
         }

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useState } from 'react';
 import API_BASE_URL, { USER_MODULE } from '../../config';
 import { useAuth } from '../../hooks/useAuth';
 import { SearchResult, SourceReference, SummaryModelConfig } from '../../types/api';
+import { SearchSettings } from '../../types/auth';
 import {
   buildExportFilename,
   exportResultsToDocxBlob,
@@ -67,6 +68,10 @@ interface BriefTabProps {
   dataSource: string;
   // The configured chat / deep-research model, used for outline + section research.
   assistantModelConfig?: SummaryModelConfig | null;
+  // The app's active reranker + search settings (group-seeded for logged-in
+  // users). Applied to brief searches only when logged in.
+  rerankerModel?: string | null;
+  searchSettings?: Partial<SearchSettings> | null;
   // Opens the document preview (citations/footnotes click through to it).
   onResultClick?: (result: SearchResult) => void;
 }
@@ -74,12 +79,24 @@ interface BriefTabProps {
 export const BriefTab: React.FC<BriefTabProps> = ({
   dataSource,
   assistantModelConfig,
+  rerankerModel,
+  searchSettings,
   onResultClick,
 }) => {
   const auth = useAuth();
   // Logged-in users get their own saved-briefs bucket; anonymous users share one.
   const userKey = USER_MODULE && auth.user ? String(auth.user.id) : null;
-  const brief = useBrief({ apiBaseUrl: API_BASE_URL, dataSource, assistantModelConfig, userKey });
+  const loggedIn = userKey != null;
+  const brief = useBrief({
+    apiBaseUrl: API_BASE_URL,
+    dataSource,
+    assistantModelConfig,
+    // Use the group's search settings only when logged in; anonymous briefs run
+    // without reranking (the default cross-encoder is too slow for many queries).
+    rerankerModel: loggedIn ? rerankerModel ?? null : null,
+    searchSettings: loggedIn ? searchSettings ?? null : null,
+    userKey,
+  });
   const [exportBusy, setExportBusy] = useState(false);
 
   const handleExportWord = useCallback(async () => {

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SourceReference, SummaryModelConfig } from '../../types/api';
+import { SearchSettings } from '../../types/auth';
 import { extractCitedNumbers } from '../citations/CitedContent';
 import {
   BriefActivityEvent,
@@ -42,6 +43,11 @@ export interface UseBriefOptions {
   // both outline generation and per-section research so the Brief tab uses the
   // same LLM as the rest of the system.
   assistantModelConfig?: SummaryModelConfig | null;
+  // Group search settings to apply to brief searches (reranker + search
+  // settings). Passed only for logged-in users so briefs search like the rest
+  // of the app; null for anonymous users (no rerank).
+  rerankerModel?: string | null;
+  searchSettings?: Partial<SearchSettings> | null;
   // Identifier for the logged-in user; saved briefs are scoped to it. When
   // absent (anonymous), the shared default bucket is used.
   userKey?: string | null;
@@ -152,6 +158,8 @@ export const useBrief = ({
   apiBaseUrl,
   dataSource,
   assistantModelConfig,
+  rerankerModel,
+  searchSettings,
   userKey,
 }: UseBriefOptions) => {
   const historyKey = userKey ? `${BRIEF_HISTORY_KEY}_u_${userKey}` : BRIEF_HISTORY_KEY;
@@ -191,6 +199,12 @@ export const useBrief = ({
   numberHeadingsRef.current = numberHeadings;
   const historyRef = useRef(history);
   historyRef.current = history;
+  // Group search settings, read at research time so the research callbacks stay
+  // stable as the (per-render) settings object changes.
+  const rerankerModelRef = useRef(rerankerModel);
+  rerankerModelRef.current = rerankerModel;
+  const searchSettingsRef = useRef(searchSettings);
+  searchSettingsRef.current = searchSettings;
 
   useEffect(() => setHistory(loadHistory(historyKey)), [historyKey]);
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -286,6 +300,8 @@ export const useBrief = ({
         query: surveyQuery,
         doneLabel: 'Document library surveyed',
         assistantModelConfig,
+        rerankerModel: rerankerModelRef.current,
+        searchSettings: searchSettingsRef.current,
         signal: controller.signal,
         handlers: {
           onActivity: (ev) => setGeneratingActivity((prev) => [ev, ...prev].slice(0, 40)),
@@ -436,6 +452,8 @@ export const useBrief = ({
         briefInstructions: instructionsRef.current.trim() || null,
         parentTitle,
         assistantModelConfig,
+        rerankerModel: rerankerModelRef.current,
+        searchSettings: searchSettingsRef.current,
         signal,
         handlers: {
           onActivity: (ev) => pushActivity(id, ev),

--- a/ui/frontend/src/tests/briefGroupSettings.test.tsx
+++ b/ui/frontend/src/tests/briefGroupSettings.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+// USER_MODULE on + an authenticated user => the brief is "logged in".
+jest.mock('../config', () => ({
+  __esModule: true,
+  default: '/api',
+  API_KEY: undefined,
+  USER_MODULE: true,
+}));
+jest.mock('../hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }));
+
+const mockRunDeepResearch = jest.fn();
+const mockRequestOutline = jest.fn();
+const mockResearchSection = jest.fn();
+jest.mock('../utils/briefStream', () => ({
+  __esModule: true,
+  requestBriefOutline: (...a: unknown[]) => mockRequestOutline(...a),
+  researchBriefSection: (...a: unknown[]) => mockResearchSection(...a),
+  runDeepResearch: (...a: unknown[]) => mockRunDeepResearch(...a),
+}));
+
+import { BriefTab } from '../components/brief/BriefTab';
+
+describe('Brief uses the group search settings when logged in', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockRunDeepResearch.mockImplementation(async ({ handlers }: any) => {
+      handlers.onSources([]);
+      handlers.onDone({ content: '', sources: [] });
+    });
+    mockRequestOutline.mockResolvedValue({ title: 't', headings: [{ title: 'A', level: 1 }] });
+  });
+
+  test('passes the group reranker + search settings into research', async () => {
+    render(
+      <BriefTab
+        dataSource="wfp"
+        rerankerModel="vertex-ai-ranker"
+        searchSettings={{ denseWeight: 0.7, fieldBoost: true }}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Topic'), { target: { value: 'cash assistance' } });
+    fireEvent.click(screen.getByText('Generate outline'));
+
+    await waitFor(() => expect(mockRunDeepResearch).toHaveBeenCalled());
+    const arg = mockRunDeepResearch.mock.calls[0][0];
+    expect(arg.rerankerModel).toBe('vertex-ai-ranker');
+    expect(arg.searchSettings).toMatchObject({ denseWeight: 0.7, fieldBoost: true });
+  });
+});

--- a/ui/frontend/src/utils/briefStream.ts
+++ b/ui/frontend/src/utils/briefStream.ts
@@ -9,6 +9,7 @@
 
 import { API_KEY } from '../config';
 import { SourceReference, SummaryModelConfig } from '../types/api';
+import { SearchSettings } from '../types/auth';
 import { streamAssistantChat } from './assistantStream';
 
 const getCsrfToken = (): string | null => {
@@ -130,14 +131,18 @@ export interface RunDeepResearchOptions {
   query: string;
   doneLabel?: string;
   assistantModelConfig?: SummaryModelConfig | null;
+  // Reranker + search settings. Logged-in briefs pass the group's settings so
+  // they search like the rest of the app; otherwise these are null (no rerank —
+  // the default CPU cross-encoder is too slow for multi-query research).
+  rerankerModel?: string | null;
+  searchSettings?: Partial<SearchSettings> | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
 
 /**
  * Run one deep-research assistant turn for an arbitrary query, mapping its
- * stream onto the Brief activity/content/sources callbacks. Reranking is
- * disabled (briefs never rerank).
+ * stream onto the Brief activity/content/sources callbacks.
  */
 export const runDeepResearch = async ({
   apiBaseUrl,
@@ -145,6 +150,8 @@ export const runDeepResearch = async ({
   query,
   doneLabel = 'Section complete',
   assistantModelConfig,
+  rerankerModel = null,
+  searchSettings = null,
   handlers,
   signal,
 }: RunDeepResearchOptions): Promise<void> => {
@@ -157,8 +164,8 @@ export const runDeepResearch = async ({
     dataSource,
     deepResearch: true,
     assistantModelConfig: assistantModelConfig ?? null,
-    rerankerModel: null, // briefs never rerank — the CPU reranker is too slow
-    searchSettings: null,
+    rerankerModel: rerankerModel ?? null,
+    searchSettings: searchSettings ?? null,
     handlers: {
       onPhase: (phase) => {
         const pct = PHASE_PROGRESS[phase];
@@ -213,6 +220,8 @@ export interface ResearchSectionOptions {
   // scoped to its parent and the generated queries reflect that context.
   parentTitle?: string | null;
   assistantModelConfig?: SummaryModelConfig | null;
+  rerankerModel?: string | null;
+  searchSettings?: Partial<SearchSettings> | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -274,6 +283,8 @@ export const researchBriefSection = ({
   briefInstructions,
   parentTitle,
   assistantModelConfig,
+  rerankerModel,
+  searchSettings,
   handlers,
   signal,
 }: ResearchSectionOptions): Promise<void> => {
@@ -283,6 +294,8 @@ export const researchBriefSection = ({
     dataSource,
     query,
     assistantModelConfig,
+    rerankerModel,
+    searchSettings,
     handlers,
     signal,
   });


### PR DESCRIPTION
## What

Brief research previously ran with **no reranker and no search settings** (a deliberate default, since the local CPU cross-encoder is too slow for multi-query research). For **logged-in users**, brief searches should match the rest of the app — i.e. use their **group's** search settings.

## Change
When the user is logged in, pass the app's active **reranker model** + **search settings** into both the outline survey and per-section research. These are the values `useGroupDefaults` already seeds from the user's group (the same ones Search and the Assistant use), so briefs now search consistently with the group's configuration (e.g. WFP's `vertex-ai-ranker`, dense/sparse weights, field boost, recency).

Anonymous briefs are unchanged — they still run without reranking.

Threading: `App` → `BriefTab` (gated on login) → `useBrief` → `briefStream` → `streamAssistantChat`.

## Verification
- Unit test: a logged-in `BriefTab` passes the group reranker + search settings into the deep-research call; existing brief tests still pass.
- Prod build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)