### PR TITLE
feat(ui): Brief citations — heading breadcrumb shown as an italic section path

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -3816,6 +3816,14 @@ h6,
   line-height: 1.5;
   color: var(--gray-700);
 }
+/* Heading breadcrumb shown as an italic section path at the top of the excerpt. */
+.citation-hover-section {
+  margin-bottom: 6px;
+  font-style: italic;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--gray-500);
+}
 
 .citation-doc-group {
   display: inline-block;

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -29,6 +29,39 @@ export const extractCitedNumbers = (text: string): number[] => {
   return Array.from(cited).sort((a, b) => a - b);
 };
 
+// A leading "-- h1 > h2 > h3 --" line is a heading breadcrumb embedded in the
+// chunk text. Split it off so the excerpt can show it as an italic section path
+// (without the -- markers) above the body.
+const SECTION_BREADCRUMB_RE = /^\s*--\s*(.+?)\s*--\s*$/;
+
+export const parseSectionBreadcrumb = (
+  text: string,
+): { section: string | null; body: string } => {
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
+  let i = 0;
+  while (i < lines.length && lines[i].trim() === '') i++;
+  const match = i < lines.length ? SECTION_BREADCRUMB_RE.exec(lines[i].trim()) : null;
+  if (match && match[1].includes(' > ')) {
+    const body = lines
+      .slice(i + 1)
+      .join('\n')
+      .replace(/^\n+/, '');
+    return { section: match[1].trim(), body };
+  }
+  return { section: null, body: text };
+};
+
+const renderCitationExcerpt = (text: string): React.ReactNode => {
+  const { section, body } = parseSectionBreadcrumb(text);
+  if (!section) return parseAndRenderSuperscripts(text);
+  return (
+    <>
+      <div className="citation-hover-section">{section}</div>
+      {body.trim() && <div>{parseAndRenderSuperscripts(body)}</div>}
+    </>
+  );
+};
+
 const InlineCitation: React.FC<{
   num: number;
   source?: SourceReference;
@@ -82,9 +115,7 @@ const InlineCitation: React.FC<{
               <div className="citation-hover-meta">Page {source.page}</div>
             )}
             {source.text && (
-              <div className="citation-hover-excerpt">
-                {parseAndRenderSuperscripts(source.text)}
-              </div>
+              <div className="citation-hover-excerpt">{renderCitationExcerpt(source.text)}</div>
             )}
           </div>,
           document.body,

--- a/ui/frontend/src/tests/citationBreadcrumb.test.ts
+++ b/ui/frontend/src/tests/citationBreadcrumb.test.ts
@@ -1,0 +1,29 @@
+import { parseSectionBreadcrumb } from '../components/citations/CitedContent';
+
+describe('parseSectionBreadcrumb', () => {
+  test('splits a leading "-- a > b > c --" breadcrumb off the body, stripping the dashes', () => {
+    const text =
+      '-- 2. Evaluation findings > 2.5. EQ5. Effects/impact > Contribution analysis --\n\nThe programme contributed to…';
+    const { section, body } = parseSectionBreadcrumb(text);
+    expect(section).toBe('2. Evaluation findings > 2.5. EQ5. Effects/impact > Contribution analysis');
+    expect(body).toBe('The programme contributed to…');
+  });
+
+  test('handles leading blank lines before the breadcrumb', () => {
+    const { section, body } = parseSectionBreadcrumb('\n\n-- A > B --\nBody text.');
+    expect(section).toBe('A > B');
+    expect(body).toBe('Body text.');
+  });
+
+  test('leaves text without a breadcrumb untouched (no section)', () => {
+    const { section, body } = parseSectionBreadcrumb('Just an ordinary excerpt with no heading line.');
+    expect(section).toBeNull();
+    expect(body).toBe('Just an ordinary excerpt with no heading line.');
+  });
+
+  test('a "-- … --" line without a " > " separator is not treated as a breadcrumb', () => {
+    const text = '-- not a path --\nbody';
+    const { section } = parseSectionBreadcrumb(text);
+    expect(section).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

In the Brief citation hover card, a source's excerpt often begins with a heading-breadcrumb line embedded in the chunk text:

```
-- 2. Evaluation findings > 2.5. EQ5. Effects/impact > Contribution analysis of the programme impact. --
```

Previously that line showed verbatim (with the `--` markers). Now it's rendered as **part of the excerpt** but as an **italic section path** with the `--` removed, and the body renders below it as before.

## Changes
- Add `parseSectionBreadcrumb()` (pure helper) to split a leading `-- a > b > c --` line off the excerpt body.
- Render the breadcrumb as an italic `.citation-hover-section` above the body in the citation hover card.
- The body still renders via Search's text formatter (`parseAndRenderSuperscripts`).

A `-- … --` line without a ` > ` path is left as ordinary text (not treated as a breadcrumb).

## Tests
- `parseSectionBreadcrumb` 4/4: strips the dashes, handles leading blank lines, leaves plain excerpts untouched, ignores non-path `-- … --` lines.
- Prod build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)