### PR TITLE
fix(search): Heatmapper attribute filters work for Postgres-sourced fields (language, evaluation category, …)

### DIFF
--- a/tests/unit/test_docsearch.py
+++ b/tests/unit/test_docsearch.py
@@ -14,6 +14,7 @@ from ui.backend.routes.search import (
     _build_metadata_filter_condition,
     _format_document_result,
     _get_indexed_doc_ids,
+    _resolve_pg_filter_fields,
     docsearch,
 )
 
@@ -438,6 +439,150 @@ def test_build_docsearch_filters_includes_indexed_doc_ids():
 
     assert has_id_filter is not None
     assert has_id_filter.has_id == indexed_ids
+
+
+def _extract_has_id(filter_obj):
+    """Pull the HasIdCondition id list out of a docsearch filter."""
+    for item in filter_obj.must:
+        if hasattr(item, "should") and item.should:
+            for cond in item.should:
+                if isinstance(cond, qmodels.HasIdCondition):
+                    return cond.has_id
+    return None
+
+
+def test_build_docsearch_filters_intersects_resolved_doc_id_constraint():
+    """A resolved doc_id constraint (from language/region) intersects the
+    indexed id set instead of being applied as a payload filter — this is the
+    fix for doc-level fields (e.g. language) returning no heatmap results."""
+    mock_db = Mock()
+    mock_db._search_conditions.return_value = []
+
+    # core_filters["doc_id"] is what _convert_language_to_doc_ids sets.
+    result = _build_docsearch_filters("", {"doc_id": "1,3,9"}, ["1", "2", "3"], mock_db)
+
+    assert _extract_has_id(result) == [
+        "1",
+        "3",
+    ]  # sorted intersection of {1,3,9} ∩ {1,2,3}
+
+
+def test_build_docsearch_filters_doc_id_not_applied_as_payload_field():
+    """The doc_id constraint must NOT become a payload FieldCondition (the
+    Qdrant document payload has no doc_id field — it's the point id)."""
+    mock_db = Mock()
+    mock_db._search_conditions.return_value = []
+
+    with patch(
+        "ui.backend.routes.search.map_core_field_to_storage", return_value="map_doc_id"
+    ) as mock_map:
+        _build_docsearch_filters("", {"doc_id": "1,2"}, ["1", "2"], mock_db)
+
+    # doc_id was popped and handled as a HasIdCondition, so it was never mapped
+    # to a payload storage field.
+    assert all(call.args[0] != "doc_id" for call in mock_map.call_args_list)
+
+
+def test_build_docsearch_filters_keeps_payload_fields_alongside_doc_id():
+    """Year/document_type stay payload conditions while doc_id intersects ids."""
+    mock_db = Mock()
+    mock_db._search_conditions.return_value = []
+
+    result = _build_docsearch_filters(
+        "", {"doc_id": "1,2", "published_year": "2020"}, ["1", "2", "3"], mock_db
+    )
+
+    assert _extract_has_id(result) == ["1", "2"]
+    # A payload condition for published_year is present.
+    has_year = any(
+        getattr(c, "key", None) == "map_published_year"
+        or (
+            hasattr(c, "must")
+            and c.must
+            and getattr(c.must[0], "key", None) == "map_published_year"
+        )
+        for c in result.must
+    )
+    assert has_year
+
+
+def test_resolve_pg_filter_fields_language_to_sys_language_doc_ids():
+    """language is resolved via the sys_language PostgreSQL column and applied
+    as a doc_id constraint (not left as a Qdrant payload filter)."""
+    core_filters = {"language": "en", "published_year": "2023"}
+    with patch(
+        "ui.backend.routes.search.doc_ids_from_pg_field", return_value=["1", "3"]
+    ) as mock_field:
+        _resolve_pg_filter_fields(core_filters, Mock(), "uneg")
+
+    # language popped → doc_id constraint set; year (Qdrant) left untouched.
+    assert "language" not in core_filters
+    assert set(core_filters["doc_id"].split(",")) == {"1", "3"}
+    assert core_filters["published_year"] == "2023"
+    assert mock_field.call_args.args[1] == "sys_language"
+
+
+def test_resolve_pg_filter_fields_src_field_to_jsonb_doc_ids():
+    """src_* fields are resolved via the src_doc_raw_metadata JSONB column."""
+    core_filters = {"src_evaluation_category": "DE", "document_type": "Activity"}
+    with patch(
+        "ui.backend.routes.search.get_src_field_mapping",
+        return_value={"src_evaluation_category": "Evaluation category"},
+    ):
+        with patch(
+            "ui.backend.routes.search.doc_ids_from_pg_jsonb", return_value=["5", "6"]
+        ) as mock_jsonb:
+            _resolve_pg_filter_fields(core_filters, Mock(), "wfp")
+
+    assert "src_evaluation_category" not in core_filters
+    assert set(core_filters["doc_id"].split(",")) == {"5", "6"}
+    assert core_filters["document_type"] == "Activity"  # Qdrant field untouched
+    # Resolved against the configured raw JSONB key.
+    assert mock_jsonb.call_args.args[1] == "Evaluation category"
+
+
+@pytest.mark.asyncio
+async def test_docsearch_language_filter_resolves_to_doc_ids(mock_pg):
+    """A language filter is resolved to doc_ids (PostgreSQL) and intersected
+    with the indexed set — regression test for 'language vs year' heatmaps
+    returning zero documents."""
+    fake_db = FakeDB(
+        scroll_results=[
+            create_fake_document("1", "English Doc", "WFP", "2023"),
+            create_fake_document("3", "Another English Doc", "WFP", "2023"),
+        ]
+    )
+    mock_pg.fetch_indexed_doc_ids.return_value = ["1", "2", "3"]
+
+    mock_request = Mock(spec=Request)
+    mock_request.query_params = {"language": "English"}
+
+    with patch("ui.backend.routes.search.get_db_for_source", return_value=fake_db):
+        with patch("ui.backend.routes.search.get_pg_for_source", return_value=mock_pg):
+            with patch("ui.backend.routes.search.run_in_threadpool") as mock_threadpool:
+                mock_threadpool.side_effect = lambda func, **kwargs: func(**kwargs)
+                # English resolves (via sys_language) to documents 1 and 3.
+                with patch(
+                    "ui.backend.routes.search.doc_ids_from_pg_field",
+                    return_value=["1", "3"],
+                ):
+                    result = await docsearch(
+                        request=mock_request,
+                        q="",
+                        limit=10,
+                        organization=None,
+                        title=None,
+                        published_year=None,
+                        document_type=None,
+                        country=None,
+                        language="English",
+                        data_source="uneg",
+                    )
+
+    # The language filter was applied as a doc-id intersection on the scroll.
+    scroll_filter = fake_db._scroll_calls[0]["filter"]
+    assert _extract_has_id(scroll_filter) == ["1", "3"]
+    assert result.total == 2
 
 
 def test_format_document_result_returns_none_for_empty_payload():

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -100,9 +100,7 @@ def _convert_region_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:
     _intersect_doc_id_filter(core_filters, doc_ids)
 
 
-def _resolve_pg_filter_fields(
-    core_filters: Dict[str, Any], pg, source: Optional[str]
-) -> None:
+def _resolve_pg_filter_fields(core_filters: Dict[str, Any], pg, source: str) -> None:
     """Resolve filter fields whose data lives in PostgreSQL — not the Qdrant
     document payload — to a ``doc_id`` constraint.
 

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -29,7 +29,11 @@ from ui.backend.utils.document_utils import (
     map_core_field_to_storage,
     normalize_document_payload,
 )
-from ui.backend.utils.facet_helpers import build_facets_from_db
+from ui.backend.utils.facet_helpers import (
+    build_facets_from_db,
+    doc_ids_from_pg_field,
+    doc_ids_from_pg_jsonb,
+)
 from ui.backend.utils.filter_helpers import (
     add_dynamic_filters,
     build_core_filters_from_params,
@@ -94,6 +98,43 @@ def _convert_region_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:
         return
     doc_ids = pg.fetch_doc_ids_by_region(region)
     _intersect_doc_id_filter(core_filters, doc_ids)
+
+
+def _resolve_pg_filter_fields(
+    core_filters: Dict[str, Any], pg, source: Optional[str]
+) -> None:
+    """Resolve filter fields whose data lives in PostgreSQL — not the Qdrant
+    document payload — to a ``doc_id`` constraint.
+
+    Document search (used by Heatmapper's attribute mode) filters the Qdrant
+    document collection, but several filterable fields are faceted from
+    PostgreSQL: ``language`` (the ``sys_language`` column) and ``src_*`` fields
+    (the ``src_doc_raw_metadata`` JSONB). Filtering those against the Qdrant
+    payload returns wrong/zero counts, so resolve each to its matching doc_ids
+    here — the same source the facet counts come from — and AND them together.
+    Qdrant-resident fields (document_type, published_year, organization,
+    country, region, …) are left in ``core_filters`` as payload filters.
+    """
+    language = core_filters.pop("language", None)
+    if language:
+        _intersect_doc_id_filter(
+            core_filters,
+            doc_ids_from_pg_field(pg, "sys_language", str(language).split(",")),
+        )
+
+    src_field_mapping = get_src_field_mapping(source) or {}
+    for core_field in list(core_filters.keys()):
+        if not core_field.startswith("src_"):
+            continue
+        raw_key = src_field_mapping.get(core_field)
+        if not raw_key:
+            continue
+        values = [
+            v.strip() for v in str(core_filters.pop(core_field)).split(",") if v.strip()
+        ]
+        _intersect_doc_id_filter(
+            core_filters, doc_ids_from_pg_jsonb(pg, raw_key, values)
+        )
 
 
 def _build_core_filters(
@@ -831,13 +872,29 @@ def _build_metadata_filter_condition(
 def _build_docsearch_filters(
     q: str, core_filters: Dict[str, Any], indexed_doc_ids: List[str], db
 ) -> Optional[qmodels.Filter]:
-    """Build combined Qdrant filter conditions for document search."""
+    """Build combined Qdrant filter conditions for document search.
+
+    Doc-level fields that live only in PostgreSQL (language, region) are
+    resolved upstream to a ``doc_id`` constraint in ``core_filters``. They are
+    NOT on the Qdrant document payload, so they are applied here as an
+    intersection on the document id set (a ``HasIdCondition``) rather than as a
+    payload filter — otherwise filtering by them would match nothing.
+    """
     filter_conditions: List[qmodels.Condition] = []
 
     if q.strip():
         search_conditions = db._search_conditions(q.strip())
         if search_conditions:
             filter_conditions.append(qmodels.Filter(should=search_conditions))
+
+    # Intersect the indexed document set with any resolved doc_id constraint
+    # (from language/region). Pop it so it is not also applied as a payload
+    # filter below.
+    allowed_ids = set(indexed_doc_ids)
+    doc_id_constraint = core_filters.pop("doc_id", None)
+    if doc_id_constraint is not None:
+        requested = {i for i in str(doc_id_constraint).split(",") if i}
+        allowed_ids &= requested
 
     for core_field, value in core_filters.items():
         if not value:
@@ -851,7 +908,7 @@ def _build_docsearch_filters(
 
     filter_conditions.append(
         qmodels.Filter(  # type: ignore[arg-type]
-            should=[qmodels.HasIdCondition(has_id=list(indexed_doc_ids))]
+            should=[qmodels.HasIdCondition(has_id=sorted(allowed_ids))]
         )
     )
 
@@ -933,6 +990,11 @@ async def docsearch(
             organization, title, published_year, document_type, country, language
         )
         add_dynamic_filters(core_filters, request.query_params, source)
+        # Fields faceted from PostgreSQL (language, src_* JSONB) aren't on the
+        # Qdrant document payload — resolve them to a doc_id constraint so
+        # Heatmapper counts match the facets. Without this a "language" or
+        # "evaluation category" axis returns zero/under-counted results.
+        _resolve_pg_filter_fields(core_filters, pg, source)
 
         combined_filter = _build_docsearch_filters(q, core_filters, indexed_doc_ids, db)
         if combined_filter is None:

--- a/ui/backend/utils/facet_helpers.py
+++ b/ui/backend/utils/facet_helpers.py
@@ -133,6 +133,60 @@ def build_facets_from_pg(pg, storage_field: str) -> Dict[str, int]:
             return {str(row[0]): int(row[1]) for row in cur.fetchall()}
 
 
+# A storage column name must be a plain SQL identifier before it can be
+# interpolated (values are always parameterised). Storage fields come from the
+# config-derived field mapping, never raw user input.
+_SAFE_PG_FIELD_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def doc_ids_from_pg_field(
+    pg, storage_field: str, values: List[str], limit: int = 50000
+) -> List[str]:
+    """doc_ids whose ``sys_*`` column matches any of the given values.
+
+    Counterpart to :func:`build_facets_from_pg` — used so document search
+    resolves PostgreSQL-sourced fields (e.g. ``sys_language``) the same way
+    their facet counts are computed, instead of filtering the Qdrant document
+    payload (which does not carry these fields).
+    """
+    vals = [v for v in values if v]
+    if not vals or not _SAFE_PG_FIELD_RE.match(storage_field):
+        return []
+    query = f"""
+        SELECT doc_id
+        FROM {pg.docs_table}
+        WHERE {storage_field} = ANY(%s)
+        LIMIT %s
+    """
+    with pg._get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (vals, limit))
+            return [str(row[0]) for row in cur.fetchall()]
+
+
+def doc_ids_from_pg_jsonb(
+    pg, raw_key: str, values: List[str], limit: int = 50000
+) -> List[str]:
+    """doc_ids whose ``src_doc_raw_metadata->>raw_key`` matches any given value.
+
+    Counterpart to :func:`build_facets_from_pg_jsonb`. ``raw_key`` comes from
+    the trusted ``src_field_mapping`` config and is passed as a parameter.
+    """
+    vals = [v for v in values if v]
+    if not vals:
+        return []
+    query = f"""
+        SELECT doc_id
+        FROM {pg.docs_table}
+        WHERE src_doc_raw_metadata->>%s = ANY(%s)
+        LIMIT %s
+    """
+    with pg._get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, (raw_key, vals, limit))
+            return [str(row[0]) for row in cur.fetchall()]
+
+
 def count_src_jsonb_field_for_doc_ids(pg, raw_key: str, doc_ids: List[str]) -> Counter:
     """Count distinct values of ``src_doc_raw_metadata->>raw_key`` across a
     specific set of docs.


### PR DESCRIPTION
## Problem

In Heatmapper's **attribute mode** (no search query), a *language × year* grid returned **no results**, and *evaluation category × year* returned **very few**, while *document type × year* worked.

## Root cause (measured)

Attribute cells are counted via `/docsearch`, which filtered the **Qdrant document payload** for every field. But a field's facet values come from different sources:

- `sys_*` (e.g. `language` → `sys_language`) → **PostgreSQL column**
- `src_*` (e.g. `src_evaluation_category`) → **PostgreSQL `src_doc_raw_metadata` JSONB**
- everything else (document_type, published_year, …) → **Qdrant document payload**

The Postgres-sourced fields aren't on the Qdrant document payload, so filtering them there matched **zero** (language) or heavily **under-counted** (evaluation category). Qdrant-resident fields worked, which is why document type was fine.

Live measurement on `wfp` confirmed facet vs docsearch divergence (e.g. language facet 271 → docsearch 0; eval-category DE facet 167 → docsearch 10).

## Fix (generic, not language-specific)

Resolve any Postgres-sourced filter field to a `doc_id` constraint from the **same source the facet counts come from**, intersect it with the indexed document set, and apply it as a `HasIdCondition` rather than a (missing) payload filter:

- `_build_docsearch_filters`: a resolved `doc_id` constraint now intersects the indexed id set instead of becoming a payload condition.
- `_resolve_pg_filter_fields` (called by `/docsearch`): `language` → `sys_language` column; `src_*` → `src_doc_raw_metadata` JSONB via the configured raw key. Qdrant-resident fields are left as payload filters.
- `facet_helpers`: `doc_ids_from_pg_field` / `doc_ids_from_pg_jsonb` mirror the existing facet builders (values parameterised; column name validated against a safe-identifier pattern).

## Verification (measured, live api on wfp)

| Field | Value | Before | After | Facet |
|---|---|---|---|---|
| language | English | 0 | **269** | 271 |
| evaluation category | DE | 10 | **167** | 167 |
| evaluation category | IE | 1 | **21** | 21 |
| document_type | Activity | 120 | **120** | 120 |
| published_year | 2020 | 32 | **32** | — |

(±1–2 vs facet because docsearch counts only *indexed* documents.) No regression on Qdrant-resident fields.

## Tests

6 new unit tests in `tests/unit/test_docsearch.py` (27 total passing): doc_id intersection in `_build_docsearch_filters`, doc_id never applied as a payload field, and `_resolve_pg_filter_fields` resolving language (sys_language) and src_* (JSONB) to doc_ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)