### PR TITLE
feat(activity): log Brief as a new activity type, upserted on each save

### DIFF
--- a/tests/unit/test_activity_routes.py
+++ b/tests/unit/test_activity_routes.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -16,9 +17,11 @@ from ui.backend.routes.activity import (
     _build_activity_items,
     _build_export_row,
     _count_search_results,
+    _find_existing_activity,
     _merge_filters_update,
     _ms_to_seconds,
     _resolve_cost,
+    log_activity,
 )
 
 # ---------------------------------------------------------------------------
@@ -575,3 +578,92 @@ class TestMergeFiltersUpdate:
         body = SimpleNamespace(summary_duration_ms=None, drilldown_tree=None)
         _merge_filters_update(activity, body)
         assert activity.filters is original
+
+
+def _brief_body(search_id, **overrides):
+    """A POST /activity body for a Brief save (type='brief')."""
+    defaults = {
+        "search_id": str(search_id),
+        "query": "Brief Title",
+        "filters": {"type": "brief"},
+        "search_results": [{"doc_id": "d1"}],
+        "ai_summary": "## Heading\n\nBody",
+        "url": "http://app/brief",
+        "session_id": "sess-1",
+        "llm_model": None,
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "cost_usd": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _fake_session():
+    return SimpleNamespace(add=Mock(), commit=AsyncMock(), refresh=AsyncMock())
+
+
+@pytest.mark.unit
+class TestLogActivityUpsert:
+    """POST /activity/ upserts by (owner, search_id) — the Brief tab relies on
+    this to keep one activity row per brief, refreshed on each save."""
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_row_in_place(self):
+        sid = uuid.uuid4()
+        existing = _make_activity(search_id=sid, query="old", filters=None)
+        body = _brief_body(sid)
+        session = _fake_session()
+        with patch(
+            "ui.backend.routes.activity._find_existing_activity",
+            new=AsyncMock(return_value=existing),
+        ):
+            await log_activity(body, user=None, session=session)
+        # Row mutated in place, no new row inserted.
+        assert existing.query == "Brief Title"
+        assert existing.filters == {"type": "brief"}
+        assert existing.ai_summary == "## Heading\n\nBody"
+        session.add.assert_not_called()
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_inserts_when_no_existing_row(self):
+        body = _brief_body(uuid.uuid4())
+        session = _fake_session()
+        with patch(
+            "ui.backend.routes.activity._find_existing_activity",
+            new=AsyncMock(return_value=None),
+        ), patch("ui.backend.routes.activity._activity_to_read", return_value="ok"):
+            result = await log_activity(body, user=None, session=session)
+        session.add.assert_called_once()
+        session.commit.assert_awaited_once()
+        assert result == "ok"
+
+    @pytest.mark.asyncio
+    async def test_does_not_blank_summary_when_omitted(self):
+        sid = uuid.uuid4()
+        existing = _make_activity(search_id=sid, ai_summary="keep me")
+        body = _brief_body(sid, ai_summary=None)
+        session = _fake_session()
+        with patch(
+            "ui.backend.routes.activity._find_existing_activity",
+            new=AsyncMock(return_value=existing),
+        ):
+            await log_activity(body, user=None, session=session)
+        assert existing.ai_summary == "keep me"
+
+    @pytest.mark.asyncio
+    async def test_find_existing_returns_none_without_owner(self):
+        session = SimpleNamespace(execute=AsyncMock())
+        result = await _find_existing_activity(
+            session, user=None, session_id=None, search_uuid=uuid.uuid4()
+        )
+        assert result is None
+        session.execute.assert_not_called()
+
+
+@pytest.mark.unit
+def test_brief_is_a_valid_activity_type():
+    from ui.backend.routes.llm_usage import _VALID_ACTIVITY_TYPES
+
+    assert "brief" in _VALID_ACTIVITY_TYPES

--- a/ui/backend/routes/activity.py
+++ b/ui/backend/routes/activity.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Optional, Sequence
+from typing import Any, Optional, Sequence
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
@@ -78,6 +78,30 @@ def _resolve_cost(
     if server is not None:
         return server
     return submitted
+
+
+async def _find_existing_activity(
+    session: AsyncSession,
+    user: User | None,
+    session_id: Optional[str],
+    search_uuid: uuid.UUID,
+) -> Optional[UserActivity]:
+    """Find an activity row by its owner (user or anonymous session) and
+    search_id, or None. Owner-scoped so users can't read/overwrite each other."""
+    if user:
+        stmt = select(UserActivity).where(
+            UserActivity.user_id == user.id,
+            UserActivity.search_id == search_uuid,
+        )
+    elif session_id:
+        stmt = select(UserActivity).where(
+            UserActivity.session_id == session_id,
+            UserActivity.search_id == search_uuid,
+        )
+    else:
+        return None
+    result = await session.execute(stmt)
+    return result.scalars().first()
 
 
 # JSONB sort keys that need nullslast() handling
@@ -200,26 +224,52 @@ async def log_activity(
     except ValueError:
         raise HTTPException(status_code=422, detail="search_id must be a valid UUID")
 
-    activity = UserActivity(
-        user_id=user.id if user else None,
-        session_id=body.session_id if not user else None,
-        search_id=search_uuid,
-        query=body.query,
-        filters=body.filters,
-        search_results=body.search_results,
-        ai_summary=body.ai_summary,
-        url=body.url,
-        llm_model=body.llm_model,
-        prompt_tokens=body.prompt_tokens,
-        completion_tokens=body.completion_tokens,
-        cost_usd=_resolve_cost(
-            body.cost_usd,
-            body.llm_model,
-            body.prompt_tokens,
-            body.completion_tokens,
-        ),
+    cost = _resolve_cost(
+        body.cost_usd,
+        body.llm_model,
+        body.prompt_tokens,
+        body.completion_tokens,
     )
-    session.add(activity)
+
+    # Upsert by (owner, search_id): update an existing row in place, otherwise
+    # insert. Searches use a fresh search_id each time, so they always insert;
+    # the Brief tab reuses one stable search_id per brief, so re-logging it on
+    # each save updates the same activity row rather than creating duplicates.
+    existing = await _find_existing_activity(
+        session, user, body.session_id, search_uuid
+    )
+    if existing is not None:
+        # search_results is JSONB holding a list; the typed-but-loose
+        # constructor accepts it on insert, so mutate through an Any alias to
+        # keep the same loose typing on the update path.
+        row: Any = existing
+        row.query = body.query
+        row.filters = body.filters
+        row.search_results = body.search_results
+        if body.ai_summary is not None:
+            row.ai_summary = body.ai_summary
+        row.url = body.url
+        row.llm_model = body.llm_model
+        row.prompt_tokens = body.prompt_tokens
+        row.completion_tokens = body.completion_tokens
+        row.cost_usd = cost
+        activity = existing
+    else:
+        activity = UserActivity(
+            user_id=user.id if user else None,
+            session_id=body.session_id if not user else None,
+            search_id=search_uuid,
+            query=body.query,
+            filters=body.filters,
+            search_results=body.search_results,
+            ai_summary=body.ai_summary,
+            url=body.url,
+            llm_model=body.llm_model,
+            prompt_tokens=body.prompt_tokens,
+            completion_tokens=body.completion_tokens,
+            cost_usd=cost,
+        )
+        session.add(activity)
     await session.commit()
     await session.refresh(activity)
     return _activity_to_read(activity, user)

--- a/ui/backend/routes/llm_usage.py
+++ b/ui/backend/routes/llm_usage.py
@@ -58,6 +58,7 @@ _VALID_ACTIVITY_TYPES = {
     "chat",
     "assistant-basic",
     "assistant-deep-research",
+    "brief",
 }
 
 _DEFAULT_RANGE_DAYS = 30

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -46,6 +46,9 @@ export interface SavedBrief {
   outlineLog?: BriefActivityEvent[];
   // Whether heading numbers ("1.", "2.1") are shown (default off).
   numberHeadings?: boolean;
+  // Stable UUID used as the Activity-log search_id, so each save updates the
+  // same activity row instead of creating duplicates.
+  activityId?: string;
 }
 
 export const BRIEF_HISTORY_KEY = 'evidencelab_brief_history_v1';

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { SourceReference, SummaryModelConfig } from '../../types/api';
 import { SearchSettings } from '../../types/auth';
+import { useActivityLogging } from '../../hooks/useActivityLogging';
 import { extractCitedNumbers } from '../citations/CitedContent';
 import {
   BriefActivityEvent,
@@ -19,6 +20,10 @@ import {
 
 let _uid = 0;
 const uid = (): string => `b${++_uid}_${Date.now()}`;
+
+// A real UUID for the Activity-log search_id (one stable id per brief).
+const newActivityId = (): string =>
+  typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : uid();
 
 // Capitalise the first letter of each word, leaving the rest as-is so existing
 // capitalisation / acronyms (e.g. WFP) survive. Used on generated brief titles.
@@ -163,6 +168,7 @@ export const useBrief = ({
   userKey,
 }: UseBriefOptions) => {
   const historyKey = userKey ? `${BRIEF_HISTORY_KEY}_u_${userKey}` : BRIEF_HISTORY_KEY;
+  const { logBrief } = useActivityLogging();
   const [stage, setStage] = useState<BriefStage>('seed');
   const [briefTitle, setBriefTitle] = useState('Evidence Brief');
   const [sections, setSections] = useState<BriefSection[]>([]);
@@ -183,6 +189,8 @@ export const useBrief = ({
   const [generatingActivity, setGeneratingActivity] = useState<BriefActivityEvent[]>([]);
 
   const briefIdRef = useRef<string | null>(null);
+  // Stable Activity-log id for the current brief (one row per brief).
+  const briefActivityIdRef = useRef<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const sectionsRef = useRef<BriefSection[]>(sections);
   sectionsRef.current = sections;
@@ -264,9 +272,29 @@ export const useBrief = ({
       }),
       outlineLog: outlineLogRef.current,
       numberHeadings: numberHeadingsRef.current,
+      activityId: briefActivityIdRef.current ?? undefined,
     };
     persist([entry, ...historyRef.current.filter((e) => e.id !== id)].slice(0, 10));
-  }, [persist]);
+
+    // Mirror the brief into the Activity log as a "brief" row, upserted on each
+    // save so there's one activity per brief reflecting its latest state.
+    const activityId = briefActivityIdRef.current;
+    if (activityId) {
+      const markdown = snap
+        .map((s) => `## ${s.title}${s.content ? `\n\n${s.content}` : ''}`)
+        .join('\n\n');
+      const seen = new Set<string>();
+      const sources = snap
+        .flatMap((s) => s.sources)
+        .filter((src) => {
+          const key = src.chunkId || src.docId;
+          if (!key || seen.has(key)) return false;
+          seen.add(key);
+          return true;
+        });
+      logBrief(activityId, briefTitleRef.current, markdown, sources);
+    }
+  }, [persist, logBrief]);
 
   // Auto-save once a brief exists (outline generated or manual start) so it
   // appears in Saved Briefs right away and keeps tracking title/content edits.
@@ -332,6 +360,7 @@ export const useBrief = ({
         signal: controller.signal,
       });
       briefIdRef.current = uid();
+      briefActivityIdRef.current = newActivityId();
       setBriefTitle(toTitleCase(topic));
       setSections(
         outline.headings
@@ -350,6 +379,7 @@ export const useBrief = ({
 
   const startManual = useCallback(() => {
     briefIdRef.current = uid();
+    briefActivityIdRef.current = newActivityId();
     setBriefTitle('Evidence Brief');
     setSections(
       // Placeholder samples: research stays disabled until the user edits them.
@@ -532,6 +562,7 @@ export const useBrief = ({
   const loadBrief = useCallback((entry: SavedBrief) => {
     abortRef.current?.abort();
     briefIdRef.current = entry.id;
+    briefActivityIdRef.current = entry.activityId || newActivityId();
     setBriefTitle(entry.title);
     setQuery(entry.query);
     setSections(
@@ -557,6 +588,7 @@ export const useBrief = ({
         id: uid(),
         title: `${entry.title} (copy)`,
         date: Date.now(),
+        activityId: newActivityId(), // a clone is its own brief → its own activity row
       };
       persist([copy, ...historyRef.current].slice(0, 10));
       loadBrief(copy);
@@ -567,6 +599,7 @@ export const useBrief = ({
   const reset = useCallback(() => {
     abortRef.current?.abort();
     briefIdRef.current = null;
+    briefActivityIdRef.current = null;
     setStage('seed');
     setSections([]);
     setRegenFor(null);

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -281,7 +281,10 @@ export const useBrief = ({
     const activityId = briefActivityIdRef.current;
     if (activityId) {
       const markdown = snap
-        .map((s) => `## ${s.title}${s.content ? `\n\n${s.content}` : ''}`)
+        .map((s) => {
+          const body = s.content ? `\n\n${s.content}` : '';
+          return `## ${s.title}${body}`;
+        })
         .join('\n\n');
       const seen = new Set<string>();
       const sources = snap

--- a/ui/frontend/src/hooks/useActivityLogging.ts
+++ b/ui/frontend/src/hooks/useActivityLogging.ts
@@ -135,7 +135,55 @@ export function useActivityLogging() {
     [],
   );
 
-  return { logSearch, updateSummary };
+  /**
+   * Upsert a Brief activity record (type "brief"). Unlike logSearch this does
+   * NOT dedupe — it is called on each brief save with a stable activityId so
+   * the backend (which upserts by search_id) keeps a single activity row per
+   * brief, refreshed with the latest title, prose and cited sources.
+   */
+  const logBrief = useCallback(
+    (
+      activityId: string,
+      title: string,
+      summaryMarkdown: string,
+      sources: Array<{
+        chunkId?: string;
+        docId?: string;
+        title?: string;
+        score?: number;
+        page?: number;
+        text?: string;
+      }>,
+    ) => {
+      if (!activityId) return;
+      const richResults = (sources || []).slice(0, 50).map((s) => ({
+        chunk_id: s.chunkId || '',
+        doc_id: s.docId || '',
+        title: s.title || '',
+        score: s.score || 0,
+        page_num: s.page || null,
+        chunk_text: s.text || '',
+        link: '',
+      }));
+
+      axios
+        .post(`${API_BASE_URL}/activity/`, {
+          search_id: activityId,
+          query: title,
+          filters: { type: 'brief' },
+          search_results: richResults,
+          url: window.location.href,
+          session_id: getSessionId(),
+          ...(summaryMarkdown ? { ai_summary: summaryMarkdown } : {}),
+        })
+        .catch((err) => {
+          console.debug('Brief activity logging failed (non-critical):', err?.message);
+        });
+    },
+    [],
+  );
+
+  return { logSearch, updateSummary, logBrief };
 }
 
 export default useActivityLogging;

--- a/ui/frontend/src/tests/greetingMessage.test.tsx
+++ b/ui/frontend/src/tests/greetingMessage.test.tsx
@@ -172,8 +172,10 @@ describe('GroupSettingsManager greetingMessage', () => {
       expect(screen.getByText('Override greeting message')).toBeInTheDocument();
     });
 
-    // The greeting message input should show the saved value
-    const input = screen.getByDisplayValue('Welcome to the portal');
+    // The greeting message input appears only after the default group is
+    // auto-selected and its settings load (several async state updates after
+    // the checkbox renders), so wait for it rather than querying synchronously.
+    const input = await screen.findByDisplayValue('Welcome to the portal');
     expect(input).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Problem
Briefs were not recorded in the **Activity** log. Searches, the assistant and Heatmapper all show up there, but the Brief tab logged nothing.

## What this does
Adds a new **\`brief\`** activity type and logs each brief, **refreshing a single activity row on every save** rather than creating a new row each time.

### Backend
- **\`POST /activity/\` now upserts** by \`(owner, search_id)\` (owner = authenticated user, or anonymous \`session_id\`):
  - Searches generate a fresh \`search_id\` per search, so they still **insert** — no behaviour change.
  - The Brief tab reuses **one stable \`search_id\` per brief**, so re-logging on each save **updates the same row in place**.
  - New \`_find_existing_activity()\` helper; owner-scoped so users can't read/overwrite each other's rows.
- Added \`"brief"\` to \`_VALID_ACTIVITY_TYPES\` (\`llm_usage.py\`) so it's a first-class type in the activity/usage filters.

### Frontend
- \`useActivityLogging\` gains **\`logBrief()\`** — posts the brief tagged \`filters.type = "brief"\`, capturing the **title** (query), the **compiled prose** (ai_summary) and the **cited sources** (search_results). Unlike \`logSearch\` it does not dedupe — it's meant to be re-sent on each save so the upsert keeps the row current.
- \`useBrief\` generates a **stable per-brief UUID** (\`activityId\`) at creation/load/clone (persisted in the saved brief), clears it on reset, and calls \`logBrief\` from \`saveCurrent\` (the existing 500 ms-debounced auto-save). Result: **one activity row per brief, reflecting its latest state.**
- \`SavedBrief\` gains an optional \`activityId\` so the id survives reloads (and a brief saved before this change gets a fresh id on next load).

## New documents
The brief mirrors into the activity log from the same client data the brief already holds, so **newly created briefs are logged automatically** — no migration or backfill needed. Briefs that pre-date this change get an \`activityId\` the next time they're opened.

## Tests
\`tests/unit/test_activity_routes.py\` — added \`TestLogActivityUpsert\`:
- inserts when no existing row; updates existing row in place; does not blank the summary when omitted; owner-less lookup returns \`None\`; \`"brief"\` is a valid activity type.
- **50/50 unit tests pass**; black / flake8 / mypy clean.

## Verification note
End-to-end Activity logging only mounts when \`USER_MODULE\` is on; behaviour is covered by the unit tests above and is ready to exercise in a \`USER_MODULE\`-on environment.