### PR TITLE
fix(heatmapper): query-mode src_* filters — code safety-net + chunk backfill

### DIFF
--- a/scripts/fixes/backfill_chunk_doc_fields.py
+++ b/scripts/fixes/backfill_chunk_doc_fields.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Backfill doc-level attributes onto chunk payloads so Heatmapper *query mode*
+filters them correctly.
+
+Heatmapper has two modes:
+
+  * Attribute mode (no search string) counts documents — it resolves filters
+    against the PostgreSQL docs table / Qdrant document collection.
+  * Query mode (with a search string) searches *chunks* and filters on the chunk
+    payload.
+
+A few attributes are doc-level and were only *sparsely* denormalised onto chunks
+(verified: ~25/300 chunks carried ``src_evaluation_category`` /
+``src_quality_rating``, ~2/300 carried ``map_region``). So a query-mode map of,
+say, "evaluation category x year" with a search string dropped most documents —
+every chunk whose payload lacked the value was filtered out.
+
+This script reads each document's authoritative value from PostgreSQL
+(``docs_<source>``) and stamps it onto *all* of that document's chunks in Qdrant
+(``chunks_<source>``), so the chunk filter matches the same documents the facet
+counts do.
+
+  Source of truth (PostgreSQL ``docs_<source>``):
+    - ``map_*``  fields  -> the mapped column (e.g. ``map_region``)
+    - ``src_*``  fields  -> ``src_doc_raw_metadata->>'<raw key>'`` (raw key from
+                            the data source's ``src_field_mapping``)
+  Target (Qdrant ``chunks_<source>``):
+    - the same field name as a per-chunk payload key
+
+Safety rails (mirrors scripts/fixes/fix_wfp_metadata_deltas.py):
+  * Dry-run by default — nothing is written without ``--apply``.
+  * Never nulls a value: documents with no value for a field are skipped, so a
+    chunk is only ever *given* a value, never cleared.
+  * Idempotent — only chunks whose payload does not already equal the target are
+    written (a ``must_not`` match on the value), so re-runs are no-ops.
+  * Writes are batched by value: all documents sharing a value are updated in one
+    ``set_payload`` call (e.g. 3 calls for DE/CE/IE), keeping Qdrant load low.
+
+Usage:
+    # Dry-run (default): report what would change, write nothing
+    python scripts/fixes/backfill_chunk_doc_fields.py --data-source wfp
+
+    # Apply for real
+    python scripts/fixes/backfill_chunk_doc_fields.py --data-source wfp --apply
+
+    # Limit to specific fields
+    python scripts/fixes/backfill_chunk_doc_fields.py --data-source wfp \
+        --fields src_evaluation_category map_region
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import time
+from collections import defaultdict, namedtuple
+from typing import Any, Dict, List, Optional, Tuple
+
+from dotenv import load_dotenv
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# Doc-level fields that are only sparsely present on chunks (measured) and so
+# break Heatmapper query mode until backfilled. ``src_*`` fields resolve their
+# value from the raw JSONB; ``map_*`` fields from the mapped column.
+DEFAULT_FIELDS = [
+    "src_evaluation_category",
+    "src_quality_rating",
+    "map_region",
+]
+
+_IDENT_RE = re.compile(r"[a-z_][a-z0-9_]*")
+
+# field        = chunk payload key (also the docs_<source> column for map_*)
+# kind         = "column" (read a docs column) | "jsonb" (read src_doc_raw_metadata)
+# source_key   = column name, or raw JSONB key for src_* fields
+FieldSpec = namedtuple("FieldSpec", "field kind source_key")
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested without a DB / Qdrant)
+# ---------------------------------------------------------------------------
+
+
+def resolve_source(config: Dict[str, Any], source: str) -> Tuple[str, Dict[str, Any]]:
+    """Resolve a data-source key or subdir against the config whitelist."""
+    for key, block in config.get("datasources", {}).items():
+        if key == source or block.get("data_subdir") == source:
+            return block.get("data_subdir", source), block
+    raise SystemExit(f"Unknown data_source: {source!r} (not in config.json)")
+
+
+def build_field_specs(block: Dict[str, Any], requested: List[str]) -> List[FieldSpec]:
+    """Resolve each requested field to where its authoritative value is read.
+
+    ``src_*`` fields need a configured ``src_field_mapping`` entry (the raw JSONB
+    key); a field without one is skipped with a warning rather than crashing.
+    """
+    src_map = block.get("src_field_mapping", {})
+    specs: List[FieldSpec] = []
+    for field in requested:
+        if not _IDENT_RE.fullmatch(field):
+            raise SystemExit(f"Illegal field name: {field!r}")
+        if field.startswith("src_"):
+            raw_key = src_map.get(field)
+            if not raw_key:
+                logger.warning("No src_field_mapping for %s; skipping it", field)
+                continue
+            specs.append(FieldSpec(field, "jsonb", raw_key))
+        else:
+            specs.append(FieldSpec(field, "column", field))
+    return specs
+
+
+def group_doc_ids_by_value(
+    rows: List[Dict[str, Any]], field: str
+) -> Dict[str, List[str]]:
+    """Map each non-empty value of ``field`` to the doc_ids that hold it.
+
+    Documents with no value are skipped (never written), and values are trimmed
+    so a stray-whitespace variant does not become its own group.
+    """
+    groups: Dict[str, List[str]] = defaultdict(list)
+    for row in rows:
+        value = row.get(field)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if not text:
+            continue
+        groups[text].append(row["doc_id"])
+    return dict(groups)
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+
+
+def _postgres_conn():
+    import psycopg2  # local import — keeps the import lazy
+
+    try:
+        from pipeline.db.postgres_client_base import build_postgres_dsn
+
+        dsn = build_postgres_dsn()
+    except ImportError:
+        dsn = (
+            f"host={os.environ.get('POSTGRES_HOST', 'localhost')} "
+            f"port={os.environ.get('POSTGRES_PORT', '5432')} "
+            f"user={os.environ.get('POSTGRES_USER', 'evidencelab')} "
+            f"password={os.environ.get('POSTGRES_PASSWORD', 'evidencelab')} "
+            f"dbname={os.environ.get('POSTGRES_DB', 'evidencelab')}"
+        )
+    return psycopg2.connect(dsn)
+
+
+def fetch_doc_values(conn, table: str, specs: List[FieldSpec]) -> List[Dict[str, Any]]:
+    """Fetch each doc's authoritative value for every spec'd field.
+
+    Column names are validated identifiers (interpolated); JSONB keys are passed
+    as bound parameters, so no user value is interpolated into the SQL string.
+    """
+    select_parts = ["doc_id"]
+    params: List[str] = []
+    for spec in specs:
+        if spec.kind == "column":
+            select_parts.append(spec.source_key)  # validated identifier
+        else:
+            select_parts.append("src_doc_raw_metadata->>%s")
+            params.append(spec.source_key)
+    query = f"SELECT {', '.join(select_parts)} FROM {table}"  # nosec B608
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        rows = cur.fetchall()
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        record: Dict[str, Any] = {"doc_id": str(row[0])}
+        for idx, spec in enumerate(specs):
+            record[spec.field] = row[1 + idx]
+        out.append(record)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Qdrant
+# ---------------------------------------------------------------------------
+
+
+def _qdrant_client():
+    from qdrant_client import QdrantClient
+
+    host = os.getenv("QDRANT_HOST", "http://localhost:6333")
+    host = host.replace("://qdrant:", "://localhost:")
+    # A filter-scoped set_payload can touch tens of thousands of chunks server
+    # side; the default 5s client timeout fires long before it finishes, so give
+    # it plenty of headroom (override with QDRANT_TIMEOUT if needed).
+    timeout = int(os.getenv("QDRANT_TIMEOUT", "600"))
+    return QdrantClient(url=host, api_key=os.getenv("QDRANT_API_KEY"), timeout=timeout)
+
+
+def _missing_filter(doc_ids: List[str], field: str, value: str):
+    """Chunks in ``doc_ids`` whose ``field`` does not already equal ``value``."""
+    from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
+
+    return Filter(
+        must=[FieldCondition(key="doc_id", match=MatchAny(any=doc_ids))],
+        must_not=[FieldCondition(key=field, match=MatchValue(value=value))],
+    )
+
+
+def _count_missing(client, collection: str, flt) -> int:
+    return client.count(collection_name=collection, count_filter=flt, exact=True).count
+
+
+def _set_payload_retry(client, collection: str, payload, flt) -> None:
+    """set_payload (scoped by filter) with bounded exponential-backoff retries."""
+    for attempt in range(5):
+        try:
+            client.set_payload(
+                collection_name=collection, payload=payload, points=flt, wait=True
+            )
+            return
+        except Exception as exc:  # noqa: BLE001 - retry any transient Qdrant error
+            wait = 2**attempt
+            logger.warning(
+                "Retry %d for %s: %s (sleep %ds)", attempt + 1, collection, exc, wait
+            )
+            time.sleep(wait)
+    raise RuntimeError(f"Failed to set payload on {collection} for {payload}")
+
+
+def backfill_field(
+    client,
+    collection: str,
+    spec: FieldSpec,
+    groups: Dict[str, List[str]],
+    apply: bool,
+) -> Tuple[int, int]:
+    """Stamp ``spec.field`` onto chunks for every value group.
+
+    Returns ``(chunks_backfilled, docs_touched)`` counted over chunks that did
+    not already carry the value (so re-runs report 0).
+    """
+    chunks_total = 0
+    docs_total = 0
+    for value, doc_ids in groups.items():
+        flt = _missing_filter(doc_ids, spec.field, value)
+        missing = _count_missing(client, collection, flt)
+        if missing == 0:
+            continue
+        chunks_total += missing
+        docs_total += len(doc_ids)
+        logger.info(
+            "  %s=%r: %d chunk(s) across %d doc(s)",
+            spec.field,
+            value,
+            missing,
+            len(doc_ids),
+        )
+        if apply:
+            _set_payload_retry(client, collection, {spec.field: value}, flt)
+    return chunks_total, docs_total
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Backfill doc-level attributes onto chunk payloads for "
+        "Heatmapper query mode."
+    )
+    parser.add_argument(
+        "--data-source", default="wfp", help="Data source (default: wfp)"
+    )
+    parser.add_argument(
+        "--fields",
+        nargs="+",
+        default=DEFAULT_FIELDS,
+        help="Chunk payload fields to backfill (default: the sparse doc-level "
+        "fields src_evaluation_category, src_quality_rating, map_region)",
+    )
+    parser.add_argument(
+        "--apply", action="store_true", help="Write changes (default: dry-run)"
+    )
+    return parser.parse_args(argv)
+
+
+def _load_config() -> Dict[str, Any]:
+    load_dotenv(os.path.join(os.path.dirname(__file__), "../../.env"))
+    config_path = os.path.join(os.path.dirname(__file__), "../../config.json")
+    with open(config_path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+    config = _load_config()
+    subdir, block = resolve_source(config, args.data_source)
+    specs = build_field_specs(block, args.fields)
+    if not specs:
+        raise SystemExit("No backfillable fields resolved; nothing to do.")
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    logger.info("=" * 64)
+    logger.info(" Chunk doc-field backfill  [%s]", mode)
+    logger.info(" data_source=%s  docs_%s -> chunks_%s", subdir, subdir, subdir)
+    logger.info(" fields=%s", [s.field for s in specs])
+    logger.info("=" * 64)
+
+    conn = _postgres_conn()
+    try:
+        rows = fetch_doc_values(conn, f"docs_{subdir}", specs)
+    finally:
+        conn.close()
+
+    client = _qdrant_client()
+    collection = f"chunks_{subdir}"
+    total_chunks = 0
+    for spec in specs:
+        groups = group_doc_ids_by_value(rows, spec.field)
+        docs_with_value = sum(len(v) for v in groups.values())
+        logger.info(
+            "%s: %d value(s), %d doc(s) with a value",
+            spec.field,
+            len(groups),
+            docs_with_value,
+        )
+        chunks, _docs = backfill_field(client, collection, spec, groups, args.apply)
+        total_chunks += chunks
+
+    label = "backfilled" if args.apply else "would backfill"
+    logger.info("-" * 64)
+    logger.info(" Summary  [%s]", mode)
+    logger.info("   chunks %s in %s: %d", label, collection, total_chunks)
+    if not args.apply:
+        logger.info(" Re-run with --apply to write these changes.")
+    logger.info("=" * 64)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_backfill_chunk_doc_fields.py
+++ b/tests/unit/test_backfill_chunk_doc_fields.py
@@ -1,0 +1,125 @@
+"""Unit tests for the chunk doc-field backfill helpers.
+
+Locks in the pure logic that decides where each field's value is read from
+(PG column vs src_doc_raw_metadata JSONB) and how documents are grouped by
+value for batched Qdrant writes — without a DB or Qdrant.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# The script lives under scripts/fixes/ (not a package); import it by path.
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "fixes"
+    / "backfill_chunk_doc_fields.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "backfill_chunk_doc_fields", _SCRIPT_PATH
+)
+bf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bf)
+
+
+BLOCK = {
+    "data_subdir": "wfp",
+    "src_field_mapping": {
+        "src_evaluation_category": "Evaluation category",
+        "src_quality_rating": "Quality rating",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# resolve_source
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSource:
+    def test_resolves_by_key(self):
+        config = {"datasources": {"wfp": {"data_subdir": "wfp"}}}
+        subdir, block = bf.resolve_source(config, "wfp")
+        assert subdir == "wfp"
+        assert block == {"data_subdir": "wfp"}
+
+    def test_resolves_by_subdir(self):
+        config = {"datasources": {"wfp_key": {"data_subdir": "wfp_sub"}}}
+        subdir, _block = bf.resolve_source(config, "wfp_sub")
+        assert subdir == "wfp_sub"
+
+    def test_unknown_source_raises(self):
+        with pytest.raises(SystemExit):
+            bf.resolve_source({"datasources": {}}, "nope")
+
+
+# ---------------------------------------------------------------------------
+# build_field_specs
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFieldSpecs:
+    def test_src_field_resolves_to_jsonb_raw_key(self):
+        specs = bf.build_field_specs(BLOCK, ["src_evaluation_category"])
+        assert specs == [
+            bf.FieldSpec("src_evaluation_category", "jsonb", "Evaluation category")
+        ]
+
+    def test_map_field_resolves_to_column(self):
+        specs = bf.build_field_specs(BLOCK, ["map_region"])
+        assert specs == [bf.FieldSpec("map_region", "column", "map_region")]
+
+    def test_src_field_without_mapping_is_skipped(self):
+        specs = bf.build_field_specs(BLOCK, ["src_unmapped"])
+        assert specs == []
+
+    def test_illegal_field_name_raises(self):
+        with pytest.raises(SystemExit):
+            bf.build_field_specs(BLOCK, ["map_region; DROP TABLE"])
+
+    def test_mixed_request_keeps_order_and_kinds(self):
+        specs = bf.build_field_specs(
+            BLOCK, ["src_evaluation_category", "map_region", "src_quality_rating"]
+        )
+        assert [s.field for s in specs] == [
+            "src_evaluation_category",
+            "map_region",
+            "src_quality_rating",
+        ]
+        assert [s.kind for s in specs] == ["jsonb", "column", "jsonb"]
+
+
+# ---------------------------------------------------------------------------
+# group_doc_ids_by_value
+# ---------------------------------------------------------------------------
+
+
+class TestGroupDocIdsByValue:
+    def test_groups_docs_by_value(self):
+        rows = [
+            {"doc_id": "a", "src_evaluation_category": "DE"},
+            {"doc_id": "b", "src_evaluation_category": "CE"},
+            {"doc_id": "c", "src_evaluation_category": "DE"},
+        ]
+        groups = bf.group_doc_ids_by_value(rows, "src_evaluation_category")
+        assert groups == {"DE": ["a", "c"], "CE": ["b"]}
+
+    def test_skips_none_and_empty_values(self):
+        rows = [
+            {"doc_id": "a", "map_region": None},
+            {"doc_id": "b", "map_region": ""},
+            {"doc_id": "c", "map_region": "   "},
+            {"doc_id": "d", "map_region": "East Africa"},
+        ]
+        groups = bf.group_doc_ids_by_value(rows, "map_region")
+        assert groups == {"East Africa": ["d"]}
+
+    def test_trims_whitespace_so_variants_merge(self):
+        rows = [
+            {"doc_id": "a", "src_quality_rating": "Satisfactory or above"},
+            {"doc_id": "b", "src_quality_rating": " Satisfactory or above "},
+        ]
+        groups = bf.group_doc_ids_by_value(rows, "src_quality_rating")
+        assert groups == {"Satisfactory or above": ["a", "b"]}

--- a/tests/unit/test_docsearch.py
+++ b/tests/unit/test_docsearch.py
@@ -12,6 +12,7 @@ from qdrant_client.http import models as qmodels
 from ui.backend.routes.search import (
     _build_docsearch_filters,
     _build_metadata_filter_condition,
+    _convert_src_fields_to_doc_ids,
     _format_document_result,
     _get_indexed_doc_ids,
     _resolve_pg_filter_fields,
@@ -539,6 +540,88 @@ def test_resolve_pg_filter_fields_src_field_to_jsonb_doc_ids():
     assert core_filters["document_type"] == "Activity"  # Qdrant field untouched
     # Resolved against the configured raw JSONB key.
     assert mock_jsonb.call_args.args[1] == "Evaluation category"
+
+
+# ---------------------------------------------------------------------------
+# _convert_src_fields_to_doc_ids — used by BOTH /docsearch (attribute mode) and
+# /search (query mode). src_* values are doc-level (only sparsely stamped onto
+# chunks), so query-mode chunk search must resolve them to doc_ids rather than
+# filter the chunk payload — regression for "evaluation category × year with a
+# search string returns very few documents".
+# ---------------------------------------------------------------------------
+
+
+def test_convert_src_fields_resolves_src_field_to_doc_id_constraint():
+    core_filters = {"src_evaluation_category": "CE", "published_year": "2023"}
+    with patch(
+        "ui.backend.routes.search.get_src_field_mapping",
+        return_value={"src_evaluation_category": "Evaluation category"},
+    ):
+        with patch(
+            "ui.backend.routes.search.doc_ids_from_pg_jsonb",
+            return_value=["a", "b"],
+        ) as mock_jsonb:
+            _convert_src_fields_to_doc_ids(core_filters, Mock(), "wfp")
+
+    assert "src_evaluation_category" not in core_filters
+    assert set(core_filters["doc_id"].split(",")) == {"a", "b"}
+    # published_year stays a Qdrant payload filter (it lives on chunks).
+    assert core_filters["published_year"] == "2023"
+    assert mock_jsonb.call_args.args[1] == "Evaluation category"
+
+
+def test_convert_src_fields_intersects_with_existing_doc_id():
+    """A src_* constraint ANDs with an existing doc_id set (e.g. from language),
+    rather than overwriting it."""
+    core_filters = {"src_evaluation_category": "CE", "doc_id": "a,b,c"}
+    with patch(
+        "ui.backend.routes.search.get_src_field_mapping",
+        return_value={"src_evaluation_category": "Evaluation category"},
+    ):
+        with patch(
+            "ui.backend.routes.search.doc_ids_from_pg_jsonb",
+            return_value=["b", "c", "d"],
+        ):
+            _convert_src_fields_to_doc_ids(core_filters, Mock(), "wfp")
+
+    assert set(core_filters["doc_id"].split(",")) == {"b", "c"}
+
+
+def test_convert_src_fields_empty_resolution_yields_no_match():
+    """When a src_* value matches no documents, the filter must collapse to the
+    no-match sentinel (return nothing) rather than be dropped (return all)."""
+    from ui.backend.routes.search import _NO_MATCH_DOC_ID
+
+    core_filters = {"src_evaluation_category": "ZZ"}
+    with patch(
+        "ui.backend.routes.search.get_src_field_mapping",
+        return_value={"src_evaluation_category": "Evaluation category"},
+    ):
+        with patch("ui.backend.routes.search.doc_ids_from_pg_jsonb", return_value=[]):
+            _convert_src_fields_to_doc_ids(core_filters, Mock(), "wfp")
+
+    assert core_filters["doc_id"] == _NO_MATCH_DOC_ID
+
+
+def test_convert_src_fields_leaves_non_src_and_unmapped_fields_untouched():
+    core_filters = {
+        "published_year": "2023",
+        "document_type": "Activity",
+        "src_unmapped": "X",
+    }
+    with patch(
+        "ui.backend.routes.search.get_src_field_mapping",
+        return_value={"src_evaluation_category": "Evaluation category"},
+    ):
+        with patch("ui.backend.routes.search.doc_ids_from_pg_jsonb") as mock_jsonb:
+            _convert_src_fields_to_doc_ids(core_filters, Mock(), "wfp")
+
+    # No configured mapping for src_unmapped → left as-is, no doc_id added.
+    mock_jsonb.assert_not_called()
+    assert core_filters["src_unmapped"] == "X"
+    assert core_filters["published_year"] == "2023"
+    assert core_filters["document_type"] == "Activity"
+    assert "doc_id" not in core_filters
 
 
 @pytest.mark.asyncio

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -120,6 +120,21 @@ def _resolve_pg_filter_fields(core_filters: Dict[str, Any], pg, source: str) -> 
             doc_ids_from_pg_field(pg, "sys_language", str(language).split(",")),
         )
 
+    _convert_src_fields_to_doc_ids(core_filters, pg, source)
+
+
+def _convert_src_fields_to_doc_ids(
+    core_filters: Dict[str, Any], pg, source: str
+) -> None:
+    """Resolve ``src_*`` filters to a ``doc_id`` constraint.
+
+    ``src_*`` field values live in the ``docs.src_doc_raw_metadata`` JSONB, not on
+    chunks nor in the Qdrant document payload (they are only sparsely stamped onto
+    chunks, so a chunk/payload filter silently drops most matching documents). Both
+    chunk search (``/search``) and document search (``/docsearch``) must therefore
+    resolve them to the matching doc_ids — the same source the facet counts come
+    from — and AND them with any existing doc_id constraint.
+    """
     src_field_mapping = get_src_field_mapping(source) or {}
     for core_field in list(core_filters.keys()):
         if not core_field.startswith("src_"):
@@ -766,10 +781,13 @@ async def search(
             language,
         )
         add_dynamic_filters(core_filters, request.query_params, source)
-        # Language and region are doc-level only; convert to doc_id filters for
-        # chunk search (region intersects with any language-derived doc_ids).
+        # Language, region and src_* fields are doc-level only (src_* is only
+        # sparsely stamped onto chunks); convert each to a doc_id filter for the
+        # chunk search so they intersect (AND) rather than dropping documents
+        # whose chunks lack the value.
         _convert_language_to_doc_ids(core_filters, pg)
         _convert_region_to_doc_ids(core_filters, pg)
+        _convert_src_fields_to_doc_ids(core_filters, pg, source)
 
         title_filter = core_filters.get("title")
         early_response = _handle_title_filter(pg, core_filters, q)


### PR DESCRIPTION
Fixes Heatmapper **query mode** (a search string + attribute axes, e.g. *evaluation category × year with 'Community engagement'*) returning almost no documents.

## Root cause (measured)
Heatmapper has two modes: attribute mode (no query) → `/docsearch`, fixed in #371; query mode (search string) → `/search` per cell. A few attributes are **doc-level** and were only *sparsely* stamped onto chunks — measured presence on a 300-chunk sample:

| field | on chunks |
|---|---|
| `src_evaluation_category` | 25/300 |
| `src_quality_rating` | 25/300 |
| `map_region` | 2/300 |
| (country, organization, document_type, year, language, tag_*) | ≥298/300 |

Query mode filtered the **chunk payload** by these sparse fields, so it silently dropped every document whose chunks lacked the value (a CE-tagged 2023 doc had chunks with `src_evaluation_category=None`). The 3 sparse/doc-level fields are exactly the ones not reliably on chunks; everything else is dense and filters correctly.

## Two complementary fixes

**1. Code safety-net — `ui/backend/routes/search.py`**
`/search` now resolves `src_*` filters to doc_ids (shared `_convert_src_fields_to_doc_ids`, alongside the existing language/region resolution), so they intersect by `doc_id` (the source facet counts use) instead of filtering the sparse chunk payload. Keeps Heatmapper correct even if chunk data is ever stale (e.g. after re-ingestion). Unit-tested (resolve / intersect / empty→no-match / non-src untouched).

**2. Data fix — `scripts/fixes/backfill_chunk_doc_fields.py`**
Backfills the doc-level values onto **all** of each document's chunks from the authoritative PostgreSQL source (`docs_<source>` column for `map_*`, `src_doc_raw_metadata` JSONB for `src_*`), so chunk-mode filtering is correct natively ("if using chunks, use chunk data"). Dry-run by default (`--apply` to write); never nulls a value; idempotent (`must_not` skip); writes batched per value. Unit-tested helpers.

## Verification (WFP data)
- Query mode `q='Community engagement'`, eval × year: cells that were **0** across 2020–2023 now return **~15–26 docs** each (code fix); `CE+2023`: 0 → 19 docs / 197 results.
- After running the backfill: `src_evaluation_category` chunk coverage **8% → 100%**; direct Qdrant `CE AND year=2023`: 0 → **7,485 chunks**; `DE AND 2022`: 0 → 8,694. 235,385 chunks backfilled.
- Dense fields (e.g. `document_type=Activity` = 59 docs) unchanged — no regression.
- All filter fields enumerated and confirmed: the only 3 sparse fields are handled; every field left as a chunk filter is ≥298/300 populated.

Defers (per discussion) the larger refactor to make attribute mode count from the Postgres docs table exclusively.