### PR TITLE
feat(ui): CSV import to create a dataset + paired LLM-judge experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Evidence Lab document processing pipeline includes the following features:
 - PDF preview with in-document search
 - Built-in searchable documentation area with sidebar navigation
 - Administration views to track pipeline, documents, performance and errors
+- Evaluation harness (superuser) — build reusable datasets and experiments to regression-test Search and AI-Summary quality against the live system, including a one-step CSV upload that creates a dataset and a paired LLM-judge experiment (one expected answer per row). See [Evaluation Harness](docs/admin/evaluation.md)
 
 3. AI platform integrations
 

--- a/docs/admin/evaluation.md
+++ b/docs/admin/evaluation.md
@@ -23,6 +23,33 @@ The typical workflow is:
 
 ---
 
+### Quick path: create a dataset + experiment from one CSV
+
+If you already have your questions **and** the expected answers in a spreadsheet, use **+ Create Experiment** (in the **Datasets** sub‑view) to do everything in one upload: it creates a dataset of the questions **and** a draft experiment with one **LLM‑judge** assertion per row, where each row is judged against its own expected answer.
+
+The CSV is the **same format as the dataset upload** (see [Add test cases](#add-test-cases)) plus one extra column:
+
+| Column | Required | Notes |
+|--------|----------|-------|
+| `query` | yes | The question / search query. |
+| `expectation` | yes | Free text describing the expected answer. Becomes that row's **LLM‑judge rubric** (per‑case override). |
+| `tags` | no | Separated by `;` within the cell. |
+| `notes` | no | Free text. |
+| `filters` | no | JSON object, e.g. `{"country": "Kenya"}`. |
+
+In the **Create Experiment** dialog you provide:
+
+- **Name** — saved as `<name>_dataset` and `<name>_experiment`.
+- **What to test** — `search` or `ai_summary`. The expectation column drives an **LLM‑judge** assertion, which evaluates the AI summary, so choose **`ai_summary`** for it to apply.
+- **Data source**, **Model combo**, **Run as group**, and the **judge threshold** (default `0.7`) — the same run configuration as a normal experiment (see [Run configuration](#run-configuration)).
+- The **CSV file** (a **sample format** download is provided).
+
+Each row's question and expectation stay paired at the row level. The import is atomic — if anything fails part‑way, the partially‑created dataset is removed so you can retry cleanly. Once created, run it from the **Experiments** table like any other experiment ([Run an experiment](#3-run-an-experiment)).
+
+> Prefer to define assertions by hand, or build a `search` experiment? Use the manual flow below instead.
+
+---
+
 ### 1. Create a dataset
 
 A **dataset** is a reusable set of **test cases** for one capability. Datasets hold *inputs only* — the assertions live on the experiment, so the same dataset can be evaluated under different expectations.

--- a/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
+++ b/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
@@ -1,0 +1,203 @@
+import React, { useRef, useState } from 'react';
+import { parseQaCsv, SAMPLE_QA_CSV, QaCsvRow } from './csv';
+import { DEFAULT_THRESHOLD, importDatasetWithExperiment } from './experimentImport';
+
+interface CreateDatasetWithExperimentModalProps {
+  onCreated: () => void;
+  onCancel: () => void;
+}
+
+const downloadSampleCsv = () => {
+  const blob = new Blob([SAMPLE_QA_CSV], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'qa-experiment-sample.csv';
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
+const clampThreshold = (value: number): number => {
+  if (Number.isNaN(value)) return DEFAULT_THRESHOLD;
+  return Math.min(1, Math.max(0, value));
+};
+
+// Read + parse the chosen CSV into rows; returns an error string instead of
+// throwing so the caller can surface it inline.
+const readRows = async (
+  file: File,
+): Promise<{ rows: QaCsvRow[]; error: string }> => {
+  let rows: QaCsvRow[];
+  try {
+    rows = parseQaCsv(await file.arrayBuffer());
+  } catch {
+    return { rows: [], error: 'Could not parse the CSV file.' };
+  }
+  if (rows.length === 0) {
+    return { rows: [], error: 'No rows with a "Question" column were found.' };
+  }
+  return { rows, error: '' };
+};
+
+const CreateDatasetWithExperimentModal: React.FC<
+  CreateDatasetWithExperimentModalProps
+> = ({ onCreated, onCancel }) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [dataSource, setDataSource] = useState('');
+  const [experimentName, setExperimentName] = useState('');
+  const [threshold, setThreshold] = useState(DEFAULT_THRESHOLD);
+  const [fileName, setFileName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const fileRef = useRef<HTMLInputElement | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const file = fileRef.current?.files?.[0];
+    if (!file) {
+      setError('Please choose a CSV file to upload.');
+      return;
+    }
+    const { rows, error: readError } = await readRows(file);
+    if (readError) {
+      setError(readError);
+      return;
+    }
+    setBusy(true);
+    try {
+      await importDatasetWithExperiment({
+        name,
+        description,
+        dataSource,
+        experimentName,
+        threshold,
+        rows,
+      });
+      onCreated();
+    } catch (err: any) {
+      setError(
+        err.response?.data?.detail
+          || 'Failed to create the dataset and experiment.',
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div
+        className="modal-content login-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h3>Create Dataset + Experiment</h3>
+          <button className="modal-close" onClick={onCancel}>&times;</button>
+        </div>
+        <div className="modal-body">
+          {error && <div className="auth-error">{error}</div>}
+          <p className="text-muted" style={{ marginTop: 0 }}>
+            Upload a CSV with a <strong>Question</strong> column and an{' '}
+            <strong>Unpacking Question / Probing</strong> column (the expected
+            answer). This creates an AI-summary dataset of the questions and a
+            draft experiment with one LLM-judge assertion per row, each judged
+            against that row&apos;s expected answer.
+          </p>
+          <form onSubmit={handleSubmit}>
+            <div className="form-group">
+              <label htmlFor="cde-name">Dataset name</label>
+              <input
+                id="cde-name"
+                type="text"
+                required
+                autoFocus
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My evaluation set"
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="cde-desc">Description (optional)</label>
+              <input
+                id="cde-desc"
+                type="text"
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="What this dataset tests"
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="cde-source">Data source</label>
+              <input
+                id="cde-source"
+                type="text"
+                required
+                value={dataSource}
+                onChange={(e) => setDataSource(e.target.value)}
+                placeholder="e.g. uneg"
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="cde-exp-name">Experiment name (optional)</label>
+              <input
+                id="cde-exp-name"
+                type="text"
+                value={experimentName}
+                onChange={(e) => setExperimentName(e.target.value)}
+                placeholder="Defaults to “<dataset> — LLM judge”"
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="cde-threshold">Judge threshold (0–1)</label>
+              <input
+                id="cde-threshold"
+                type="number"
+                min={0}
+                max={1}
+                step={0.05}
+                value={threshold}
+                onChange={(e) => setThreshold(clampThreshold(e.target.valueAsNumber))}
+              />
+            </div>
+            <div className="form-group">
+              <label htmlFor="cde-file">Questions CSV</label>
+              <div className="testing-upload-group">
+                <button
+                  type="button"
+                  className="btn-sm"
+                  onClick={() => fileRef.current?.click()}
+                >
+                  {fileName || 'Choose CSV…'}
+                </button>
+                <button
+                  type="button"
+                  className="testing-raw-toggle"
+                  onClick={downloadSampleCsv}
+                >
+                  sample format
+                </button>
+              </div>
+              <input
+                id="cde-file"
+                ref={fileRef}
+                type="file"
+                accept=".csv,text/csv"
+                style={{ display: 'none' }}
+                onChange={(e) => setFileName(e.target.files?.[0]?.name || '')}
+              />
+            </div>
+            <button type="submit" className="auth-submit" disabled={busy}>
+              {busy ? 'Creating…' : 'Create Dataset + Experiment'}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CreateDatasetWithExperimentModal;

--- a/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
+++ b/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
@@ -1,6 +1,16 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import API_BASE_URL from '../../../config';
+import type { TestCapability } from '../../../types/testing';
 import { parseQaCsv, SAMPLE_QA_CSV, QaCsvRow } from './csv';
 import { DEFAULT_THRESHOLD, importDatasetWithExperiment } from './experimentImport';
+import {
+  ConfigDraft,
+  ConfigForm,
+  GroupOption,
+  configToDraft,
+  draftToConfig,
+} from './ExperimentEditor';
 
 interface CreateDatasetWithExperimentModalProps {
   onCreated: () => void;
@@ -18,6 +28,8 @@ const downloadSampleCsv = () => {
   link.remove();
   URL.revokeObjectURL(url);
 };
+
+const CAPABILITIES: TestCapability[] = ['search', 'ai_summary'];
 
 const clampThreshold = (value: number): number => {
   if (Number.isNaN(value)) return DEFAULT_THRESHOLD;
@@ -46,13 +58,56 @@ const CreateDatasetWithExperimentModal: React.FC<
 > = ({ onCreated, onCancel }) => {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
+  const [capability, setCapability] = useState<TestCapability>('ai_summary');
   const [dataSource, setDataSource] = useState('');
-  const [experimentName, setExperimentName] = useState('');
   const [threshold, setThreshold] = useState(DEFAULT_THRESHOLD);
+  const [config, setConfig] = useState<ConfigDraft>(configToDraft(null));
+  const [modelCombos, setModelCombos] = useState<string[]>([]);
+  const [groups, setGroups] = useState<GroupOption[]>([]);
   const [fileName, setFileName] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const fileRef = useRef<HTMLInputElement | null>(null);
+
+  // Load all model combos on mount so the dropdown is populated; default to the
+  // first (system default) combo, mirroring the experiment editor.
+  useEffect(() => {
+    let cancelled = false;
+    axios
+      .get<Record<string, unknown>>(`${API_BASE_URL}/config/model-combos`)
+      .then((resp) => {
+        if (cancelled) return;
+        const names = Object.keys(resp.data || {});
+        setModelCombos(names);
+        setConfig((c) =>
+          c.model_combo && names.includes(c.model_combo)
+            ? c
+            : { ...c, model_combo: names[0] || '' },
+        );
+      })
+      .catch(() => {
+        // Non-fatal: the combo dropdown stays empty if config can't load.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load user groups for the "Run as group" dropdown.
+  useEffect(() => {
+    let cancelled = false;
+    axios
+      .get<GroupOption[]>(`${API_BASE_URL}/groups/`)
+      .then((resp) => {
+        if (!cancelled) setGroups(resp.data || []);
+      })
+      .catch(() => {
+        // Non-fatal: groups may be unavailable (user module off) — dropdown empty.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -72,9 +127,10 @@ const CreateDatasetWithExperimentModal: React.FC<
       await importDatasetWithExperiment({
         name,
         description,
+        capability,
         dataSource,
-        experimentName,
         threshold,
+        config: draftToConfig(config),
         rows,
       });
       onCreated();
@@ -101,15 +157,15 @@ const CreateDatasetWithExperimentModal: React.FC<
         <div className="modal-body">
           {error && <div className="auth-error">{error}</div>}
           <p className="text-muted" style={{ marginTop: 0 }}>
-            Upload a CSV with a <strong>Question</strong> column and an{' '}
-            <strong>Unpacking Question / Probing</strong> column (the expected
-            answer). This creates an AI-summary dataset of the questions and a
-            draft experiment with one LLM-judge assertion per row, each judged
-            against that row&apos;s expected answer.
+            Upload a CSV in the regular dataset format (
+            <code>query, tags, notes, filters</code>) plus one{' '}
+            <strong>expectation</strong> column. This creates a dataset of the
+            questions and a draft experiment with one LLM-judge assertion per
+            row, each judged against that row&apos;s expectation.
           </p>
           <form onSubmit={handleSubmit}>
             <div className="form-group">
-              <label htmlFor="cde-name">Dataset name</label>
+              <label htmlFor="cde-name">Name</label>
               <input
                 id="cde-name"
                 type="text"
@@ -119,6 +175,10 @@ const CreateDatasetWithExperimentModal: React.FC<
                 onChange={(e) => setName(e.target.value)}
                 placeholder="My evaluation set"
               />
+              <small className="text-muted">
+                Saved as <code>{`${name || 'name'}_dataset`}</code> and{' '}
+                <code>{`${name || 'name'}_experiment`}</code>.
+              </small>
             </div>
             <div className="form-group">
               <label htmlFor="cde-desc">Description (optional)</label>
@@ -131,6 +191,23 @@ const CreateDatasetWithExperimentModal: React.FC<
               />
             </div>
             <div className="form-group">
+              <label htmlFor="cde-capability">What to test</label>
+              <select
+                id="cde-capability"
+                value={capability}
+                onChange={(e) => setCapability(e.target.value as TestCapability)}
+              >
+                {CAPABILITIES.map((c) => (
+                  <option key={c} value={c}>{c}</option>
+                ))}
+              </select>
+              <small className="text-muted">
+                The expectation column builds an LLM-judge assertion, which
+                evaluates the AI summary — choose <code>ai_summary</code> for it
+                to apply.
+              </small>
+            </div>
+            <div className="form-group">
               <label htmlFor="cde-source">Data source</label>
               <input
                 id="cde-source"
@@ -141,16 +218,13 @@ const CreateDatasetWithExperimentModal: React.FC<
                 placeholder="e.g. uneg"
               />
             </div>
-            <div className="form-group">
-              <label htmlFor="cde-exp-name">Experiment name (optional)</label>
-              <input
-                id="cde-exp-name"
-                type="text"
-                value={experimentName}
-                onChange={(e) => setExperimentName(e.target.value)}
-                placeholder="Defaults to “<dataset> — LLM judge”"
-              />
-            </div>
+            <ConfigForm
+              draft={config}
+              modelCombos={modelCombos}
+              groups={groups}
+              onChange={setConfig}
+              showHints={false}
+            />
             <div className="form-group">
               <label htmlFor="cde-threshold">Judge threshold (0–1)</label>
               <input

--- a/ui/frontend/src/components/admin/testing/DatasetList.tsx
+++ b/ui/frontend/src/components/admin/testing/DatasetList.tsx
@@ -186,14 +186,17 @@ const DatasetList: React.FC<DatasetListProps> = ({ onOpen }) => {
           className="testing-dataset-actions"
           style={{ marginLeft: 'auto' }}
         >
-          <button className="btn-sm" onClick={() => setShowImport(true)}>
-            + Create Dataset + Experiment
-          </button>
           <button
             className="btn-sm btn-primary"
             onClick={() => setShowCreate(true)}
           >
             + Create Dataset
+          </button>
+          <button
+            className="btn-sm btn-primary"
+            onClick={() => setShowImport(true)}
+          >
+            + Create Experiment
           </button>
         </div>
       </div>

--- a/ui/frontend/src/components/admin/testing/DatasetList.tsx
+++ b/ui/frontend/src/components/admin/testing/DatasetList.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import API_BASE_URL from '../../../config';
 import type { TestCapability, TestDataset } from '../../../types/testing';
 import ConfirmModal from '../ConfirmModal';
+import CreateDatasetWithExperimentModal from './CreateDatasetWithExperimentModal';
 import { formatTimestamp } from './testingFormat';
 
 const CAPABILITIES: TestCapability[] = ['search', 'ai_summary'];
@@ -122,6 +123,7 @@ const DatasetList: React.FC<DatasetListProps> = ({ onOpen }) => {
   const [error, setError] = useState('');
   const [capabilityFilter, setCapabilityFilter] = useState<'' | TestCapability>('');
   const [showCreate, setShowCreate] = useState(false);
+  const [showImport, setShowImport] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<TestDataset | null>(null);
 
   const fetchDatasets = useCallback(async () => {
@@ -180,13 +182,20 @@ const DatasetList: React.FC<DatasetListProps> = ({ onOpen }) => {
         <p className="text-muted" style={{ margin: 0 }}>
           {datasets.length} dataset{datasets.length !== 1 ? 's' : ''}
         </p>
-        <button
-          className="btn-sm btn-primary"
-          onClick={() => setShowCreate(true)}
+        <div
+          className="testing-dataset-actions"
           style={{ marginLeft: 'auto' }}
         >
-          + Create Dataset
-        </button>
+          <button className="btn-sm" onClick={() => setShowImport(true)}>
+            + Create Dataset + Experiment
+          </button>
+          <button
+            className="btn-sm btn-primary"
+            onClick={() => setShowCreate(true)}
+          >
+            + Create Dataset
+          </button>
+        </div>
       </div>
 
       <table className="admin-table">
@@ -243,6 +252,16 @@ const DatasetList: React.FC<DatasetListProps> = ({ onOpen }) => {
             fetchDatasets();
           }}
           onCancel={() => setShowCreate(false)}
+        />
+      )}
+
+      {showImport && (
+        <CreateDatasetWithExperimentModal
+          onCreated={() => {
+            setShowImport(false);
+            fetchDatasets();
+          }}
+          onCancel={() => setShowImport(false)}
         />
       )}
     </div>

--- a/ui/frontend/src/components/admin/testing/ExperimentEditor.tsx
+++ b/ui/frontend/src/components/admin/testing/ExperimentEditor.tsx
@@ -24,26 +24,28 @@ interface ExperimentEditorProps {
 /*  Config form                                                       */
 /* ------------------------------------------------------------------ */
 
-interface ConfigDraft {
+export interface ConfigDraft {
   model_combo: string;
   group_id: string;
 }
 
 const stringField = (v: unknown): string => (typeof v === 'string' ? v : '');
 
-const configToDraft = (config?: Record<string, unknown> | null): ConfigDraft => ({
+export const configToDraft = (
+  config?: Record<string, unknown> | null,
+): ConfigDraft => ({
   model_combo: stringField((config || {}).model_combo),
   group_id: stringField((config || {}).group_id),
 });
 
-const draftToConfig = (draft: ConfigDraft): Record<string, unknown> => {
+export const draftToConfig = (draft: ConfigDraft): Record<string, unknown> => {
   const config: Record<string, unknown> = {};
   if (draft.model_combo.trim()) config.model_combo = draft.model_combo.trim();
   if (draft.group_id.trim()) config.group_id = draft.group_id.trim();
   return config;
 };
 
-interface GroupOption {
+export interface GroupOption {
   id: string;
   name: string;
 }
@@ -53,13 +55,16 @@ interface ConfigFormProps {
   modelCombos: string[];
   groups: GroupOption[];
   onChange: (draft: ConfigDraft) => void;
+  // Show the per-field helper captions (hidden in the compact create modal).
+  showHints?: boolean;
 }
 
-const ConfigForm: React.FC<ConfigFormProps> = ({
+export const ConfigForm: React.FC<ConfigFormProps> = ({
   draft,
   modelCombos,
   groups,
   onChange,
+  showHints = true,
 }) => {
   const set = (patch: Partial<ConfigDraft>) => onChange({ ...draft, ...patch });
   return (
@@ -77,9 +82,11 @@ const ConfigForm: React.FC<ConfigFormProps> = ({
             </option>
           ))}
         </select>
-        <p className="text-muted" style={{ marginTop: '0.25rem' }}>
-          Embedding, summary and reranker models (same combos as the search UI).
-        </p>
+        {showHints && (
+          <p className="text-muted" style={{ marginTop: '0.25rem' }}>
+            Embedding, summary and reranker models (same combos as the search UI).
+          </p>
+        )}
       </div>
       <div className="form-group">
         <label htmlFor="cfg-group">Run as group</label>
@@ -95,9 +102,11 @@ const ConfigForm: React.FC<ConfigFormProps> = ({
             </option>
           ))}
         </select>
-        <p className="text-muted" style={{ marginTop: '0.25rem' }}>
-          Search settings + summary prompt from this group (rerank, sections, …).
-        </p>
+        {showHints && (
+          <p className="text-muted" style={{ marginTop: '0.25rem' }}>
+            Search settings + summary prompt from this group (rerank, sections, …).
+          </p>
+        )}
       </div>
     </div>
   );

--- a/ui/frontend/src/components/admin/testing/csv.ts
+++ b/ui/frontend/src/components/admin/testing/csv.ts
@@ -1,32 +1,21 @@
-// CSV parsing for the "Create Dataset + Experiment" import. Each row pairs a
-// question (the test-case input) with an expected answer (the per-row LLM-judge
-// rubric). Mirrors the lightweight xlsx-based parsing used by DatasetEditor.
+// CSV parsing for the "Create Dataset + Experiment" import. The format mirrors
+// the regular dataset CSV upload (columns: query, tags, notes, filters) with one
+// extra column, "expectation", whose value becomes that row's LLM-judge rubric.
 
 import * as XLSX from 'xlsx-js-style';
 
 export interface QaCsvRow {
-  query: string;
-  expectedAnswer: string;
+  // Same shape as the regular dataset CSV case input: { query, filters? }.
+  input: Record<string, unknown>;
   tags?: string[];
   notes?: string;
+  // Becomes the per-row llm_judge rubric (the "expected answer").
+  expectation: string;
 }
 
-// Header aliases, compared case-insensitively after trimming. The example
-// export uses "Question" and "Unpacking Question / Probing"; the more generic
-// spreadsheet headers people tend to use are accepted too.
-const QUESTION_KEYS = ['question', 'query'];
-const EXPECTED_KEYS = [
-  'unpacking question / probing',
-  'expected_answer',
-  'expected answer',
-  'expected_result',
-  'expected result',
-  'expected',
-  'rubric',
-  'probing',
-];
-const TAGS_KEYS = ['tags'];
-const NOTES_KEYS = ['notes'];
+// Header aliases, compared case-insensitively after trimming.
+const QUERY_KEYS = ['query', 'question'];
+const EXPECTATION_KEYS = ['expectation', 'expected_answer', 'expected_result'];
 
 // First non-empty value among the given header aliases.
 const pick = (row: Record<string, string>, keys: string[]): string => {
@@ -49,24 +38,31 @@ const normaliseRow = (raw: Record<string, unknown>): Record<string, string> => {
 
 const toQaRow = (raw: Record<string, unknown>): QaCsvRow | null => {
   const row = normaliseRow(raw);
-  const query = pick(row, QUESTION_KEYS);
+  const query = pick(row, QUERY_KEYS);
   if (!query) return null;
-  const tags = pick(row, TAGS_KEYS)
+  const input: Record<string, unknown> = { query };
+  if (row.filters) {
+    try {
+      const parsed = JSON.parse(row.filters);
+      if (parsed && typeof parsed === 'object') input.filters = parsed;
+    } catch {
+      // Ignore malformed filters JSON — keep the query-only case.
+    }
+  }
+  const tags = (row.tags || '')
     .split(/[;,]/)
     .map((tag) => tag.trim())
     .filter(Boolean);
-  const notes = pick(row, NOTES_KEYS);
   return {
-    query,
-    expectedAnswer: pick(row, EXPECTED_KEYS),
+    input,
     tags: tags.length > 0 ? tags : undefined,
-    notes: notes || undefined,
+    notes: row.notes || undefined,
+    expectation: pick(row, EXPECTATION_KEYS),
   };
 };
 
-// Parse CSV bytes or text into question/expected-answer rows. Rows without a
-// question column are dropped. xlsx handles quoted, multi-line cells and detects
-// the file's code page (the sample export is Windows-1252, not UTF-8), so raw
+// Parse CSV bytes or text into rows. Rows without a query column are dropped.
+// xlsx handles quoted, multi-line cells and detects the file's code page, so raw
 // bytes are preferred over a UTF-8 text decode.
 export const parseQaCsv = (data: ArrayBuffer | string): QaCsvRow[] => {
   const workbook =
@@ -81,12 +77,13 @@ export const parseQaCsv = (data: ArrayBuffer | string): QaCsvRow[] => {
   return rows.map(toQaRow).filter((row): row is QaCsvRow => row !== null);
 };
 
+// Same columns as the regular dataset CSV plus an "expectation" column.
 export const SAMPLE_QA_CSV = [
-  'Question,Unpacking Question / Probing,tags,notes',
-  '"What were the effects of COVID-19 on WFP activities?",'
-    + '"Retrieve the most commonly cited ways in which WFP programmes changed '
-    + 'after the pandemic, and the results of those changes.",covid,Core question',
-  '"How timely was WFP in responding to COVID-19 needs?",'
-    + '"Was WFP able to respond in due time despite COVID-induced constraints? '
-    + 'Did the actions come at the appropriate time?",timeliness,',
+  'query,tags,notes,filters,expectation',
+  '"What were the effects of COVID-19 on WFP activities?",covid,Core question,,'
+    + '"The summary should cover the most commonly cited ways WFP programmes '
+    + 'changed after the pandemic and the results of those changes."',
+  '"How timely was WFP in responding to COVID-19 needs?",timeliness,,,'
+    + '"Whether WFP responded in due time despite COVID constraints and whether '
+    + 'the actions came at the appropriate time."',
 ].join('\n');

--- a/ui/frontend/src/components/admin/testing/csv.ts
+++ b/ui/frontend/src/components/admin/testing/csv.ts
@@ -1,0 +1,92 @@
+// CSV parsing for the "Create Dataset + Experiment" import. Each row pairs a
+// question (the test-case input) with an expected answer (the per-row LLM-judge
+// rubric). Mirrors the lightweight xlsx-based parsing used by DatasetEditor.
+
+import * as XLSX from 'xlsx-js-style';
+
+export interface QaCsvRow {
+  query: string;
+  expectedAnswer: string;
+  tags?: string[];
+  notes?: string;
+}
+
+// Header aliases, compared case-insensitively after trimming. The example
+// export uses "Question" and "Unpacking Question / Probing"; the more generic
+// spreadsheet headers people tend to use are accepted too.
+const QUESTION_KEYS = ['question', 'query'];
+const EXPECTED_KEYS = [
+  'unpacking question / probing',
+  'expected_answer',
+  'expected answer',
+  'expected_result',
+  'expected result',
+  'expected',
+  'rubric',
+  'probing',
+];
+const TAGS_KEYS = ['tags'];
+const NOTES_KEYS = ['notes'];
+
+// First non-empty value among the given header aliases.
+const pick = (row: Record<string, string>, keys: string[]): string => {
+  for (const key of keys) {
+    const value = row[key];
+    if (value) return value;
+  }
+  return '';
+};
+
+// Lower-case + trim the header keys and stringify/trim the cell values so
+// matching is robust to spreadsheet capitalisation and stray whitespace.
+const normaliseRow = (raw: Record<string, unknown>): Record<string, string> => {
+  const out: Record<string, string> = {};
+  Object.keys(raw).forEach((key) => {
+    out[key.trim().toLowerCase()] = String(raw[key] ?? '').trim();
+  });
+  return out;
+};
+
+const toQaRow = (raw: Record<string, unknown>): QaCsvRow | null => {
+  const row = normaliseRow(raw);
+  const query = pick(row, QUESTION_KEYS);
+  if (!query) return null;
+  const tags = pick(row, TAGS_KEYS)
+    .split(/[;,]/)
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+  const notes = pick(row, NOTES_KEYS);
+  return {
+    query,
+    expectedAnswer: pick(row, EXPECTED_KEYS),
+    tags: tags.length > 0 ? tags : undefined,
+    notes: notes || undefined,
+  };
+};
+
+// Parse CSV bytes or text into question/expected-answer rows. Rows without a
+// question column are dropped. xlsx handles quoted, multi-line cells and detects
+// the file's code page (the sample export is Windows-1252, not UTF-8), so raw
+// bytes are preferred over a UTF-8 text decode.
+export const parseQaCsv = (data: ArrayBuffer | string): QaCsvRow[] => {
+  const workbook =
+    typeof data === 'string'
+      ? XLSX.read(data, { type: 'string' })
+      : XLSX.read(new Uint8Array(data), { type: 'array' });
+  const sheet = workbook.Sheets[workbook.SheetNames[0]];
+  if (!sheet) return [];
+  const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+    defval: '',
+  });
+  return rows.map(toQaRow).filter((row): row is QaCsvRow => row !== null);
+};
+
+export const SAMPLE_QA_CSV = [
+  'Question,Unpacking Question / Probing,tags,notes',
+  '"What were the effects of COVID-19 on WFP activities?",'
+    + '"Retrieve the most commonly cited ways in which WFP programmes changed '
+    + 'after the pandemic, and the results of those changes.",covid,Core question',
+  '"How timely was WFP in responding to COVID-19 needs?",'
+    + '"Was WFP able to respond in due time despite COVID-induced constraints? '
+    + 'Did the actions come at the appropriate time?",timeliness,',
+].join('\n');

--- a/ui/frontend/src/components/admin/testing/experimentImport.ts
+++ b/ui/frontend/src/components/admin/testing/experimentImport.ts
@@ -1,0 +1,104 @@
+// Orchestrates the "Create Dataset + Experiment" import: create an ai_summary
+// dataset, one test case per question, and a draft experiment whose single
+// llm_judge column is overridden per row with that row's expected answer. The
+// row-level pairing (question <-> expected answer) is built as the cases are
+// created, so a question can never end up matched to the wrong rubric.
+
+import axios from 'axios';
+import API_BASE_URL from '../../../config';
+import type { AssertionMatrix, CaseRowState } from '../../../types/testing';
+import type { QaCsvRow } from './csv';
+
+// Fallback rubric for the llm_judge column. Every row supplies its own expected
+// answer as a per-cell override (ovr), so this is only used when a row's
+// expected answer is blank.
+export const DEFAULT_RUBRIC =
+  'The AI summary should accurately and completely address the question, '
+  + 'consistent with the expected answer provided for the test case.';
+
+export const DEFAULT_THRESHOLD = 0.7;
+
+interface CreatedCase {
+  caseId: string;
+  expectedAnswer: string;
+}
+
+// Build the experiment's assertion matrix: a single llm_judge column plus, per
+// case, an active flag, the column toggle, and the expected answer as the
+// per-cell rubric override. Matches the shape produced by ExperimentEditor.
+export const buildJudgeMatrix = (
+  cases: CreatedCase[],
+  threshold: number,
+): AssertionMatrix => {
+  const columns = [{ type: 'llm_judge', rubric: DEFAULT_RUBRIC, threshold }];
+  const out: Record<string, CaseRowState> = {};
+  cases.forEach(({ caseId, expectedAnswer }) => {
+    out[caseId] = { active: true, cols: [true], ovr: [expectedAnswer.trim()] };
+  });
+  return { columns, cases: out };
+};
+
+export interface ImportParams {
+  name: string;
+  description?: string;
+  dataSource: string;
+  experimentName?: string;
+  threshold: number;
+  rows: QaCsvRow[];
+}
+
+// Best-effort removal of a half-created dataset (cascades its cases). Surfacing
+// the original failure to the caller matters more than a cleanup error.
+const deleteDatasetQuietly = async (datasetId: string): Promise<void> => {
+  try {
+    await axios.delete(`${API_BASE_URL}/testing/datasets/${datasetId}`);
+  } catch {
+    // Intentionally ignored — caller re-throws the original error.
+  }
+};
+
+const createCases = async (
+  datasetId: string,
+  rows: QaCsvRow[],
+): Promise<CreatedCase[]> => {
+  const created: CreatedCase[] = [];
+  for (const row of rows) {
+    const resp = await axios.post<{ id: string }>(
+      `${API_BASE_URL}/testing/datasets/${datasetId}/cases`,
+      { input: { query: row.query }, tags: row.tags, notes: row.notes },
+    );
+    created.push({ caseId: resp.data.id, expectedAnswer: row.expectedAnswer });
+  }
+  return created;
+};
+
+// Create the dataset, its cases, and the paired draft experiment. On any
+// failure after the dataset exists, the dataset is removed so a retry is clean
+// (fail hard, no half-imported state). Returns the new dataset id.
+export const importDatasetWithExperiment = async (
+  params: ImportParams,
+): Promise<string> => {
+  const datasetResp = await axios.post<{ id: string }>(
+    `${API_BASE_URL}/testing/datasets`,
+    {
+      name: params.name.trim(),
+      description: params.description?.trim() || undefined,
+      capability: 'ai_summary',
+      data_source: params.dataSource.trim(),
+    },
+  );
+  const datasetId = datasetResp.data.id;
+  try {
+    const created = await createCases(datasetId, params.rows);
+    await axios.post(`${API_BASE_URL}/testing/experiments`, {
+      dataset_id: datasetId,
+      name: params.experimentName?.trim() || `${params.name.trim()} — LLM judge`,
+      config: null,
+      case_expectations: buildJudgeMatrix(created, params.threshold),
+    });
+    return datasetId;
+  } catch (err) {
+    await deleteDatasetQuietly(datasetId);
+    throw err;
+  }
+};

--- a/ui/frontend/src/components/admin/testing/experimentImport.ts
+++ b/ui/frontend/src/components/admin/testing/experimentImport.ts
@@ -39,11 +39,17 @@ export const buildJudgeMatrix = (
 };
 
 export interface ImportParams {
+  // Base name; saved as `<name>_dataset` and `<name>_experiment`.
   name: string;
   description?: string;
+  // What is tested: "search" | "ai_summary". The llm_judge assertion built from
+  // the expectation column only applies to ai_summary.
+  capability: string;
   dataSource: string;
-  experimentName?: string;
   threshold: number;
+  // Run configuration (model combo / run-as-group); same shape as the
+  // experiment editor's config. Omitted keys fall back to run defaults.
+  config?: Record<string, unknown>;
   rows: QaCsvRow[];
 }
 
@@ -65,9 +71,9 @@ const createCases = async (
   for (const row of rows) {
     const resp = await axios.post<{ id: string }>(
       `${API_BASE_URL}/testing/datasets/${datasetId}/cases`,
-      { input: { query: row.query }, tags: row.tags, notes: row.notes },
+      { input: row.input, tags: row.tags, notes: row.notes },
     );
-    created.push({ caseId: resp.data.id, expectedAnswer: row.expectedAnswer });
+    created.push({ caseId: resp.data.id, expectedAnswer: row.expectation });
   }
   return created;
 };
@@ -78,22 +84,27 @@ const createCases = async (
 export const importDatasetWithExperiment = async (
   params: ImportParams,
 ): Promise<string> => {
+  const base = params.name.trim();
   const datasetResp = await axios.post<{ id: string }>(
     `${API_BASE_URL}/testing/datasets`,
     {
-      name: params.name.trim(),
+      name: `${base}_dataset`,
       description: params.description?.trim() || undefined,
-      capability: 'ai_summary',
+      capability: params.capability,
       data_source: params.dataSource.trim(),
     },
   );
   const datasetId = datasetResp.data.id;
   try {
     const created = await createCases(datasetId, params.rows);
+    const config =
+      params.config && Object.keys(params.config).length > 0
+        ? params.config
+        : null;
     await axios.post(`${API_BASE_URL}/testing/experiments`, {
       dataset_id: datasetId,
-      name: params.experimentName?.trim() || `${params.name.trim()} — LLM judge`,
-      config: null,
+      name: `${base}_experiment`,
+      config,
       case_expectations: buildJudgeMatrix(created, params.threshold),
     });
     return datasetId;

--- a/ui/frontend/src/tests/csvAssertionImport.test.ts
+++ b/ui/frontend/src/tests/csvAssertionImport.test.ts
@@ -1,0 +1,152 @@
+import axios from 'axios';
+import { parseQaCsv } from '../components/admin/testing/csv';
+import {
+  DEFAULT_RUBRIC,
+  buildJudgeMatrix,
+  importDatasetWithExperiment,
+} from '../components/admin/testing/experimentImport';
+
+jest.mock('../config', () => ({ __esModule: true, default: '/api' }));
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const HEADER = 'Question,Unpacking Question / Probing';
+
+describe('parseQaCsv', () => {
+  test('maps the Question and Unpacking columns to query and expected answer', () => {
+    const csv = [
+      HEADER,
+      'What changed after COVID?,Retrieve the most commonly cited changes.',
+    ].join('\n');
+    const rows = parseQaCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].query).toBe('What changed after COVID?');
+    expect(rows[0].expectedAnswer).toBe('Retrieve the most commonly cited changes.');
+  });
+
+  test('accepts generic header aliases and parses tags/notes', () => {
+    const csv = [
+      'query,expected_answer,tags,notes',
+      'How timely was WFP?,Respond in due time.,timeliness;covid,A note',
+    ].join('\n');
+    const rows = parseQaCsv(csv);
+    expect(rows[0].query).toBe('How timely was WFP?');
+    expect(rows[0].expectedAnswer).toBe('Respond in due time.');
+    expect(rows[0].tags).toEqual(['timeliness', 'covid']);
+    expect(rows[0].notes).toBe('A note');
+  });
+
+  test('keeps quoted multi-line expected answers intact', () => {
+    const csv = `${HEADER}\nQ1,"line one\n\nline two"`;
+    const rows = parseQaCsv(csv);
+    expect(rows[0].expectedAnswer).toContain('line one');
+    expect(rows[0].expectedAnswer).toContain('line two');
+  });
+
+  test('drops rows without a question', () => {
+    const csv = [
+      HEADER,
+      ',orphan expected answer',
+      'Real question,Real expected',
+    ].join('\n');
+    const rows = parseQaCsv(csv);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].query).toBe('Real question');
+  });
+});
+
+describe('buildJudgeMatrix', () => {
+  test('creates one llm_judge column with each row overriding its rubric', () => {
+    const matrix = buildJudgeMatrix(
+      [
+        { caseId: 'c1', expectedAnswer: 'answer one' },
+        { caseId: 'c2', expectedAnswer: 'answer two' },
+      ],
+      0.7,
+    );
+    expect(matrix.columns).toEqual([
+      { type: 'llm_judge', rubric: DEFAULT_RUBRIC, threshold: 0.7 },
+    ]);
+    expect(matrix.cases.c1).toEqual({
+      active: true,
+      cols: [true],
+      ovr: ['answer one'],
+    });
+    expect(matrix.cases.c2.ovr).toEqual(['answer two']);
+  });
+});
+
+describe('importDatasetWithExperiment', () => {
+  const rows = [
+    { query: 'Q1', expectedAnswer: 'E1' },
+    { query: 'Q2', expectedAnswer: 'E2' },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const wireSuccess = () => {
+    let caseCount = 0;
+    mockedAxios.post.mockImplementation((url: string) => {
+      if (url.includes('/cases')) {
+        caseCount += 1;
+        return Promise.resolve({ data: { id: `c${caseCount}` } });
+      }
+      if (url.includes('/experiments')) {
+        return Promise.resolve({ data: { id: 'e1' } });
+      }
+      return Promise.resolve({ data: { id: 'ds1' } });
+    });
+  };
+
+  test('creates the dataset, a case per row, and the paired experiment', async () => {
+    wireSuccess();
+    const datasetId = await importDatasetWithExperiment({
+      name: 'My set',
+      dataSource: 'uneg',
+      threshold: 0.7,
+      rows,
+    });
+    expect(datasetId).toBe('ds1');
+
+    const datasetCall = mockedAxios.post.mock.calls.find(([url]) =>
+      /\/testing\/datasets$/.test(url as string),
+    );
+    expect(datasetCall?.[1]).toMatchObject({
+      capability: 'ai_summary',
+      data_source: 'uneg',
+      name: 'My set',
+    });
+
+    const expCall = mockedAxios.post.mock.calls.find(([url]) =>
+      (url as string).includes('/experiments'),
+    );
+    const body = expCall?.[1] as any;
+    expect(body.dataset_id).toBe('ds1');
+    expect(body.name).toBe('My set — LLM judge');
+    expect(body.case_expectations.cases.c1.ovr).toEqual(['E1']);
+    expect(body.case_expectations.cases.c2.ovr).toEqual(['E2']);
+  });
+
+  test('deletes the dataset and rethrows when case creation fails', async () => {
+    mockedAxios.post.mockImplementation((url: string) => {
+      if (url.includes('/cases')) return Promise.reject(new Error('boom'));
+      return Promise.resolve({ data: { id: 'ds1' } });
+    });
+    mockedAxios.delete.mockResolvedValue({ data: {} });
+
+    await expect(
+      importDatasetWithExperiment({
+        name: 'My set',
+        dataSource: 'uneg',
+        threshold: 0.7,
+        rows,
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(mockedAxios.delete).toHaveBeenCalledWith(
+      expect.stringContaining('/testing/datasets/ds1'),
+    );
+  });
+});

--- a/ui/frontend/src/tests/csvAssertionImport.test.ts
+++ b/ui/frontend/src/tests/csvAssertionImport.test.ts
@@ -10,48 +10,63 @@ jest.mock('../config', () => ({ __esModule: true, default: '/api' }));
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const HEADER = 'Question,Unpacking Question / Probing';
+const HEADER = 'query,tags,notes,filters,expectation';
+const NAME = 'My set';
+const SOURCE = 'uneg';
+const EXP_PATH = '/experiments';
+const CAP = 'ai_summary';
 
 describe('parseQaCsv', () => {
-  test('maps the Question and Unpacking columns to query and expected answer', () => {
+  test('mirrors the regular dataset columns plus an expectation column', () => {
     const csv = [
       HEADER,
-      'What changed after COVID?,Retrieve the most commonly cited changes.',
+      'What changed after COVID?,covid;baseline,A note,,Retrieve the cited changes.',
     ].join('\n');
     const rows = parseQaCsv(csv);
     expect(rows).toHaveLength(1);
-    expect(rows[0].query).toBe('What changed after COVID?');
-    expect(rows[0].expectedAnswer).toBe('Retrieve the most commonly cited changes.');
-  });
-
-  test('accepts generic header aliases and parses tags/notes', () => {
-    const csv = [
-      'query,expected_answer,tags,notes',
-      'How timely was WFP?,Respond in due time.,timeliness;covid,A note',
-    ].join('\n');
-    const rows = parseQaCsv(csv);
-    expect(rows[0].query).toBe('How timely was WFP?');
-    expect(rows[0].expectedAnswer).toBe('Respond in due time.');
-    expect(rows[0].tags).toEqual(['timeliness', 'covid']);
+    expect(rows[0].input).toEqual({ query: 'What changed after COVID?' });
+    expect(rows[0].tags).toEqual(['covid', 'baseline']);
     expect(rows[0].notes).toBe('A note');
+    expect(rows[0].expectation).toBe('Retrieve the cited changes.');
   });
 
-  test('keeps quoted multi-line expected answers intact', () => {
-    const csv = `${HEADER}\nQ1,"line one\n\nline two"`;
-    const rows = parseQaCsv(csv);
-    expect(rows[0].expectedAnswer).toContain('line one');
-    expect(rows[0].expectedAnswer).toContain('line two');
-  });
-
-  test('drops rows without a question', () => {
+  test('parses a filters JSON column into the case input', () => {
     const csv = [
       HEADER,
-      ',orphan expected answer',
-      'Real question,Real expected',
+      'nutrition outcomes,,,"{""country"": ""Kenya""}",Expected text',
     ].join('\n');
     const rows = parseQaCsv(csv);
+    expect(rows[0].input).toEqual({
+      query: 'nutrition outcomes',
+      filters: { country: 'Kenya' },
+    });
+    expect(rows[0].expectation).toBe('Expected text');
+  });
+
+  test('accepts header aliases (question / expected_answer)', () => {
+    const csv = [
+      'question,expected_answer',
+      'How timely was WFP?,Respond in due time.',
+    ].join('\n');
+    const rows = parseQaCsv(csv);
+    expect(rows[0].input).toEqual({ query: 'How timely was WFP?' });
+    expect(rows[0].expectation).toBe('Respond in due time.');
+  });
+
+  test('keeps quoted multi-line expectations intact', () => {
+    const csv = `${HEADER}\nQ1,,,,"line one\n\nline two"`;
+    const rows = parseQaCsv(csv);
+    expect(rows[0].expectation).toContain('line one');
+    expect(rows[0].expectation).toContain('line two');
+  });
+
+  test('drops rows without a query', () => {
+    const csv = [HEADER, ',,,,orphan expectation', 'Real question,,,,Real'].join(
+      '\n',
+    );
+    const rows = parseQaCsv(csv);
     expect(rows).toHaveLength(1);
-    expect(rows[0].query).toBe('Real question');
+    expect(rows[0].input).toEqual({ query: 'Real question' });
   });
 });
 
@@ -78,8 +93,8 @@ describe('buildJudgeMatrix', () => {
 
 describe('importDatasetWithExperiment', () => {
   const rows = [
-    { query: 'Q1', expectedAnswer: 'E1' },
-    { query: 'Q2', expectedAnswer: 'E2' },
+    { input: { query: 'Q1' }, expectation: 'E1' },
+    { input: { query: 'Q2' }, expectation: 'E2' },
   ];
 
   beforeEach(() => {
@@ -100,11 +115,12 @@ describe('importDatasetWithExperiment', () => {
     });
   };
 
-  test('creates the dataset, a case per row, and the paired experiment', async () => {
+  test('names dataset/experiment with suffixes and pairs expectations', async () => {
     wireSuccess();
     const datasetId = await importDatasetWithExperiment({
-      name: 'My set',
-      dataSource: 'uneg',
+      name: NAME,
+      capability: CAP,
+      dataSource: SOURCE,
       threshold: 0.7,
       rows,
     });
@@ -114,19 +130,58 @@ describe('importDatasetWithExperiment', () => {
       /\/testing\/datasets$/.test(url as string),
     );
     expect(datasetCall?.[1]).toMatchObject({
-      capability: 'ai_summary',
+      capability: CAP,
       data_source: 'uneg',
-      name: 'My set',
+      name: 'My set_dataset',
     });
 
+    const caseCall = mockedAxios.post.mock.calls.find(([url]) =>
+      (url as string).includes('/cases'),
+    );
+    expect(caseCall?.[1]).toMatchObject({ input: { query: 'Q1' } });
+
     const expCall = mockedAxios.post.mock.calls.find(([url]) =>
-      (url as string).includes('/experiments'),
+      (url as string).includes(EXP_PATH),
     );
     const body = expCall?.[1] as any;
-    expect(body.dataset_id).toBe('ds1');
-    expect(body.name).toBe('My set — LLM judge');
+    expect(body.name).toBe('My set_experiment');
     expect(body.case_expectations.cases.c1.ovr).toEqual(['E1']);
     expect(body.case_expectations.cases.c2.ovr).toEqual(['E2']);
+  });
+
+  test('passes model_combo / group_id config through to the experiment', async () => {
+    wireSuccess();
+    await importDatasetWithExperiment({
+      name: NAME,
+      capability: CAP,
+      dataSource: SOURCE,
+      threshold: 0.7,
+      config: { model_combo: 'Azure Foundry', group_id: 'g1' },
+      rows,
+    });
+    const expCall = mockedAxios.post.mock.calls.find(([url]) =>
+      (url as string).includes(EXP_PATH),
+    );
+    expect((expCall?.[1] as any).config).toEqual({
+      model_combo: 'Azure Foundry',
+      group_id: 'g1',
+    });
+  });
+
+  test('sends null config when none is supplied', async () => {
+    wireSuccess();
+    await importDatasetWithExperiment({
+      name: NAME,
+      capability: CAP,
+      dataSource: SOURCE,
+      threshold: 0.7,
+      config: {},
+      rows,
+    });
+    const expCall = mockedAxios.post.mock.calls.find(([url]) =>
+      (url as string).includes(EXP_PATH),
+    );
+    expect((expCall?.[1] as any).config).toBeNull();
   });
 
   test('deletes the dataset and rethrows when case creation fails', async () => {
@@ -138,8 +193,9 @@ describe('importDatasetWithExperiment', () => {
 
     await expect(
       importDatasetWithExperiment({
-        name: 'My set',
-        dataSource: 'uneg',
+        name: NAME,
+        capability: CAP,
+        dataSource: SOURCE,
         threshold: 0.7,
         rows,
       }),


### PR DESCRIPTION
## Description

Adds a **Create Experiment** flow to the admin Testing harness (Admin → Testing → Datasets) that bulk-imports a CSV and, in one step, builds an evaluation **dataset** plus a paired **LLM-judge experiment**.

Upload a CSV in the **regular dataset format** (`query, tags, notes, filters`) plus one extra **`expectation`** column. The flow:
- creates a dataset of the questions (`<name>_dataset`),
- creates a draft experiment (`<name>_experiment`) with a single `llm_judge` assertion column, where **each row's `expectation` becomes that row's per-cell rubric override** (`ovr`) — so every question is judged against its own expected answer,
- pairs question ↔ expectation as the cases are created and **fails hard** (deletes the half-created dataset) on any error, so a question can never be matched to the wrong rubric.

The modal mirrors the existing dataset upload + experiment editor: single **Name** (auto-suffixed), **What to test** capability selector (`search`/`ai_summary`), **Model combo** and **Run as group** controls (reusing the editor's `ConfigForm`, which gains an optional `showHints` prop), data source, judge **threshold** (default 0.7), and a sample-format download.

### Notes for reviewers
- Frontend-only. **No backend/DB/schema/migration changes**; reuses existing `/testing/*` endpoints.
- CSV parsing reuses the existing client-side xlsx approach; header matching is case-insensitive with aliases (`question`/`query`, `expected_answer`/`expectation`), handles quoted multi-line cells and non-UTF-8 (Windows-1252) files.
- The `expectation`→`llm_judge` assertion only evaluates AI summaries, so it is meaningful for the `ai_summary` capability (the selector hint nudges toward it).

## Type of Change
- [x] New feature
- [x] Documentation update

## Testing
- [x] Tests pass locally — full frontend suite green (459 tests, 53 suites)
- [x] New unit tests (`ui/frontend/src/tests/csvAssertionImport.test.ts`): CSV parsing/aliases/filters/multiline, `_dataset`/`_experiment` naming, expectation→`ovr` pairing, config + capability passthrough, and fail-hard cleanup
- [x] `tsc --noEmit` clean; ESLint clean on changed files

## Documentation
- [x] Online docs: new "Quick path: create a dataset + experiment from one CSV" section in `docs/admin/evaluation.md` (the Admin → Evaluation Harness page)
- [x] README: feature bullet under admin capabilities

## Checklist
- [x] Code follows project style guidelines (pre-commit hooks pass)
- [x] Self-review completed
- [x] No secrets; no DB/schema changes; no new public endpoints
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)