### PR TITLE
feat(admin): simplify CSV dataset + experiment upload

### DIFF
--- a/docs/admin/evaluation.md
+++ b/docs/admin/evaluation.md
@@ -23,9 +23,9 @@ The typical workflow is:
 
 ---
 
-### Quick path: create a dataset + experiment from one CSV
+### Quickstart: Load dataset and experiment in one file
 
-If you already have your questions **and** the expected answers in a spreadsheet, use **+ Create Experiment** (in the **Datasets** sub‑view) to do everything in one upload: it creates a dataset of the questions **and** a draft experiment with one **LLM‑judge** assertion per row, where each row is judged against its own expected answer.
+If you already have your questions **and** the expected answers in a spreadsheet, use **+ Create Dataset and Experiment** (in the **Datasets** sub‑view) to do everything in one upload: it creates a dataset of the questions **and** a draft experiment with one **LLM‑judge** assertion per row, where each row is judged against its own expected answer.
 
 The CSV is the **same format as the dataset upload** (see [Add test cases](#add-test-cases)) plus one extra column:
 
@@ -37,7 +37,7 @@ The CSV is the **same format as the dataset upload** (see [Add test cases](#add-
 | `notes` | no | Free text. |
 | `filters` | no | JSON object, e.g. `{"country": "Kenya"}`. |
 
-In the **Create Experiment** dialog you provide:
+In the **Create Dataset and Experiment** dialog you provide:
 
 - **Name** — saved as `<name>_dataset` and `<name>_experiment`.
 - **What to test** — `search` or `ai_summary`. The expectation column drives an **LLM‑judge** assertion, which evaluates the AI summary, so choose **`ai_summary`** for it to apply.
@@ -46,9 +46,13 @@ In the **Create Experiment** dialog you provide:
 
 Each row's question and expectation stay paired at the row level. The import is atomic — if anything fails part‑way, the partially‑created dataset is removed so you can retry cleanly. Once created, run it from the **Experiments** table like any other experiment ([Run an experiment](#3-run-an-experiment)).
 
-> Prefer to define assertions by hand, or build a `search` experiment? Use the manual flow below instead.
+> Prefer to define assertions by hand, or build a `search` experiment? Use the manual path below instead.
 
 ---
+
+### Manual path: build a dataset and experiment step by step
+
+Create the **dataset** and the **experiment** separately — use this when you want to define assertions by hand or build a `search` experiment. The steps below cover the full workflow.
 
 ### 1. Create a dataset
 

--- a/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
+++ b/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import API_BASE_URL from '../../../config';
 import type { TestCapability } from '../../../types/testing';
-import { parseQaCsv, SAMPLE_QA_CSV, QaCsvRow } from './csv';
+import { parseQaCsv, QaCsvRow } from './csv';
 import { DEFAULT_THRESHOLD, importDatasetWithExperiment } from './experimentImport';
 import {
   ConfigDraft,
@@ -16,18 +16,6 @@ interface CreateDatasetWithExperimentModalProps {
   onCreated: () => void;
   onCancel: () => void;
 }
-
-const downloadSampleCsv = () => {
-  const blob = new Blob([SAMPLE_QA_CSV], { type: 'text/csv;charset=utf-8' });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement('a');
-  link.href = url;
-  link.download = 'qa-experiment-sample.csv';
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
-};
 
 const CAPABILITIES: TestCapability[] = ['search', 'ai_summary'];
 
@@ -157,11 +145,8 @@ const CreateDatasetWithExperimentModal: React.FC<
         <div className="modal-body">
           {error && <div className="auth-error">{error}</div>}
           <p className="text-muted" style={{ marginTop: 0 }}>
-            Upload a CSV in the regular dataset format (
-            <code>query, tags, notes, filters</code>) plus one{' '}
-            <strong>expectation</strong> column. This creates a dataset of the
-            questions and a draft experiment with one LLM-judge assertion per
-            row, each judged against that row&apos;s expectation.
+            Upload dataset and expectation to create experiment. See the parent
+            page for a link to a sample sheet.
           </p>
           <form onSubmit={handleSubmit}>
             <div className="form-group">
@@ -175,10 +160,6 @@ const CreateDatasetWithExperimentModal: React.FC<
                 onChange={(e) => setName(e.target.value)}
                 placeholder="My evaluation set"
               />
-              <small className="text-muted">
-                Saved as <code>{`${name || 'name'}_dataset`}</code> and{' '}
-                <code>{`${name || 'name'}_experiment`}</code>.
-              </small>
             </div>
             <div className="form-group">
               <label htmlFor="cde-desc">Description (optional)</label>
@@ -246,13 +227,6 @@ const CreateDatasetWithExperimentModal: React.FC<
                   onClick={() => fileRef.current?.click()}
                 >
                   {fileName || 'Choose CSV…'}
-                </button>
-                <button
-                  type="button"
-                  className="testing-raw-toggle"
-                  onClick={downloadSampleCsv}
-                >
-                  sample format
                 </button>
               </div>
               <input

--- a/ui/frontend/src/components/admin/testing/DatasetEditor.tsx
+++ b/ui/frontend/src/components/admin/testing/DatasetEditor.tsx
@@ -9,17 +9,13 @@ import CaseEditor, {
   caseToDraft,
   emptyDraft,
 } from './CaseEditor';
+import { SAMPLE_DATASET_CSV } from './csv';
 
 /* ------------------------------------------------------------------ */
 /*  CSV import helpers (columns: query, tags, notes, filters)         */
 /* ------------------------------------------------------------------ */
 
-const SAMPLE_CSV = [
-  'query,tags,notes,filters',
-  'girls education in Kenya,regression;baseline,Core evaluation question,',
-  'cash vs in-kind transfers in Kenya,regression,Comparison question,',
-  'nutrition outcomes for children,smoke,,"{""country"": ""Kenya""}"',
-].join('\n');
+const SAMPLE_CSV = SAMPLE_DATASET_CSV;
 
 // Map one parsed CSV row (header-keyed) to a case payload; null if no query.
 const rowToPayload = (row: Record<string, unknown>): CasePayload | null => {

--- a/ui/frontend/src/components/admin/testing/DatasetList.tsx
+++ b/ui/frontend/src/components/admin/testing/DatasetList.tsx
@@ -5,8 +5,21 @@ import type { TestCapability, TestDataset } from '../../../types/testing';
 import ConfirmModal from '../ConfirmModal';
 import CreateDatasetWithExperimentModal from './CreateDatasetWithExperimentModal';
 import { formatTimestamp } from './testingFormat';
+import { SAMPLE_DATASET_CSV, SAMPLE_QA_CSV } from './csv';
 
 const CAPABILITIES: TestCapability[] = ['search', 'ai_summary'];
+
+const downloadCsv = (content: string, filename: string) => {
+  const blob = new Blob([content], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
 
 /* ------------------------------------------------------------------ */
 /*  Create-dataset modal                                              */
@@ -186,18 +199,44 @@ const DatasetList: React.FC<DatasetListProps> = ({ onOpen }) => {
           className="testing-dataset-actions"
           style={{ marginLeft: 'auto' }}
         >
-          <button
-            className="btn-sm btn-primary"
-            onClick={() => setShowCreate(true)}
+          <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}
           >
-            + Create Dataset
-          </button>
-          <button
-            className="btn-sm btn-primary"
-            onClick={() => setShowImport(true)}
+            <button
+              className="btn-sm btn-primary"
+              onClick={() => setShowCreate(true)}
+            >
+              + Create Dataset
+            </button>
+            <button
+              type="button"
+              className="testing-raw-toggle"
+              onClick={() =>
+                downloadCsv(SAMPLE_DATASET_CSV, 'test-cases-sample.csv')
+              }
+            >
+              sample format
+            </button>
+          </div>
+          <div
+            style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem' }}
           >
-            + Create Experiment
-          </button>
+            <button
+              className="btn-sm btn-primary"
+              onClick={() => setShowImport(true)}
+            >
+              + Create Dataset and Experiment
+            </button>
+            <button
+              type="button"
+              className="testing-raw-toggle"
+              onClick={() =>
+                downloadCsv(SAMPLE_QA_CSV, 'qa-experiment-sample.csv')
+              }
+            >
+              sample format
+            </button>
+          </div>
         </div>
       </div>
 

--- a/ui/frontend/src/components/admin/testing/csv.ts
+++ b/ui/frontend/src/components/admin/testing/csv.ts
@@ -78,6 +78,15 @@ export const parseQaCsv = (data: ArrayBuffer | string): QaCsvRow[] => {
 };
 
 // Same columns as the regular dataset CSV plus an "expectation" column.
+// Regular dataset sample (query, tags, notes, filters). The QA sample below is
+// the same shape plus one extra `expectation` column.
+export const SAMPLE_DATASET_CSV = [
+  'query,tags,notes,filters',
+  'girls education in Kenya,regression;baseline,Core evaluation question,',
+  'cash vs in-kind transfers in Kenya,regression,Comparison question,',
+  'nutrition outcomes for children,smoke,,"{""country"": ""Kenya""}"',
+].join('\n');
+
 export const SAMPLE_QA_CSV = [
   'query,tags,notes,filters,expectation',
   '"What were the effects of COVID-19 on WFP activities?",covid,Core question,,'


### PR DESCRIPTION
Simplifies the admin **Tests → Datasets** CSV upload flow so the sample sheets live on the pane (next to the buttons) and the modal is leaner.

### Datasets pane (`DatasetList.tsx`)
- Renamed **+ Create Experiment** → **+ Create Dataset and Experiment**.
- Added a **sample format** download under *each* button, same layout — the first is the regular dataset CSV (`query, tags, notes, filters`), the second the same plus one extra `expectation` column.
- Moved the regular sample to `csv.ts` as `SAMPLE_DATASET_CSV` (shared by `DatasetEditor` too — removes duplication).

### Create Dataset + Experiment modal
- Replaced the long description with: *"Upload dataset and expectation to create experiment. See the parent page for a link to a sample sheet."*
- Removed the in-modal **sample format** link (now on the parent pane).
- Removed the *"Saved as `<name>_dataset` / `<name>_experiment`"* helper line.

### Docs (`docs/admin/evaluation.md`)
- Renamed **Quick path…** → **Quickstart: Load dataset and experiment in one file** (and updated the button-name references).
- Added a **Manual path** section title so the step-by-step flow is clearly differentiated.

### Testing
- `tsc --noEmit`: clean for changed files; `csvAssertionImport` test passes.
- (4 unrelated suites fail to load on this base due to a pre-existing `@dnd-kit`/ESM jest-transform issue in `brief/` — not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)