### PR TITLE
fix(admin): scope Create-Dataset+Experiment combos to the data source

### DIFF
--- a/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
+++ b/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
@@ -57,12 +57,21 @@ const CreateDatasetWithExperimentModal: React.FC<
   const [error, setError] = useState('');
   const fileRef = useRef<HTMLInputElement | null>(null);
 
-  // Load all model combos on mount so the dropdown is populated; default to the
-  // first (system default) combo, mirroring the experiment editor.
+  // Load model combos filtered to the entered data source (mirroring the
+  // experiment editor + the search UI) so only combos actually configured for
+  // this environment appear — not every combo in config.json. Re-fetches as the
+  // data source changes; defaults to the first combo, which also auto-selects it
+  // when the data source has only one configured combo.
   useEffect(() => {
+    const source = dataSource.trim();
+    if (!source) {
+      setModelCombos([]);
+      return undefined;
+    }
     let cancelled = false;
+    const params = `?data_source=${encodeURIComponent(source)}`;
     axios
-      .get<Record<string, unknown>>(`${API_BASE_URL}/config/model-combos`)
+      .get<Record<string, unknown>>(`${API_BASE_URL}/config/model-combos${params}`)
       .then((resp) => {
         if (cancelled) return;
         const names = Object.keys(resp.data || {});
@@ -79,7 +88,7 @@ const CreateDatasetWithExperimentModal: React.FC<
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [dataSource]);
 
   // Load user groups for the "Run as group" dropdown.
   useEffect(() => {


### PR DESCRIPTION
## Bug
Running an experiment created via **+ Create Dataset and Experiment** failed with:
`Unexpected Response: 400 … "Wrong input: Not existing vector name error: azure_small"`

The CSV-upload modal (`CreateDatasetWithExperimentModal`) fetched `/config/model-combos` **without** a `data_source`, so the combo dropdown listed *every* `ui_model_combos` entry in `config.json` and defaulted to the **first** one (`Azure Foundry` → `azure_small`). But `chunks_wfp` only has the `google_gemini_1536` named vector, so the search rejected `azure_small`.

The backend already supports filtering (`/config/model-combos?data_source=wfp` returns only `Google Vertex`), and the **ExperimentEditor** already uses it — the modal just didn't.

## Fix
The modal now fetches combos scoped to the entered **data source** (re-fetching as it changes), mirroring the experiment editor and the search UI. So:
- Only combos **configured for the environment** appear (WFP → just `Google Vertex`), not all of `config.json`.
- It defaults to the first combo, which **auto-selects it when only one** is configured.

No config changes.

## Testing
- `tsc --noEmit`: clean for the changed file.
- (Pre-existing unrelated `@dnd-kit`/ESM jest suite-load failures in `brief/` remain — not touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)