### PR TITLE
feat(groups): per-group feature-tab toggles + label overrides

### DIFF
--- a/tests/unit/test_group_tab_settings.py
+++ b/tests/unit/test_group_tab_settings.py
@@ -1,0 +1,91 @@
+"""Unit tests for per-group feature-tab merge logic (users route helpers)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from ui.backend.routes.users import TAB_KEYS, _merge_group_settings, _merge_tabs
+
+pytestmark = pytest.mark.unit
+
+
+def _group(name, search_settings):
+    """A minimal stand-in for a UserGroup row."""
+    return SimpleNamespace(name=name, search_settings=search_settings)
+
+
+# ---------------------------------------------------------------------------
+# _merge_tabs
+# ---------------------------------------------------------------------------
+class TestMergeTabs:
+    def test_returns_all_tab_keys(self):
+        merged = _merge_tabs([])
+        assert set(merged.keys()) == set(TAB_KEYS)
+        # No configs => everything disabled, no labels.
+        assert all(not merged[t]["enabled"] for t in TAB_KEYS)
+
+    def test_enabled_if_any_group_enables(self):
+        a = {"search": {"enabled": True}, "assistant": {"enabled": False}}
+        b = {"search": {"enabled": False}, "assistant": {"enabled": True}}
+        merged = _merge_tabs([a, b])
+        assert merged["search"]["enabled"] is True
+        assert merged["assistant"]["enabled"] is True
+        assert merged["brief"]["enabled"] is False  # absent everywhere
+
+    def test_label_comes_from_first_enabling_group(self):
+        a = {"brief": {"enabled": False, "label": "Disabled-Brief"}}
+        b = {"brief": {"enabled": True, "label": "Briefings"}}
+        c = {"brief": {"enabled": True, "label": "Reports"}}
+        merged = _merge_tabs([a, b, c])
+        assert merged["brief"]["enabled"] is True
+        # 'a' disables it (ignored); 'b' is the first enabling group.
+        assert merged["brief"]["label"] == "Briefings"
+
+    def test_label_none_when_enabled_without_label(self):
+        merged = _merge_tabs([{"heatmap": {"enabled": True, "label": "  "}}])
+        assert merged["heatmap"]["enabled"] is True
+        assert merged["heatmap"]["label"] is None  # frontend uses its default
+
+
+# ---------------------------------------------------------------------------
+# _merge_group_settings
+# ---------------------------------------------------------------------------
+class TestMergeGroupSettings:
+    def test_no_tabs_key_when_no_group_configures_tabs(self):
+        groups = [_group("Default", {"rerank": True}), _group("B", None)]
+        merged = _merge_group_settings(groups)
+        assert "tabs" not in merged
+        assert merged["rerank"] is True
+
+    def test_tabs_present_and_unioned_when_configured(self):
+        groups = [
+            _group("Default", {"tabs": {"search": {"enabled": True}}}),
+            _group(
+                "Editors",
+                {"tabs": {"assistant": {"enabled": True, "label": "Ask"}}},
+            ),
+        ]
+        merged = _merge_group_settings(groups)
+        assert merged["tabs"]["search"]["enabled"] is True
+        assert merged["tabs"]["assistant"]["enabled"] is True
+        assert merged["tabs"]["assistant"]["label"] == "Ask"
+
+    def test_tabs_special_cased_not_first_non_null(self):
+        # First group enables only search; second enables brief. A naive
+        # first-non-null merge would keep only the first group's tabs dict.
+        groups = [
+            _group("A", {"tabs": {"search": {"enabled": True}}}),
+            _group("B", {"tabs": {"brief": {"enabled": True}}}),
+        ]
+        merged = _merge_group_settings(groups)
+        assert merged["tabs"]["search"]["enabled"] is True
+        assert merged["tabs"]["brief"]["enabled"] is True
+
+    def test_other_keys_keep_first_non_null(self):
+        groups = [
+            _group("A", {"denseWeight": 0.5, "tabs": {"search": {"enabled": True}}}),
+            _group("B", {"denseWeight": 0.9}),
+        ]
+        merged = _merge_group_settings(groups)
+        assert merged["denseWeight"] == 0.5  # first wins
+        assert merged["tabs"]["search"]["enabled"] is True

--- a/ui/backend/routes/users.py
+++ b/ui/backend/routes/users.py
@@ -242,20 +242,60 @@ async def get_my_groups(
     ]
 
 
+# Main feature tabs that a group can show/hide and relabel.
+TAB_KEYS = ("search", "assistant", "brief", "heatmap")
+
+
+def _merge_tabs(tab_configs: Sequence[dict]) -> dict:
+    """Union per-group tab visibility/labels.
+
+    ``tab_configs`` is each group's ``search_settings['tabs']`` dict, ordered by
+    group name ASC. A tab is **enabled if any group enables it**; its label comes
+    from the first (lowest-priority-first) enabling group that sets a non-empty
+    label, else ``None`` (the frontend then uses its default label).
+    """
+    result: dict = {}
+    for tab in TAB_KEYS:
+        enabled = False
+        label = None
+        for cfg in tab_configs:
+            entry = cfg.get(tab) or {}
+            if entry.get("enabled"):
+                enabled = True
+                if label is None:
+                    candidate = (entry.get("label") or "").strip()
+                    if candidate:
+                        label = candidate
+        result[tab] = {"enabled": enabled, "label": label}
+    return result
+
+
 def _merge_group_settings(groups: Sequence) -> dict:
     """Merge search_settings from multiple groups (first non-null per key wins).
 
     Groups are expected to be ordered by name ASC so that the "Default" group
     has lowest priority (comes first alphabetically for most custom group names).
+
+    The ``tabs`` key is special-cased: instead of first-non-null, it is unioned
+    across groups (see :func:`_merge_tabs`) so a feature tab shows if *any* group
+    enables it. ``tabs`` is only present in the result when at least one group
+    configured it.
     """
     merged: dict = {}
+    tab_configs: list = []
     for group in groups:
         settings = group.search_settings
         if not settings:
             continue
         for key, value in settings.items():
+            if key == "tabs":
+                if isinstance(value, dict):
+                    tab_configs.append(value)
+                continue
             if key not in merged:
                 merged[key] = value
+    if tab_configs:
+        merged["tabs"] = _merge_tabs(tab_configs)
     return merged
 
 

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import axios from 'axios';
 import './App.css';
 // Deployment theme overrides — must load after App.css so the customization
@@ -14,6 +14,7 @@ import API_BASE_URL, {
   GA_MEASUREMENT_ID,
   USER_MODULE,
   USER_MODULE_MODE,
+  ASSISTANT_ENABLED,
 } from './config';
 
 import {
@@ -36,6 +37,7 @@ import { SummaryModal } from './components/documents/SummaryModal';
 import { TopBar } from './components/layout/TopBar';
 import AppFooter from './components/layout/AppFooter';
 import { NavTabs } from './components/layout/NavTabs';
+import { resolveTabs, TAB_KEYS, TabKey } from './components/layout/tabConfig';
 import { SearchBox } from './components/SearchBox';
 import { PdfPreviewOverlay } from './components/app/PdfPreviewOverlay';
 import { SearchTabContent } from './components/app/SearchTabContent';
@@ -802,8 +804,10 @@ function App() {
   const [showLoadResearchModal, setShowLoadResearchModal] = useState(false);
   const [addingNodeParentId, setAddingNodeParentId] = useState<string | null>(null);
 
-  // Apply per-group search defaults (fetched when user is authenticated)
-  useGroupDefaults(USER_MODULE, authState, {
+  // Apply per-group search defaults (fetched when user is authenticated).
+  // The returned effective settings also carry `tabs` (per-group feature-tab
+  // visibility/labels, merged across the user's groups by the backend).
+  const groupDefaults = useGroupDefaults(USER_MODULE, authState, {
     denseWeight: setSearchDenseWeight,
     rerank: setRerankEnabled,
     recencyBoost: setRecencyBoostEnabled,
@@ -819,6 +823,14 @@ function App() {
     fieldBoostFields: setFieldBoostFields,
     greetingMessage: setGreetingMessage,
   });
+
+  // Resolve which main tabs to show and their labels. The chat tab additionally
+  // requires the global ASSISTANT_ENABLED config flag.
+  const tabConfig = useMemo(() => {
+    const resolved = resolveTabs(groupDefaults?.tabs);
+    resolved.assistant.enabled = resolved.assistant.enabled && ASSISTANT_ENABLED;
+    return resolved;
+  }, [groupDefaults]);
 
   // Debug: Log semantic threshold on startup
   useEffect(() => {
@@ -860,6 +872,15 @@ function App() {
 
     window.history.pushState(null, '', newPath);
   }, [selectedDomain, searchModel, selectedModelCombo]);
+
+  // If the active tab is a main feature tab that a group has disabled, fall back
+  // to the first enabled one so the user never lands on a hidden/empty tab.
+  useEffect(() => {
+    if (!TAB_KEYS.includes(activeTab as TabKey)) return;
+    if (tabConfig[activeTab as TabKey].enabled) return;
+    const firstEnabled = TAB_KEYS.find((t) => tabConfig[t].enabled);
+    if (firstEnabled && firstEnabled !== activeTab) handleTabChange(firstEnabled);
+  }, [tabConfig, activeTab, handleTabChange]);
 
   const handleAboutClick = useCallback(() => {
     setDocsInitialPath('overview/about.md');
@@ -2900,7 +2921,7 @@ function App() {
         onDocsClick={handleDocsClick}
         onAdminClick={() => handleTabChange('admin')}
         onLoadResearch={handleLoadResearch}
-        navTabs={<NavTabs activeTab={activeTab} onTabChange={handleTabChange} />}
+        navTabs={<NavTabs activeTab={activeTab} onTabChange={handleTabChange} tabs={tabConfig} />}
       />
 
       <SearchBox

--- a/ui/frontend/src/components/admin/GroupSettingsManager.tsx
+++ b/ui/frontend/src/components/admin/GroupSettingsManager.tsx
@@ -8,6 +8,14 @@ import {
   DEFAULT_SECTION_TYPES,
   SYSTEM_DEFAULTS,
 } from '../../utils/searchUrl';
+import { DEFAULT_TAB_LABELS, TAB_KEYS, TabKey } from '../layout/tabConfig';
+
+type TabValues = Record<TabKey, { enabled: boolean; label: string }>;
+
+const defaultTabValues = (): TabValues =>
+  Object.fromEntries(
+    TAB_KEYS.map((k) => [k, { enabled: true, label: '' }]),
+  ) as TabValues;
 
 /** Keys that can be overridden per group. */
 const SETTING_KEYS: (keyof SearchSettings)[] = [
@@ -131,6 +139,71 @@ const AppearanceSection: React.FC<{
   );
 };
 
+const FeaturesSection: React.FC<{
+  collapsed: boolean;
+  onToggle: () => void;
+  tabsOverride: boolean;
+  tabValues: TabValues;
+  setTabsOverride: React.Dispatch<React.SetStateAction<boolean>>;
+  setTabValues: React.Dispatch<React.SetStateAction<TabValues>>;
+}> = ({ collapsed, onToggle, tabsOverride, tabValues, setTabsOverride, setTabValues }) => (
+  <div className="filter-section">
+    <div className="filter-section-header" onClick={onToggle}>
+      <span className="filter-section-toggle">{collapsed ? '▼' : '▶'}</span>
+      <span className="filter-section-title">Features &amp; Tabs</span>
+    </div>
+    {collapsed && (
+      <div className="filter-section-content">
+        <label style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '13px' }}>
+          <input
+            type="checkbox"
+            checked={tabsOverride}
+            onChange={(e) => setTabsOverride(e.target.checked)}
+          />
+          Configure which tabs this group sees
+        </label>
+        {tabsOverride && (
+          <div style={{ marginTop: '8px' }}>
+            <p className="text-muted" style={{ fontSize: '12px', margin: '0 0 8px' }}>
+              A tab shows if any of a user&apos;s groups enables it; its label comes
+              from an enabling group. Leave a label blank to use the default.
+            </p>
+            {TAB_KEYS.map((k) => (
+              <div
+                key={k}
+                style={{ display: 'flex', alignItems: 'center', gap: '8px', marginBottom: '6px' }}
+              >
+                <label
+                  style={{ display: 'flex', alignItems: 'center', gap: '6px', minWidth: '90px', fontSize: '13px' }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={tabValues[k].enabled}
+                    onChange={(e) =>
+                      setTabValues((prev) => ({ ...prev, [k]: { ...prev[k], enabled: e.target.checked } }))
+                    }
+                  />
+                  {DEFAULT_TAB_LABELS[k]}
+                </label>
+                <input
+                  type="text"
+                  value={tabValues[k].label}
+                  placeholder={`Label (default: ${DEFAULT_TAB_LABELS[k]})`}
+                  disabled={!tabValues[k].enabled}
+                  onChange={(e) =>
+                    setTabValues((prev) => ({ ...prev, [k]: { ...prev[k], label: e.target.value } }))
+                  }
+                  style={{ flex: 1 }}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    )}
+  </div>
+);
+
 const GroupSettingsManager: React.FC = () => {
   const [groups, setGroups] = useState<UserGroup[]>([]);
   const [selectedGroupId, setSelectedGroupId] = useState('');
@@ -146,8 +219,14 @@ const GroupSettingsManager: React.FC = () => {
 
   // Collapsible sections — both open by default
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
-    new Set(['search_settings', 'content_settings', 'ai_summary', 'appearance'])
+    new Set(['search_settings', 'content_settings', 'ai_summary', 'appearance', 'features'])
   );
+
+  // Per-group feature-tab visibility/labels (stored under search_settings.tabs).
+  // `tabsOverride` off => this group doesn't constrain tabs (contributes nothing
+  // to the cross-group union).
+  const [tabsOverride, setTabsOverride] = useState(false);
+  const [tabValues, setTabValues] = useState<TabValues>(defaultTabValues);
 
   const toggleSection = (key: string) => {
     setCollapsedSections((prev) => {
@@ -196,6 +275,8 @@ const GroupSettingsManager: React.FC = () => {
       setOverrides(new Set());
       setValues({ ...SYSTEM_DEFAULTS });
       setSummaryPromptValue('');
+      setTabsOverride(false);
+      setTabValues(defaultTabValues());
       return;
     }
     const group = groups.find((g) => g.id === selectedGroupId);
@@ -214,6 +295,26 @@ const GroupSettingsManager: React.FC = () => {
 
     setOverrides(newOverrides);
     setValues(newValues);
+
+    // Load feature-tab override (search_settings.tabs)
+    const tabsCfg = (settings as any).tabs;
+    if (tabsCfg && typeof tabsCfg === 'object') {
+      setTabsOverride(true);
+      setTabValues(
+        Object.fromEntries(
+          TAB_KEYS.map((k) => [
+            k,
+            {
+              enabled: Boolean(tabsCfg[k]?.enabled),
+              label: (tabsCfg[k]?.label as string) || '',
+            },
+          ]),
+        ) as TabValues,
+      );
+    } else {
+      setTabsOverride(false);
+      setTabValues(defaultTabValues());
+    }
 
     // Load summary prompt override
     setSummaryPromptValue(group.summary_prompt || '');
@@ -236,6 +337,15 @@ const GroupSettingsManager: React.FC = () => {
         if (overrides.has(key)) {
           payload[key] = values[key];
         }
+      }
+      // Feature-tab overrides: only written when this group opts in.
+      if (tabsOverride) {
+        payload.tabs = Object.fromEntries(
+          TAB_KEYS.map((k) => [
+            k,
+            { enabled: tabValues[k].enabled, label: tabValues[k].label.trim() || null },
+          ]),
+        );
       }
       const patchBody: Record<string, unknown> = {
         search_settings: Object.keys(payload).length > 0 ? payload : {},
@@ -674,6 +784,16 @@ const GroupSettingsManager: React.FC = () => {
               </div>
 
               {/* Appearance Settings */}
+              {/* Features & Tabs — show/hide the main tabs and relabel them */}
+              <FeaturesSection
+                collapsed={collapsedSections.has('features')}
+                onToggle={() => toggleSection('features')}
+                tabsOverride={tabsOverride}
+                tabValues={tabValues}
+                setTabsOverride={setTabsOverride}
+                setTabValues={setTabValues}
+              />
+
               <AppearanceSection
                 collapsed={collapsedSections.has('appearance')}
                 onToggle={() => toggleSection('appearance')}

--- a/ui/frontend/src/components/layout/NavTabs.tsx
+++ b/ui/frontend/src/components/layout/NavTabs.tsx
@@ -1,16 +1,21 @@
 import React, { useState } from 'react';
-import { ASSISTANT_ENABLED } from '../../config';
+import { ResolvedTab, TabKey, resolveTabs } from './tabConfig';
 
 type TabName = 'search' | 'assistant' | 'brief' | 'heatmap' | 'documents' | 'pipeline' | 'processing' | 'info' | 'tech' | 'data' | 'privacy' | 'terms' | 'stats' | 'admin' | 'docs';
 
 interface NavTabsProps {
   activeTab: TabName;
   onTabChange: (tab: TabName) => void;
+  // Resolved per-group tab visibility/labels. When omitted, every main tab
+  // shows with its default label (stock behaviour).
+  tabs?: Record<TabKey, ResolvedTab>;
 }
 
 const ACTIVE_CLASS = 'nav-tab-active';
+const MAIN_TABS: TabKey[] = ['search', 'assistant', 'brief', 'heatmap'];
 
-export const NavTabs = ({ activeTab, onTabChange }: NavTabsProps) => {
+export const NavTabs = ({ activeTab, onTabChange, tabs }: NavTabsProps) => {
+  const resolved = tabs ?? resolveTabs(undefined);
   const [monitorDropdownOpen, setMonitorDropdownOpen] = useState(false);
   const monitorActive = activeTab === 'documents' || activeTab === 'pipeline' || activeTab === 'processing' || activeTab === 'stats';
 
@@ -29,32 +34,17 @@ export const NavTabs = ({ activeTab, onTabChange }: NavTabsProps) => {
 
   return (
     <nav className="nav-tabs">
-      <button
-        className={`nav-tab ${activeTab === 'search' ? ACTIVE_CLASS : ''}`}
-        onClick={() => onTabChange('search')}
-      >
-        Search
-      </button>
-      {ASSISTANT_ENABLED && (
-        <button
-          className={`nav-tab ${activeTab === 'assistant' ? ACTIVE_CLASS : ''}`}
-          onClick={() => onTabChange('assistant')}
-        >
-          Chat
-        </button>
+      {MAIN_TABS.map((key) =>
+        resolved[key].enabled ? (
+          <button
+            key={key}
+            className={`nav-tab ${activeTab === key ? ACTIVE_CLASS : ''}`}
+            onClick={() => onTabChange(key)}
+          >
+            {resolved[key].label}
+          </button>
+        ) : null,
       )}
-      <button
-        className={`nav-tab ${activeTab === 'brief' ? ACTIVE_CLASS : ''}`}
-        onClick={() => onTabChange('brief')}
-      >
-        Brief
-      </button>
-      <button
-        className={`nav-tab ${activeTab === 'heatmap' ? ACTIVE_CLASS : ''}`}
-        onClick={() => onTabChange('heatmap')}
-      >
-        Map
-      </button>
       <div className="dropdown-container nav-dropdown">
         <button
           className={`nav-tab nav-tab-dropdown ${monitorActive ? ACTIVE_CLASS : ''}`}

--- a/ui/frontend/src/components/layout/tabConfig.ts
+++ b/ui/frontend/src/components/layout/tabConfig.ts
@@ -1,0 +1,47 @@
+// Per-group feature-tab config: which main tabs are shown and their labels.
+// Sourced from /users/me/effective-settings (`.tabs`, merged across the user's
+// groups by the backend). Kept intentionally lightweight — it only controls tab
+// visibility and labels, not behaviour.
+
+export type TabKey = 'search' | 'assistant' | 'brief' | 'heatmap';
+
+export const TAB_KEYS: TabKey[] = ['search', 'assistant', 'brief', 'heatmap'];
+
+export const DEFAULT_TAB_LABELS: Record<TabKey, string> = {
+  search: 'Search',
+  assistant: 'Chat',
+  brief: 'Brief',
+  heatmap: 'Map',
+};
+
+export interface TabSetting {
+  enabled?: boolean;
+  label?: string | null;
+}
+
+export interface ResolvedTab {
+  enabled: boolean;
+  label: string;
+}
+
+export type TabsOverride = Partial<Record<TabKey, TabSetting>>;
+
+/**
+ * Resolve the effective per-tab config for the UI.
+ *
+ * `override` is the merged group setting (`effective-settings.tabs`). When it is
+ * absent (no group configured tabs) every tab defaults to **enabled** with its
+ * default label, preserving the stock behaviour. When present, a tab is shown
+ * only if it is enabled, using its override label (or the default if blank).
+ */
+export function resolveTabs(
+  override?: TabsOverride | null,
+): Record<TabKey, ResolvedTab> {
+  const out = {} as Record<TabKey, ResolvedTab>;
+  for (const key of TAB_KEYS) {
+    const entry = override ? override[key] : undefined;
+    const label = (entry?.label || '').trim() || DEFAULT_TAB_LABELS[key];
+    out[key] = { enabled: override ? Boolean(entry?.enabled) : true, label };
+  }
+  return out;
+}

--- a/ui/frontend/src/hooks/useGroupDefaults.ts
+++ b/ui/frontend/src/hooks/useGroupDefaults.ts
@@ -12,7 +12,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import API_BASE_URL from '../config';
-import type { SearchSettings } from '../types/auth';
+import type { SearchSettings, EffectiveSettings } from '../types/auth';
 
 /** Custom event name dispatched when admin saves group settings. */
 export const GROUP_SETTINGS_UPDATED_EVENT = 'groupSettingsUpdated';
@@ -63,8 +63,8 @@ export function useGroupDefaults(
   userModuleEnabled: boolean,
   authState: AuthState,
   setters: Setters,
-): SearchSettings | undefined {
-  const [groupDefaults, setGroupDefaults] = useState<SearchSettings | undefined>(undefined);
+): EffectiveSettings | undefined {
+  const [groupDefaults, setGroupDefaults] = useState<EffectiveSettings | undefined>(undefined);
   /** Bumped to trigger a re-fetch (e.g. after admin saves group settings). */
   const [refreshKey, setRefreshKey] = useState(0);
   /** Fingerprint of the last applied defaults to avoid re-applying identical data. */
@@ -86,7 +86,7 @@ export function useGroupDefaults(
       return;
     }
     try {
-      const resp = await axios.get<SearchSettings>(`${API_BASE_URL}/users/me/effective-settings`);
+      const resp = await axios.get<EffectiveSettings>(`${API_BASE_URL}/users/me/effective-settings`);
       const settings = resp.data;
       if (settings && Object.keys(settings).length > 0) {
         setGroupDefaults(settings);

--- a/ui/frontend/src/tests/tabConfig.test.ts
+++ b/ui/frontend/src/tests/tabConfig.test.ts
@@ -1,0 +1,43 @@
+import {
+  DEFAULT_TAB_LABELS,
+  TAB_KEYS,
+  resolveTabs,
+} from '../components/layout/tabConfig';
+
+describe('resolveTabs', () => {
+  it('defaults every tab to enabled with its default label when no override', () => {
+    const r = resolveTabs(undefined);
+    TAB_KEYS.forEach((k) => {
+      expect(r[k].enabled).toBe(true);
+      expect(r[k].label).toBe(DEFAULT_TAB_LABELS[k]);
+    });
+  });
+
+  it('respects per-tab enabled flags from the override', () => {
+    const r = resolveTabs({
+      search: { enabled: true },
+      assistant: { enabled: false },
+      brief: { enabled: true },
+      heatmap: { enabled: false },
+    });
+    expect(r.search.enabled).toBe(true);
+    expect(r.assistant.enabled).toBe(false);
+    expect(r.brief.enabled).toBe(true);
+    expect(r.heatmap.enabled).toBe(false);
+  });
+
+  it('uses the override label when set and the default when blank', () => {
+    const r = resolveTabs({
+      brief: { enabled: true, label: 'Briefings' },
+      search: { enabled: true, label: '   ' },
+    });
+    expect(r.brief.label).toBe('Briefings');
+    expect(r.search.label).toBe(DEFAULT_TAB_LABELS.search);
+  });
+
+  it('treats a present override as authoritative: a missing tab is disabled', () => {
+    const r = resolveTabs({ search: { enabled: true } });
+    expect(r.search.enabled).toBe(true);
+    expect(r.assistant.enabled).toBe(false);
+  });
+});

--- a/ui/frontend/src/types/auth.ts
+++ b/ui/frontend/src/types/auth.ts
@@ -31,6 +31,16 @@ export interface SearchSettings {
   greetingMessage?: string;
 }
 
+/**
+ * The full /users/me/effective-settings payload: search settings plus the
+ * per-group feature-tab visibility/labels (merged across the user's groups by
+ * the backend; see components/layout/tabConfig.ts). Kept separate from
+ * SearchSettings so `tabs` doesn't leak into the search-defaults setters.
+ */
+export interface EffectiveSettings extends SearchSettings {
+  tabs?: Record<string, { enabled?: boolean; label?: string | null }>;
+}
+
 export interface UserGroup {
   id: string;
   name: string;


### PR DESCRIPTION
**Draft — in progress.** Per-group toggles to show/hide the main tabs (Search, Chat, Brief, Map) and override their labels.

- **Backend:** `/users/me/effective-settings` unions a new `tabs` block stored in each group's `search_settings` — a tab is enabled if **any** of the user's groups enables it; its label comes from the first enabling group. Other settings keep first-non-null. (+unit tests)
- **Frontend (todo):** "Features & Tabs" section in `GroupSettingsManager` (checkbox + label per tab); `NavTabs`/`App` conditionally render + relabel via `tabConfig.resolveTabs`. No DB migration (reuses `search_settings` JSONB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)