### PR TITLE
fix(ui): embed table & figure screenshots in Word export

### DIFF
--- a/docs/using-evidence-lab/brief.md
+++ b/docs/using-evidence-lab/brief.md
@@ -93,7 +93,7 @@ The exported `.docx` is a polished, branded document titled **AI-generated Resea
 - A clickable **table of contents** that jumps to each heading (no "update fields" prompt on open).
 - An information box noting the content is AI-generated and should be verified.
 - The brief topic as the heading, followed by each section's text.
-- Inline citations linked to the source documents (and the cited page), plus a **References** list and a **Reference Excerpts** section with the supporting passages.
+- Inline citations linked to the source documents (and the cited page), plus a **References** list and a **Reference Excerpts** section with the supporting passages. Any tables or figures in those passages are embedded as the same images shown on screen, so they keep their original layout.
 
 ![The exported Word document](/docs/images/brief/brief-word-doc.png)
 

--- a/ui/frontend/src/components/ExportResultsButton.tsx
+++ b/ui/frontend/src/components/ExportResultsButton.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { saveAs } from 'file-saver';
+import API_BASE_URL from '../config';
 import type { SearchResult } from '../types/api';
 import {
   buildExportFilename,
@@ -57,6 +58,9 @@ export const ExportResultsButton: React.FC<ExportResultsButtonProps> = ({
           typeof window !== 'undefined' && window.location
             ? window.location.origin
             : undefined,
+        // Same API base the on-screen cards use to load table/figure
+        // screenshots, so the export embeds those exact images.
+        fileBaseUrl: API_BASE_URL,
       });
       saveAs(blob, buildExportFilename(query, new Date()));
     } catch (err) {

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -116,6 +116,9 @@ export const BriefTab: React.FC<BriefTabProps> = ({
         resultsSectionTitle: 'Reference Excerpts',
         siteOrigin:
           typeof window !== 'undefined' && window.location ? window.location.origin : undefined,
+        // Same API base the on-screen cards use to load table/figure
+        // screenshots, so the brief embeds those exact images.
+        fileBaseUrl: API_BASE_URL,
       });
       saveAs(blob, buildExportFilename(brief.briefTitle || 'evidence-brief', new Date()));
     } catch (err) {

--- a/ui/frontend/src/utils/__tests__/exportResultsToDocx.test.ts
+++ b/ui/frontend/src/utils/__tests__/exportResultsToDocx.test.ts
@@ -16,8 +16,10 @@ import {
   DOCX_MIME,
   buildExportFilename,
   exportResultsToDocxBlob,
+  fetchResultImages,
   markdownToParagraphs,
   resolveResultLink,
+  type ExportOptions,
 } from '../exportResultsToDocx';
 import { buildGroupedReferences, extractCitedNumbers } from '../citations';
 import type { SearchResult } from '../../types/api';
@@ -451,5 +453,170 @@ describe('exportResultsToDocxBlob', () => {
     expect(styles).toMatch(/Heading1[\s\S]*?w:val="40"/);
     expect(styles).toMatch(/Heading1[\s\S]*?w:val="5B8FA8"/);
     expect(styles).toMatch(/Heading2[\s\S]*?w:val="28"/);
+  });
+});
+
+describe('table & figure screenshots', () => {
+  // Fixed clock for deterministic timestamps; the exact value is irrelevant
+  // (no assertion depends on it) so we use an epoch number rather than repeat
+  // the date-string literal used elsewhere in this file.
+  const FIXED = new Date(1_745_312_700_000);
+
+  // 1×1 transparent PNG — valid enough to embed and to exercise byte-based
+  // dimension decoding (its IHDR header encodes a 1×1 image).
+  const PNG_1x1_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+  const pngArrayBuffer = (): ArrayBuffer => {
+    const buf = Buffer.from(PNG_1x1_BASE64, 'base64');
+    return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  };
+
+  /** A mock `fetch` that returns the 1×1 PNG (or fails) for the /file/ URL. */
+  const mockImageFetch = (mode: 'ok' | 'notfound' | 'reject' = 'ok') =>
+    jest.fn(async () => {
+      if (mode === 'reject') throw new Error('network down');
+      return {
+        ok: mode === 'ok',
+        arrayBuffer: async () => pngArrayBuffer(),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+
+  /** A result whose chunk contains a table screenshot plus the (redundant)
+   *  flattened cell text — mirrors what the on-screen card receives. */
+  const tableResult = (overrides: Partial<SearchResult> = {}): SearchResult =>
+    makeResult({
+      chunk_id: 'tbl',
+      doc_id: 'doc-tbl',
+      title: 'Strategic Evaluation with a Table',
+      page_num: 99,
+      text: 'Minimum 6 9 Maximum 26 9 Average 15 9',
+      chunk_elements: [
+        {
+          element_type: 'table',
+          image_path: '/data/uneg/tables/table_18.png',
+          image_size: [600, 300],
+          num_rows: 3,
+          num_cols: 3,
+          rows: [
+            [{ text: 'Minimum' }, { text: '6' }, { text: '9' }],
+            [{ text: 'Maximum' }, { text: '26' }, { text: '9' }],
+            [{ text: 'Average' }, { text: '15' }, { text: '9' }],
+          ],
+          page: 99,
+          position_hint: 1,
+        },
+      ],
+      ...overrides,
+    });
+
+  const exportOpts = (over: Partial<ExportOptions> = {}): ExportOptions => ({
+    query: 'tables',
+    results: [tableResult()],
+    now: () => FIXED,
+    fileBaseUrl: '/api',
+    fetchFn: mockImageFetch(),
+    ...over,
+  });
+
+  const mediaFiles = (zip: JSZip): string[] =>
+    Object.keys(zip.files).filter((n) => n.startsWith('word/media/'));
+
+  const unzipDoc = async (blob: Blob): Promise<string> => {
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    return zip.file('word/document.xml')!.async('string');
+  };
+
+  test('embeds the table screenshot as an image in the docx', async () => {
+    const zip = await JSZip.loadAsync(
+      await (await exportResultsToDocxBlob(exportOpts())).arrayBuffer(),
+    );
+    expect(mediaFiles(zip).length).toBeGreaterThan(0);
+  });
+
+  test('fetches the screenshot from the same /file/ URL the card uses', async () => {
+    const fetchFn = mockImageFetch();
+    await exportResultsToDocxBlob(exportOpts({ fetchFn }));
+    expect(fetchFn).toHaveBeenCalledWith('/api/file/data/uneg/tables/table_18.png');
+  });
+
+  test('drops the redundant flattened table text when the screenshot is embedded', async () => {
+    const xml = await unzipDoc(await exportResultsToDocxBlob(exportOpts()));
+    expect(xml).toContain('Strategic Evaluation with a Table'); // title kept
+    expect(xml).not.toContain('Maximum 26'); // mangled table text suppressed
+  });
+
+  test('skips a screenshot that fails to fetch but still produces the document', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const blob = await exportResultsToDocxBlob(
+      exportOpts({ fetchFn: mockImageFetch('reject') }),
+    );
+    expect(blob.type).toBe(DOCX_MIME);
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    expect(mediaFiles(zip).length).toBe(0);
+    // With no image embedded, the text is no longer redundant and falls back in,
+    // so the reader still gets the table content (as text) rather than nothing.
+    expect(await unzipDoc(blob)).toContain('Maximum 26');
+    warn.mockRestore();
+  });
+
+  test('skips a 404 screenshot without throwing', async () => {
+    const blob = await exportResultsToDocxBlob(
+      exportOpts({ fetchFn: mockImageFetch('notfound') }),
+    );
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    expect(mediaFiles(zip).length).toBe(0);
+  });
+
+  test('fetchResultImages returns empty when no fileBaseUrl is set', async () => {
+    const map = await fetchResultImages({ query: 'x', results: [tableResult()] });
+    expect(map.size).toBe(0);
+  });
+
+  test('fetchResultImages decodes the type and scales the size to fit the page', async () => {
+    const map = await fetchResultImages(exportOpts());
+    const img = map.get('data/uneg/tables/table_18.png');
+    expect(img).toBeDefined();
+    expect(img!.type).toBe('png');
+    // image_size [600, 300] is exactly the max width, so it is kept at 2:1.
+    expect(img!.width).toBe(600);
+    expect(img!.height).toBe(300);
+  });
+
+  test('embeds a referenced figure screenshot too (sized from decoded bytes)', async () => {
+    const result = makeResult({
+      chunk_id: 'fig',
+      doc_id: 'doc-fig',
+      title: 'Report With A Figure',
+      page_num: 5,
+      text: 'See Figure 2 for details.',
+      chunk_elements: [
+        {
+          element_type: 'text',
+          text: 'See Figure 2 for details.',
+          label: 'text',
+          page: 5,
+          position_hint: 0,
+        },
+        {
+          element_type: 'image',
+          path: '/data/uneg/figs/figure-2.png',
+          bbox: [0, 0, 300, 200],
+          page: 5,
+          position_hint: 1,
+        },
+      ],
+    });
+    const fetchFn = mockImageFetch();
+    const blob = await exportResultsToDocxBlob({
+      query: 'figs',
+      results: [result],
+      now: () => FIXED,
+      fileBaseUrl: '/api',
+      fetchFn,
+    });
+    expect(fetchFn).toHaveBeenCalledWith('/api/file/data/uneg/figs/figure-2.png');
+    const zip = await JSZip.loadAsync(await blob.arrayBuffer());
+    expect(mediaFiles(zip).length).toBeGreaterThan(0);
   });
 });

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -2,9 +2,12 @@
  * Client-side generator for a nicely-formatted Word (.docx) export of a
  * search result set, including the AI summary.
  *
- * The export is produced entirely in the browser using the `docx` package —
- * no backend round-trip is required. The resulting Blob can be handed to
- * `file-saver`'s `saveAs` for download.
+ * The export is produced in the browser using the `docx` package. The only
+ * backend round-trip is fetching the table / figure screenshots shown on
+ * screen (from `<fileBaseUrl>/file/<path>`) so they can be embedded in the
+ * document; with no `fileBaseUrl` the export is fully client-side and
+ * text-only. The resulting Blob can be handed to `file-saver`'s `saveAs` for
+ * download.
  *
  * Design goals (see also the unit tests):
  *  - Cover page with query, dataset, timestamp, and result count.
@@ -22,6 +25,7 @@ import {
   ExternalHyperlink,
   Footer,
   HeadingLevel,
+  ImageRun,
   InternalHyperlink,
   LevelFormat,
   Packer,
@@ -32,7 +36,11 @@ import {
   TextRun,
   convertInchesToTwip,
 } from 'docx';
-import type { SearchResult } from '../types/api';
+import type { ChunkElement, SearchResult } from '../types/api';
+import {
+  buildOrderedElements,
+  isTextRedundantWithTable,
+} from '../components/searchResultCardUtils';
 import {
   buildCitationSequenceMap,
   buildGroupedReferences,
@@ -68,6 +76,15 @@ export interface ExportOptions {
    *  built from real content (internal links to heading bookmarks), not a Word
    *  field, so opening the document never prompts to update fields. */
   tableOfContents?: boolean;
+  /** Base URL of the file-serving API (e.g. "/api"), used to fetch the table /
+   *  figure screenshots shown on screen so they can be embedded in the export.
+   *  When omitted, no screenshots are fetched and the export is text-only —
+   *  this preserves the prior behaviour and keeps SSR / unit tests that don't
+   *  exercise images simple. */
+  fileBaseUrl?: string;
+  /** Injectable fetch implementation for deterministic tests. Defaults to the
+   *  global `fetch` (bound to `globalThis`). */
+  fetchFn?: typeof fetch;
 }
 
 /** MIME type for a .docx file — exported so the call-site can set it on Blobs
@@ -366,6 +383,235 @@ const extractMarkdownHeadings = (md: string): { text: string; depth: number }[] 
 };
 
 // ---------------------------------------------------------------------------
+// Table / figure screenshots
+//
+// The on-screen search card renders any table or figure in a result as the
+// low-resolution screenshot the pipeline extracted (served from
+// `<fileBaseUrl>/file/<path>`). The text-only export mangled tables — a table's
+// cell text was flattened into one paragraph. We now fetch those exact images
+// and embed them with docx `ImageRun`, matching what the user sees on screen.
+// ---------------------------------------------------------------------------
+
+/** A screenshot fetched and ready for embedding. */
+export interface FetchedImage {
+  /** Raw image bytes. A `Uint8Array` (not a bare `ArrayBuffer`) is what docx's
+   *  packer reliably embeds — it matches the `Buffer` shape `fs.readFileSync`
+   *  yields in the library's own examples. */
+  data: Uint8Array;
+  /** docx-supported raster type, derived from the file extension. */
+  type: 'png' | 'jpg' | 'gif' | 'bmp';
+  /** Display size in px, already scaled to fit the page content width. */
+  width: number;
+  height: number;
+}
+
+/** Max embedded image width (~6 in at 96 dpi) so a screenshot fits the page
+ *  content box without overflowing the margins. We never upscale past the
+ *  image's natural width. */
+const MAX_IMAGE_WIDTH_PX = 600;
+
+/** File extension → docx raster type. A Map (not an object) sidesteps the
+ *  `security/detect-object-injection` lint warning on dynamic key access. */
+const IMAGE_TYPE_BY_EXT = new Map<string, FetchedImage['type']>([
+  ['png', 'png'],
+  ['jpg', 'jpg'],
+  ['jpeg', 'jpg'],
+  ['gif', 'gif'],
+  ['bmp', 'bmp'],
+]);
+
+/** Strip a leading slash so the path matches the on-screen `<img>` src and can
+ *  be appended to `<fileBaseUrl>/file/`. */
+const normaliseImagePath = (p?: string): string | undefined => {
+  const trimmed = p?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
+};
+
+/** The screenshot path for a table/figure element (image_path for tables, path
+ *  for figures) — identical to what the on-screen renderer uses. */
+const visualElementPath = (el: ChunkElement): string | undefined =>
+  normaliseImagePath(el.image_path || el.path);
+
+/** The table/figure elements shown on screen for a result, in document order.
+ *  Reuses the exact same selection/ordering as the search card so the export
+ *  stays in lock-step with what the user sees. */
+const visualElementsFor = (
+  result: SearchResult,
+): Array<ChunkElement & { key: string }> =>
+  buildOrderedElements(result).filter(
+    (el) => el.element_type === 'table' || el.element_type === 'image',
+  );
+
+/** docx image type for a path, or null for types `ImageRun` cannot embed
+ *  (e.g. webp, svg). */
+const imageTypeForPath = (path: string): FetchedImage['type'] | null => {
+  const ext = path.split('.').pop()?.toLowerCase() ?? '';
+  return IMAGE_TYPE_BY_EXT.get(ext) ?? null;
+};
+
+/** Natural [width, height] from a PNG's IHDR header, or null. */
+const pngDimensions = (view: DataView): [number, number] | null =>
+  view.byteLength >= 24 && view.getUint32(0) === 0x89504e47
+    ? [view.getUint32(16), view.getUint32(20)]
+    : null;
+
+/** Natural [width, height] from a JPEG SOF marker, or null. */
+const jpegDimensions = (view: DataView): [number, number] | null => {
+  if (view.byteLength < 4 || view.getUint16(0) !== 0xffd8) return null;
+  let offset = 2;
+  while (offset + 9 < view.byteLength) {
+    if (view.getUint8(offset) !== 0xff) {
+      offset += 1;
+      continue;
+    }
+    const marker = view.getUint8(offset + 1);
+    const isSof =
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      marker !== 0xc4 &&
+      marker !== 0xc8 &&
+      marker !== 0xcc;
+    if (isSof) return [view.getUint16(offset + 7), view.getUint16(offset + 5)];
+    offset += 2 + view.getUint16(offset + 2);
+  }
+  return null;
+};
+
+/** Decode natural pixel dimensions from raw image bytes (PNG/JPEG). */
+const naturalDimensions = (data: Uint8Array): [number, number] | null => {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  return pngDimensions(view) ?? jpegDimensions(view);
+};
+
+/** Scale natural dimensions to fit {@link MAX_IMAGE_WIDTH_PX}, preserving the
+ *  aspect ratio and never upscaling. */
+const fitToPage = (w: number, h: number): { width: number; height: number } => {
+  if (w <= 0 || h <= 0) {
+    return { width: MAX_IMAGE_WIDTH_PX, height: Math.round(MAX_IMAGE_WIDTH_PX * 0.75) };
+  }
+  const width = Math.min(w, MAX_IMAGE_WIDTH_PX);
+  return { width: Math.round(width), height: Math.round(h * (width / w)) };
+};
+
+/** Best available display size: the element's stored `image_size` (tables carry
+ *  it), else dimensions decoded from the bytes (figures), else the bbox aspect
+ *  ratio. */
+const displaySizeFor = (
+  el: ChunkElement,
+  data: Uint8Array,
+): { width: number; height: number } => {
+  const size = el.image_size;
+  if (Array.isArray(size) && size.length >= 2 && size[0] > 0 && size[1] > 0) {
+    return fitToPage(size[0], size[1]);
+  }
+  const decoded = naturalDimensions(data);
+  if (decoded) return fitToPage(decoded[0], decoded[1]);
+  const bbox = el.bbox;
+  if (Array.isArray(bbox) && bbox.length >= 4) {
+    return fitToPage(bbox[2] - bbox[0], bbox[3] - bbox[1]);
+  }
+  return fitToPage(0, 0);
+};
+
+/** Fetch and decode a single screenshot. Returns null (and warns) when the
+ *  image is missing, unfetchable, or an unembeddable type — the caller skips it
+ *  and still produces the document, mirroring the on-screen `onError` that
+ *  hides a broken thumbnail. */
+const fetchVisualImage = async (
+  el: ChunkElement,
+  path: string,
+  fileBaseUrl: string,
+  fetchFn: typeof fetch,
+): Promise<FetchedImage | null> => {
+  const type = imageTypeForPath(path);
+  if (!type) return null;
+  try {
+    const res = await fetchFn(`${fileBaseUrl.replace(/\/+$/, '')}/file/${path}`);
+    if (!res.ok) return null;
+    const data = new Uint8Array(await res.arrayBuffer());
+    const { width, height } = displaySizeFor(el, data);
+    return { data, type, width, height };
+  } catch (err) {
+    console.warn('Export to Word: could not fetch screenshot', path, err);
+    return null;
+  }
+};
+
+/** Fetch every table/figure screenshot shown across the result set, de-duped by
+ *  path so each image is fetched once. Returns an empty map when no
+ *  `fileBaseUrl` is configured (e.g. SSR / tests), leaving the export
+ *  text-only. */
+export const fetchResultImages = async (
+  opts: ExportOptions,
+): Promise<Map<string, FetchedImage>> => {
+  const out = new Map<string, FetchedImage>();
+  const { fileBaseUrl } = opts;
+  if (!fileBaseUrl) return out;
+  const fetchFn =
+    opts.fetchFn ??
+    (typeof fetch !== 'undefined' ? (fetch.bind(globalThis) as typeof fetch) : undefined);
+  if (!fetchFn) return out;
+
+  // De-dupe across results so each unique screenshot is fetched only once.
+  const unique = new Map<string, ChunkElement>();
+  for (const result of opts.results) {
+    for (const el of visualElementsFor(result)) {
+      const path = visualElementPath(el);
+      if (path && !unique.has(path)) unique.set(path, el);
+    }
+  }
+  await Promise.all(
+    Array.from(unique.entries()).map(async ([path, el]) => {
+      const img = await fetchVisualImage(el, path, fileBaseUrl, fetchFn);
+      if (img) out.set(path, img);
+    }),
+  );
+  return out;
+};
+
+/** Paragraphs embedding each successfully-fetched screenshot for a result, in
+ *  document order. Images that failed to fetch are simply absent. */
+const buildResultImageParagraphs = (
+  result: SearchResult,
+  images: Map<string, FetchedImage>,
+): Paragraph[] => {
+  const out: Paragraph[] = [];
+  for (const el of visualElementsFor(result)) {
+    const path = visualElementPath(el);
+    const img = path ? images.get(path) : undefined;
+    if (!img) continue;
+    out.push(
+      new Paragraph({
+        alignment: AlignmentType.CENTER,
+        spacing: { after: 120 },
+        children: [
+          new ImageRun({
+            type: img.type,
+            data: img.data,
+            transformation: { width: img.width, height: img.height },
+          }),
+        ],
+      }),
+    );
+  }
+  return out;
+};
+
+/** True when an embedded table screenshot makes the chunk text redundant — we
+ *  then drop the (mangled) text box so the screenshot stands in its place,
+ *  exactly as the on-screen card hides the redundant snippet. */
+const tableScreenshotReplacesText = (
+  result: SearchResult,
+  images: Map<string, FetchedImage>,
+): boolean =>
+  visualElementsFor(result).some((el) => {
+    if (el.element_type !== 'table') return false;
+    const path = visualElementPath(el);
+    return !!path && images.has(path) && isTextRedundantWithTable(result.text, el);
+  });
+
+// ---------------------------------------------------------------------------
 // Builders — one per section of the docx
 // ---------------------------------------------------------------------------
 
@@ -529,11 +775,42 @@ const buildSummarySection = (
   return out;
 };
 
+/** The FULL excerpt (never truncated) rendered as a single bordered, shaded box
+ *  at a smaller font — one paragraph so the box stays continuous across page
+ *  breaks, with blank lines separating sub-blocks. Returns nothing when there is
+ *  no text, or when an embedded table screenshot already conveys it (the
+ *  on-screen card hides the redundant snippet the same way). */
+const buildExcerptParagraphs = (
+  r: SearchResult,
+  images: Map<string, FetchedImage>,
+): Paragraph[] => {
+  const blocks = normaliseExcerpt(String(r.text || ''))
+    .split(/\n{2,}/)
+    .map((b) => b.split('\n').join(' ').trim())
+    .filter(Boolean);
+  if (!blocks.length || tableScreenshotReplacesText(r, images)) return [];
+  const excerptRuns: TextRun[] = [];
+  blocks.forEach((b, i) => {
+    if (i > 0) excerptRuns.push(new TextRun({ break: 2 }));
+    excerptRuns.push(new TextRun({ text: b, italics: true, size: 18, color: '3A3A3A' }));
+  });
+  const boxSide = { style: BorderStyle.SINGLE, size: 4, color: 'D7DCE1', space: 8 };
+  return [
+    new Paragraph({
+      shading: { type: ShadingType.CLEAR, color: 'auto', fill: 'F6F8FA' },
+      border: { top: boxSide, bottom: boxSide, left: boxSide, right: boxSide },
+      spacing: { after: 160, line: 252 },
+      children: excerptRuns,
+    }),
+  ];
+};
+
 const buildResultCard = (
   r: SearchResult,
   idx: number,
   siteOrigin: string,
-  dataSource?: string,
+  dataSource: string | undefined,
+  images: Map<string, FetchedImage>,
 ): Paragraph[] => {
   const out: Paragraph[] = [];
   const altTitle = typeof r.document_title === 'string' ? r.document_title : '';
@@ -583,30 +860,11 @@ const buildResultCard = (
     );
   }
 
-  // Render the FULL excerpt (never truncated) inside a single bordered, shaded
-  // box at a smaller font. One paragraph guarantees a single continuous box
-  // that still flows across page breaks; blank lines separate any sub-blocks.
-  const excerpt = normaliseExcerpt(String(r.text || ''));
-  const blocks = excerpt
-    .split(/\n{2,}/)
-    .map((b) => b.split('\n').join(' ').trim())
-    .filter(Boolean);
-  if (blocks.length) {
-    const excerptRuns: TextRun[] = [];
-    blocks.forEach((b, i) => {
-      if (i > 0) excerptRuns.push(new TextRun({ break: 2 }));
-      excerptRuns.push(new TextRun({ text: b, italics: true, size: 18, color: '3A3A3A' }));
-    });
-    const boxSide = { style: BorderStyle.SINGLE, size: 4, color: 'D7DCE1', space: 8 };
-    out.push(
-      new Paragraph({
-        shading: { type: ShadingType.CLEAR, color: 'auto', fill: 'F6F8FA' },
-        border: { top: boxSide, bottom: boxSide, left: boxSide, right: boxSide },
-        spacing: { after: 160, line: 252 },
-        children: excerptRuns,
-      }),
-    );
-  }
+  // Embed the same table/figure screenshots shown on screen, in document order,
+  // so a table renders as its image rather than mangled, flattened cell text,
+  // followed by the FULL excerpt (unless a screenshot already conveys it).
+  out.push(...buildResultImageParagraphs(r, images));
+  out.push(...buildExcerptParagraphs(r, images));
 
   out.push(
     new Paragraph({
@@ -626,8 +884,9 @@ const buildResultCard = (
 const buildResultsSection = (
   results: SearchResult[],
   siteOrigin: string,
-  dataSource?: string,
+  dataSource: string | undefined,
   sectionTitle = 'Search Results',
+  images: Map<string, FetchedImage> = new Map(),
 ): Paragraph[] => {
   const out: Paragraph[] = [];
   out.push(
@@ -638,7 +897,7 @@ const buildResultsSection = (
     }),
   );
   results.forEach((r, idx) => {
-    out.push(...buildResultCard(r, idx, siteOrigin, dataSource));
+    out.push(...buildResultCard(r, idx, siteOrigin, dataSource, images));
   });
   return out;
 };
@@ -650,7 +909,10 @@ const buildResultsSection = (
 /** Build the in-memory `docx` Document for the given export options. Exposed
  *  separately from {@link exportResultsToDocxBlob} to allow unit tests to
  *  introspect the document structure without packing a Blob. */
-export const buildExportDocument = (opts: ExportOptions): Document => {
+export const buildExportDocument = (
+  opts: ExportOptions,
+  images: Map<string, FetchedImage> = new Map(),
+): Document => {
   const now = (opts.now ?? (() => new Date()))();
   const siteOrigin = opts.siteOrigin || 'https://evidencelab.ai';
 
@@ -671,6 +933,7 @@ export const buildExportDocument = (opts: ExportOptions): Document => {
       siteOrigin,
       opts.dataSource,
       opts.resultsSectionTitle,
+      images,
     ),
   ];
 
@@ -743,9 +1006,13 @@ export const buildExportDocument = (opts: ExportOptions): Document => {
   });
 };
 
-/** Serialise the export to a Word-compatible Blob. */
+/** Serialise the export to a Word-compatible Blob. Table / figure screenshots
+ *  are fetched first (when `fileBaseUrl` is set) so they can be embedded
+ *  in-document; a screenshot that fails to fetch is skipped, never aborting the
+ *  export. */
 export const exportResultsToDocxBlob = async (opts: ExportOptions): Promise<Blob> => {
-  const doc = buildExportDocument(opts);
+  const images = await fetchResultImages(opts);
+  const doc = buildExportDocument(opts, images);
   const blob = await Packer.toBlob(doc);
   // docx's Packer returns a Blob with the generic zip MIME — override so
   // consumers (and tests) see the Word-specific type.


### PR DESCRIPTION
## Description

Issue **339556**. In Search (and Brief) results, a chunk containing a table is shown on screen as the low-resolution **screenshot** the pipeline extracted. But **Export to Word** rendered the chunk's `text` instead — which for a table is just the cell values flattened together — so the table's structure was mangled in the `.docx`.

This change fetches the **same screenshot shown on screen** (from `<fileBaseUrl>/file/<path>`) and embeds it into the Word document via docx `ImageRun`, so tables and figures keep their original layout. When a table screenshot is embedded and the chunk text merely repeats it, the redundant (mangled) text box is dropped — mirroring how the on-screen card hides the redundant snippet.

**How it works**
- `fetchResultImages()` pre-fetches every table/figure screenshot across the result set, reusing the **exact** on-screen `buildOrderedElements()` selection so the export stays in lock-step with the UI. Images are de-duped, typed from the file extension, and sized from the table's `image_size` (or decoded PNG/JPEG headers for figures), scaled to fit the page width without upscaling.
- `buildResultCard` embeds the images in document order; `buildExcerptParagraphs` suppresses the redundant text.
- `fileBaseUrl` is wired from both `ExportResultsButton` (Search) and `BriefTab` (Brief), using the same API base the cards use — so **both** exports benefit.
- A screenshot that 404s or is an unembeddable type is **skipped** (the export still produces, with the text falling back in) — matching the on-screen `onError` behavior that hides a broken thumbnail.

Reuses the existing path-validated `GET /file/{path}` endpoint — no new endpoints, no new dependencies (docx `ImageRun` already available).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other: ___

## Testing
- [x] Tests pass locally — full frontend suite **513/513**; export suites **47/47**
- [x] New tests added — embedding, `/file/` URL, redundant-text suppression, fetch-failure & 404 skip-but-still-produce, referenced figures, sizing/no-`fileBaseUrl`
- [x] Manual testing completed — verified a WFP table result exports with the table rendered as its on-screen image (see issue screenshots)

## Checklist
- [x] Code follows project style guidelines — `tsc` clean; ESLint introduces **0 new** findings (only pre-existing warnings remain); pre-commit hooks pass (file hygiene, detect-secrets, gitleaks, code-metrics)
- [x] Complexity within limits — max cognitive complexity **13** (refactored `buildResultCard` back under the ≤15 target after the change nudged it to 16)
- [x] Self-review of code completed
- [x] Documentation updated — `docs/using-evidence-lab/brief.md` notes tables/figures embed as images
- [x] No breaking changes