### PR TITLE
fix(ui): sort country filters alphabetically in search and heatmapper

### DIFF
--- a/ui/frontend/src/components/filters/FilterComponents.tsx
+++ b/ui/frontend/src/components/filters/FilterComponents.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Facets, FacetValue, RangeInfo } from '../../types/api';
+import { orderFacetValuesForDisplay } from '../../utils/facetMerge';
 
 interface SelectedFiltersDisplayProps {
   facets: Facets;
@@ -230,7 +231,7 @@ const computeDisplayItems = (
   }
 
   if (facetSearchResults[coreField]) {
-    const results = facetSearchResults[coreField];
+    const results = orderFacetValuesForDisplay(coreField, facetSearchResults[coreField]);
     const remaining = results.length - defaultDisplayCount;
     return {
       displayItems: isExpanded ? results : results.slice(0, defaultDisplayCount),
@@ -238,8 +239,9 @@ const computeDisplayItems = (
     };
   }
 
-  const filteredItems = facetValues.filter((item) =>
-    item.value.toLowerCase().includes(searchTerm)
+  const filteredItems = orderFacetValuesForDisplay(
+    coreField,
+    facetValues.filter((item) => item.value.toLowerCase().includes(searchTerm))
   );
   const remaining = filteredItems.length - defaultDisplayCount;
   return {

--- a/ui/frontend/src/utils/__tests__/facetMerge.test.ts
+++ b/ui/frontend/src/utils/__tests__/facetMerge.test.ts
@@ -15,6 +15,7 @@ import {
   countFieldValues,
   extractFieldValues,
   mergeFacetField,
+  orderFacetValuesForDisplay,
   resolveMetaKey,
 } from '../facetMerge';
 import type { FacetValue, SearchResult } from '../../types/api';
@@ -188,5 +189,47 @@ describe('mergeFacetField', () => {
       new Map([['Hit', 7]]),
     );
     expect(merged.map((m) => m.value)).toEqual(['Hit', 'Zero']);
+  });
+});
+
+describe('orderFacetValuesForDisplay', () => {
+  test('country values when count-ordered then alphabetised by value', () => {
+    const values: FacetValue[] = [
+      { value: 'Zimbabwe', count: 90 },
+      { value: 'Afghanistan', count: 50 },
+      { value: 'Kenya', count: 70 },
+    ];
+    const ordered = orderFacetValuesForDisplay('country', values);
+    expect(ordered.map((v) => v.value)).toEqual(['Afghanistan', 'Kenya', 'Zimbabwe']);
+  });
+
+  test('country alphabetising preserves each value count', () => {
+    const values: FacetValue[] = [
+      { value: 'Kenya', count: 70 },
+      { value: 'Afghanistan', count: 50 },
+    ];
+    const ordered = orderFacetValuesForDisplay('country', values);
+    expect(ordered).toEqual([
+      { value: 'Afghanistan', count: 50 },
+      { value: 'Kenya', count: 70 },
+    ]);
+  });
+
+  test('non-country field when called then order unchanged', () => {
+    const values: FacetValue[] = [
+      { value: 'Report', count: 90 },
+      { value: 'Evaluation', count: 50 },
+    ];
+    const ordered = orderFacetValuesForDisplay('document_type', values);
+    expect(ordered.map((v) => v.value)).toEqual(['Report', 'Evaluation']);
+  });
+
+  test('country sorting when given input then does not mutate it', () => {
+    const values: FacetValue[] = [
+      { value: 'Zimbabwe', count: 90 },
+      { value: 'Afghanistan', count: 50 },
+    ];
+    orderFacetValuesForDisplay('country', values);
+    expect(values.map((v) => v.value)).toEqual(['Zimbabwe', 'Afghanistan']);
   });
 });

--- a/ui/frontend/src/utils/facetMerge.ts
+++ b/ui/frontend/src/utils/facetMerge.ts
@@ -96,3 +96,25 @@ export const mergeFacetField = (
   });
   return merged;
 };
+
+/** Core facet fields whose filter values are always displayed in
+ *  alphabetical order rather than by count. Country lists are long and
+ *  count order makes them hard to scan or to spot near-duplicate names,
+ *  so we sort A→Z instead. */
+const ALPHABETICAL_FACET_FIELDS = new Set(['country']);
+
+/** Order facet values for display.
+ *
+ *  For fields in {@link ALPHABETICAL_FACET_FIELDS} (currently `country`),
+ *  returns a new array sorted alphabetically by display value. All other
+ *  fields are returned unchanged, preserving the upstream (count-based)
+ *  order. Used as the final display gate so both the Search sidebar and
+ *  the Heatmapper filter modal — which share this code path — show
+ *  country filters alphabetically. */
+export const orderFacetValuesForDisplay = (
+  coreField: string,
+  values: FacetValue[],
+): FacetValue[] =>
+  ALPHABETICAL_FACET_FIELDS.has(coreField)
+    ? [...values].sort((a, b) => a.value.localeCompare(b.value))
+    : values;


### PR DESCRIPTION
## Description

Country filter lists were ordered by document count, which made the long
lists hard to scan and near-duplicate country names easy to miss. This sorts
the **country** filter alphabetically (A→Z) in both places it appears:

- **Search** sidebar filters
- **Heatmapper / map** filter modal

Both features render their filters through the shared `FilterSections`
component, which funnels every field through `computeDisplayItems`. The sort is
applied there via a small, tested helper (`orderFacetValuesForDisplay`) so a
single change covers both surfaces. All other facet fields keep their existing
count-based ordering.

### Implementation
- `ui/frontend/src/utils/facetMerge.ts` — new `orderFacetValuesForDisplay(coreField, values)` helper; alphabetises only fields in `ALPHABETICAL_FACET_FIELDS` (currently `country`), returns a new array (no mutation), leaves all other fields untouched.
- `ui/frontend/src/components/filters/FilterComponents.tsx` — apply the helper at the display gate (`computeDisplayItems`), covering both the typed-search-results and default branches.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other: ___

## Testing
- [x] Tests pass locally
- [x] New tests added for new functionality
- [ ] Manual testing completed

Verification performed:
- `npm test --testPathPattern=facetMerge` → 22 passed (4 new tests covering country alphabetisation, count preservation, non-country pass-through, and no-mutation).
- `tsc --noEmit` → clean.
- `code_metrics.py --fail-on-bad --skip-js-cognitive` → Passed.
- ESLint → 0 new errors (only pre-existing object-injection warnings).

Note: not yet click-tested in a running UI against a live data source — the change is unit-tested at the sort-logic level and the shared render path is confirmed.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [ ] Documentation updated (no user-facing docs affected)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)