### PR TITLE
fix(ui): drop hallucinated AI-summary citations with no backing source

### DIFF
--- a/ui/frontend/src/components/AiSummaryWithCitations.tsx
+++ b/ui/frontend/src/components/AiSummaryWithCitations.tsx
@@ -308,7 +308,7 @@ export const AiSummaryWithCitations: React.FC<AiSummaryWithCitationsProps> = ({
   findOutMoreActiveFact,
 }) => {
   const cleanedText = stripTrailingBoilerplate(summaryText);
-  const citationMapping = buildCitationSequenceMap(cleanedText);
+  const citationMapping = buildCitationSequenceMap(cleanedText, searchResults);
   const blocks = splitSummaryBlocks(cleanedText);
   // Track across all blocks so only the very first heading gets the button
   let isFirstHeadingGlobal = true;

--- a/ui/frontend/src/tests/aiSummaryCitations.test.tsx
+++ b/ui/frontend/src/tests/aiSummaryCitations.test.tsx
@@ -1,0 +1,45 @@
+/**
+ * Regression test for the "fake references" bug: the AI summary must never
+ * render a citation number that has no backing search result. The LLM
+ * occasionally emits an out-of-range marker (e.g. `[2]` when only one result
+ * exists); such markers must be dropped, not shown as bare numbers.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { AiSummaryWithCitations } from '../components/AiSummaryWithCitations';
+import { SearchResult } from '../types/api';
+
+const makeResults = (n: number): SearchResult[] =>
+  Array.from({ length: n }, (_, i) => ({
+    chunk_id: `c${i + 1}`,
+    doc_id: `d${i + 1}`,
+    text: `text ${i + 1}`,
+    page_num: i + 1,
+    headings: [],
+    score: 1,
+    title: `Doc ${i + 1}`,
+  }));
+
+describe('AiSummaryWithCitations — hallucinated citations', () => {
+  test('renders real citations but drops out-of-range markers', () => {
+    // Only one result exists, so [1] is real and [2] is hallucinated.
+    const summary =
+      'Privacy gaps exist at country level [1]. Enforcement is inconsistent [2].';
+    const { container } = render(
+      <AiSummaryWithCitations
+        summaryText={summary}
+        searchResults={makeResults(1)}
+        onResultClick={() => undefined}
+      />,
+    );
+
+    const badges = container.querySelectorAll('.ai-summary-citation');
+    expect(badges).toHaveLength(1);
+    expect(badges[0].textContent).toBe('1');
+
+    // The orphan number must not survive anywhere in the rendered output,
+    // while the surrounding prose is preserved.
+    expect(container.textContent).toContain('Enforcement is inconsistent');
+    expect(container.textContent).not.toContain('2');
+  });
+});

--- a/ui/frontend/src/utils/__tests__/citations.test.ts
+++ b/ui/frontend/src/utils/__tests__/citations.test.ts
@@ -6,8 +6,22 @@
 import {
   buildCitationSequenceMap,
   extractCitedNumbers,
+  extractValidCitedNumbers,
   parseCitationNumbers,
 } from '../citations';
+import { SearchResult } from '../../types/api';
+
+/** Build `n` minimal search results so citation numbers `1..n` resolve. */
+const makeResults = (n: number): SearchResult[] =>
+  Array.from({ length: n }, (_, i) => ({
+    chunk_id: `c${i + 1}`,
+    doc_id: `d${i + 1}`,
+    text: `text ${i + 1}`,
+    page_num: i + 1,
+    headings: [],
+    score: 1,
+    title: `Doc ${i + 1}`,
+  }));
 
 describe('parseCitationNumbers', () => {
   test('parses a single number', () => {
@@ -29,25 +43,70 @@ describe('extractCitedNumbers', () => {
   });
 });
 
+describe('extractValidCitedNumbers', () => {
+  test('keeps only numbers that resolve to a search result', () => {
+    // 12 results → [8] and [10] are real; [19] is a hallucinated marker.
+    expect(
+      extractValidCitedNumbers('a [8] b [19] c [10]', makeResults(12)),
+    ).toEqual([8, 10]);
+  });
+  test('drops numbers below 1 and above the result count', () => {
+    expect(extractValidCitedNumbers('x [0] y [2] z [99]', makeResults(3))).toEqual([
+      2,
+    ]);
+  });
+  test('returns [] when no cited number resolves', () => {
+    expect(extractValidCitedNumbers('only [5]', makeResults(2))).toEqual([]);
+  });
+});
+
 describe('buildCitationSequenceMap', () => {
-  test('maps each original number to its 1-based sequential position', () => {
+  test('maps each valid original number to its 1-based sequential position', () => {
     // Non-contiguous indices 2, 5, 9 renumber to 1, 2, 3 — the exact mapping
     // the on-screen summary applies and the docx export must mirror.
-    const map = buildCitationSequenceMap('a [9] b [2] c [5]');
+    const map = buildCitationSequenceMap('a [9] b [2] c [5]', makeResults(9));
     expect(map.get(2)).toBe(1);
     expect(map.get(5)).toBe(2);
     expect(map.get(9)).toBe(3);
     expect(map.size).toBe(3);
   });
   test('is an identity map when citations are already contiguous from 1', () => {
-    const map = buildCitationSequenceMap('a [1] b [2] c [3]');
+    const map = buildCitationSequenceMap('a [1] b [2] c [3]', makeResults(3));
     expect([...map.entries()]).toEqual([
       [1, 1],
       [2, 2],
       [3, 3],
     ]);
   });
+  test('excludes hallucinated numbers so they get no display slot', () => {
+    // Regression for the "fake references" bug: [19] has no backing result, so
+    // it must not enter the map and must not consume a sequence slot — the real
+    // citations [8] and [10] renumber cleanly to 1 and 2.
+    const map = buildCitationSequenceMap(
+      'claim [8] more [19] end [10]',
+      makeResults(12),
+    );
+    expect(map.has(19)).toBe(false);
+    expect(map.get(8)).toBe(1);
+    expect(map.get(10)).toBe(2);
+    expect(map.size).toBe(2);
+  });
+  test('drops trailing hallucinated numbers, leaving real ones unchanged', () => {
+    // Mirrors the reported failure: the summary densely cites [1]..[3]
+    // (an identity map) plus a hallucinated [9] when only 3 results exist.
+    // The fake disappears; the real numbers keep their displayed values.
+    const map = buildCitationSequenceMap(
+      'one [1] two [2] three [3] fake [9]',
+      makeResults(3),
+    );
+    expect([...map.entries()]).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
+    expect(map.has(9)).toBe(false);
+  });
   test('returns an empty map when nothing is cited', () => {
-    expect(buildCitationSequenceMap('nothing cited').size).toBe(0);
+    expect(buildCitationSequenceMap('nothing cited', makeResults(3)).size).toBe(0);
   });
 });

--- a/ui/frontend/src/utils/citations.ts
+++ b/ui/frontend/src/utils/citations.ts
@@ -37,15 +37,33 @@ export const extractCitedNumbers = (summaryText: string): number[] => {
   return Array.from(cited).sort((a, b) => a - b);
 };
 
-/** Map each original citation number to its sequential display number
+/** The cited numbers that actually resolve to a search result, sorted
+ *  ascending. A `[N]` marker only backs a real reference when `N` is within
+ *  `1..results.length`; anything outside that range — most commonly a
+ *  model-hallucinated number such as `[19]` when only 12 results exist — is
+ *  dropped here so no surface (on-screen summary, References list, or export)
+ *  ever renders a citation that points to nothing. */
+export const extractValidCitedNumbers = (
+  summaryText: string,
+  results: SearchResult[],
+): number[] =>
+  extractCitedNumbers(summaryText).filter(
+    (num) => num >= 1 && num <= results.length,
+  );
+
+/** Map each *valid* original citation number to its sequential display number
  *  (`1..k`, in citation order). This is the renumbering the on-screen summary
  *  applies to inline `[N]` markers, and the docx/HTML exports must apply the
- *  same map so their inline markers agree with the screen. */
+ *  same map so their inline markers agree with the screen. Numbers with no
+ *  backing result are excluded (see {@link extractValidCitedNumbers}), so a
+ *  number absent from the map is not a real citation and must not be
+ *  rendered — every consumer keys off this map to stay consistent. */
 export const buildCitationSequenceMap = (
   summaryText: string,
+  results: SearchResult[],
 ): Map<number, number> => {
   const citationMapping = new Map<number, number>();
-  extractCitedNumbers(summaryText).forEach((origNum, seqIdx) => {
+  extractValidCitedNumbers(summaryText, results).forEach((origNum, seqIdx) => {
     citationMapping.set(origNum, seqIdx + 1);
   });
   return citationMapping;
@@ -71,15 +89,12 @@ export const buildGroupedReferences = (
   summaryText: string,
   results: SearchResult[],
 ): DocumentGroup[] => {
-  const sortedCitations = extractCitedNumbers(summaryText);
+  const sequenceMap = buildCitationSequenceMap(summaryText, results);
   const groupMap = new Map<string, DocumentGroup>();
   const groupOrder: string[] = [];
 
-  sortedCitations.forEach((origNum, seqIdx) => {
-    const resultIndex = origNum - 1;
-    if (resultIndex < 0 || resultIndex >= results.length) return;
-
-    const result = results[resultIndex];
+  extractValidCitedNumbers(summaryText, results).forEach((origNum) => {
+    const result = results[origNum - 1];
     const key = result.title;
 
     if (!groupMap.has(key)) {
@@ -92,7 +107,12 @@ export const buildGroupedReferences = (
       groupOrder.push(key);
     }
 
-    groupMap.get(key)!.refs.push({ sequential: seqIdx + 1, result });
+    // Sequential number comes from the shared map so the References list and
+    // the inline `[N]` markers stay in lock-step by construction.
+    groupMap.get(key)!.refs.push({
+      sequential: sequenceMap.get(origNum)!,
+      result,
+    });
   });
 
   return groupOrder.map((key) => groupMap.get(key)!);

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -518,7 +518,7 @@ const buildSummarySection = (
     results,
     siteOrigin,
     dataSource,
-    sequenceMap: buildCitationSequenceMap(summary),
+    sequenceMap: buildCitationSequenceMap(summary, results),
   };
   // Demote any markdown headings inside the summary by 1 so the section's
   // own H1 stays unique. Pass the citation context so [N] markers in the


### PR DESCRIPTION
## Description

The AI summary occasionally displayed citation numbers (e.g. **16, 17, 18, 19**) that looked like references but resolved to nothing — no hover card, and no matching entry in the References list. This is the "fake references" bug (Refs **344709**).

**Root cause.** `buildCitationSequenceMap` (`ui/frontend/src/utils/citations.ts`) renumbered *every* `[N]` marker it found in the summary text without checking it against the actual search results. When the LLM emitted an out-of-range marker (an `N` greater than the number of results — a hallucinated citation), that number still received a sequential display slot and was rendered inline as a bare number. The References builder (`buildGroupedReferences`) *did* skip out-of-range numbers, so the two disagreed: a number appeared inline with no corresponding reference. It's intermittent because it only surfaces when the model cites past the result count.

**Fix.** Add `extractValidCitedNumbers`, which keeps only numbers within `1..results.length`, and have both the inline sequence map and the grouped References list key off it. Out-of-range markers are now dropped consistently across the on-screen summary, the References list, and the docx export (which already mirrored the sequence map). Real citations renumber cleanly without the fakes consuming slots, so every surface stays in lock-step by construction.

Frontend-only, single shared utility (`citations.ts`) plus its two call sites (`AiSummaryWithCitations.tsx`, `exportResultsToDocx.ts`).

## Type of Change
- [x] Bug fix

## Testing
- [x] Tests pass locally
- [x] New tests added for new functionality
- [x] Manual testing completed

- `src/utils/__tests__/citations.test.ts` — filter + sequence-map regression tests (hallucinated numbers excluded; real numbers renumber cleanly).
- `src/tests/aiSummaryCitations.test.tsx` — renders the component and asserts the orphan number never reaches the DOM while real citations and prose survive.
- Existing `exportResultsToDocx` / `buildGroupedReferences` tests unchanged and green.
- `tsc --noEmit` clean; full frontend suite green apart from one pre-existing flaky test unrelated to this change.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Documentation updated (JSDoc on the new/changed utilities)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)