### PR TITLE
feat(evals): add pass-rate line chart to experiment runs view

### DIFF
--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -86,6 +86,7 @@
       "node_modules/(?!(axios|react-markdown|remark-.*|unified|bail|is-plain-obj|trough|vfile.*|unist-.*|mdast-.*|micromark.*|decode-named-character-reference|character-entities.*|character-reference-invalid|property-information|hast-util-.*|space-separated-tokens|comma-separated-tokens|ccount|escape-string-regexp|markdown-table|devlop|trim-lines|estree-util-.*|html-url-attributes|is-alphabetical|is-alphanumerical|is-decimal|is-hexadecimal|longest-streak|parse-entities|stringify-entities|zwitch|@ungap)/)"
     ],
     "moduleNameMapper": {
+      "^react-plotly\\.js$": "<rootDir>/src/testMocks/reactPlotly.tsx",
       "^unist-util-visit-parents/do-not-use-color$": "unist-util-visit-parents/lib/color.node.js",
       "^#minpath$": "<rootDir>/node_modules/vfile/lib/minpath.js",
       "^#minproc$": "<rootDir>/node_modules/vfile/lib/minproc.js",

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -11632,6 +11632,23 @@ a.admin-citation-clickable:hover {
   flex-direction: column;
   gap: 0.6rem;
 }
+/* Pass-rate-by-run trend chart, shown above the runs list. */
+.testing-runs-chart {
+  border: 1px solid var(--color-border, #d0d7de);
+  border-radius: 8px;
+  background: var(--color-surface, #fff);
+  padding: 0.8rem 0.9rem 0.4rem;
+  margin-bottom: 0.9rem;
+}
+.testing-runs-chart-title {
+  display: block;
+  margin-bottom: 0.3rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-text-muted, #57606a);
+}
 .testing-run {
   border: 1px solid var(--color-border, #d0d7de);
   border-radius: 8px;

--- a/ui/frontend/src/components/admin/testing/ExperimentDetail.tsx
+++ b/ui/frontend/src/components/admin/testing/ExperimentDetail.tsx
@@ -16,6 +16,7 @@ import {
   formatTimestamp,
   prettyJson,
 } from './testingFormat';
+import RunPassRateChart from './RunPassRateChart';
 
 interface ExperimentDetailProps {
   experimentId: string;
@@ -643,17 +644,20 @@ const ExperimentDetail: React.FC<ExperimentDetailProps> = ({
           experiment.
         </p>
       ) : (
-        <div className="testing-runs">
-          {runs.map((run, idx) => (
-            <RunSection
-              key={run.id}
-              run={run}
-              caseInputs={caseInputs}
-              defaultOpen={idx === 0}
-              isLatest={idx === 0}
-            />
-          ))}
-        </div>
+        <>
+          <RunPassRateChart runs={runs} />
+          <div className="testing-runs">
+            {runs.map((run, idx) => (
+              <RunSection
+                key={run.id}
+                run={run}
+                caseInputs={caseInputs}
+                defaultOpen={idx === 0}
+                isLatest={idx === 0}
+              />
+            ))}
+          </div>
+        </>
       )}
     </div>
   );

--- a/ui/frontend/src/components/admin/testing/RunPassRateChart.tsx
+++ b/ui/frontend/src/components/admin/testing/RunPassRateChart.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import Plot from 'react-plotly.js';
+import type { TestRun } from '../../../types/testing';
+
+interface RunPassRateChartProps {
+  runs: TestRun[];
+}
+
+/* Brand primary — matches --brand-primary in App.css. */
+const LINE_COLOR = '#5B8FA8';
+
+/* Show the chart once any run has a pass rate; a single run renders one marker. */
+const MIN_POINTS = 1;
+
+/* Only completed runs carry a numeric pass_rate; pending/running runs report
+   progress instead, so they are excluded from the trend. */
+const hasPassRate = (run: TestRun): boolean =>
+  typeof run.summary_stats?.pass_rate === 'number';
+
+const byRunNumber = (a: TestRun, b: TestRun): number => a.run_number - b.run_number;
+
+/**
+ * Line chart of pass rate across an experiment's runs.
+ *
+ * The x-axis is the actual run number and the y-axis is the pass rate
+ * (0–100%), so the chart reflects exactly which runs executed and updates as
+ * new runs are added. A single run renders as one marker; the chart is hidden
+ * only when no run has a recorded pass rate (e.g. every run failed).
+ *
+ * Args:
+ *   runs: The experiment's runs, in any order (the API returns them newest
+ *     first; this component sorts ascending by run number for plotting).
+ *
+ * Returns:
+ *   A styled Plotly line chart, or ``null`` when no completed run has a pass
+ *   rate to plot.
+ */
+const RunPassRateChart: React.FC<RunPassRateChartProps> = ({ runs }) => {
+  const points = runs.filter(hasPassRate).sort(byRunNumber);
+
+  if (points.length < MIN_POINTS) return null;
+
+  const x = points.map((run) => run.run_number);
+  const y = points.map((run) => run.summary_stats?.pass_rate ?? 0);
+
+  return (
+    <div className="testing-runs-chart">
+      <span className="testing-runs-chart-title">Pass rate by run</span>
+      <Plot
+        data={[
+          {
+            type: 'scatter',
+            mode: 'lines+markers',
+            x,
+            y,
+            line: { color: LINE_COLOR, width: 2 },
+            marker: { color: LINE_COLOR, size: 7 },
+            hovertemplate: 'Run #%{x}: %{y:.0%} pass<extra></extra>',
+          },
+        ]}
+        layout={{
+          height: 240,
+          margin: { t: 12, b: 44, l: 56, r: 20 },
+          paper_bgcolor: 'white',
+          plot_bgcolor: 'white',
+          font: { size: 12, color: '#334155' },
+          xaxis: {
+            title: 'Run number',
+            dtick: 1,
+            tickformat: 'd',
+            fixedrange: true,
+            zeroline: false,
+          },
+          yaxis: {
+            title: 'Pass rate',
+            tickformat: ',.0%',
+            range: [0, 1.05],
+            fixedrange: true,
+            zeroline: false,
+          },
+          showlegend: false,
+        }}
+        style={{ width: '100%', height: '240px' }}
+        config={{ responsive: true, displayModeBar: false }}
+      />
+    </div>
+  );
+};
+
+export default RunPassRateChart;

--- a/ui/frontend/src/testMocks/reactPlotly.tsx
+++ b/ui/frontend/src/testMocks/reactPlotly.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// Jest stub for react-plotly.js. The real package eagerly loads the full
+// plotly.js bundle, which does not run under jsdom, so any test that renders a
+// component importing <Plot> would crash. This is wired in globally via
+// `jest.moduleNameMapper` in package.json; tests that need to assert on the
+// plotted data mock the module themselves with a prop-capturing factory.
+const Plot: React.FC = () => <div data-testid="plot" />;
+
+export default Plot;

--- a/ui/frontend/src/tests/runPassRateChart.test.tsx
+++ b/ui/frontend/src/tests/runPassRateChart.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import RunPassRateChart from '../components/admin/testing/RunPassRateChart';
+import type { SummaryStats, TestRun } from '../types/testing';
+
+// Capture the props Plotly is rendered with so we can assert on the plotted data
+// without depending on Plotly's DOM output.
+let lastPlotProps: { data?: Array<{ x?: number[]; y?: number[] }> } | null = null;
+jest.mock('react-plotly.js', () => ({
+  __esModule: true,
+  default: (props: { data?: Array<{ x?: number[]; y?: number[] }> }) => {
+    lastPlotProps = props;
+    return <div data-testid="plot" />;
+  },
+}));
+
+const stats = (pass_rate: number): SummaryStats => ({
+  total: 10,
+  passed: Math.round(pass_rate * 10),
+  failed: 10 - Math.round(pass_rate * 10),
+  errored: 0,
+  pass_rate,
+  mean_score: pass_rate,
+  duration_ms: 1000,
+});
+
+const makeRun = (
+  run_number: number,
+  summary_stats: SummaryStats | null,
+  status: TestRun['status'] = 'completed',
+): TestRun => ({
+  id: `run-${run_number}`,
+  experiment_id: 'exp-1',
+  run_number,
+  status,
+  summary_stats,
+  started_at: '2026-01-01T00:00:00Z',
+  finished_at: '2026-01-01T00:01:00Z',
+  created_at: '2026-01-01T00:00:00Z',
+  results: [],
+});
+
+beforeEach(() => {
+  lastPlotProps = null;
+});
+
+describe('RunPassRateChart', () => {
+  it('test_chart_when_single_completed_run_then_plots_one_point', () => {
+    const { getByTestId } = render(<RunPassRateChart runs={[makeRun(1, stats(0.5))]} />);
+    expect(getByTestId('plot')).toBeInTheDocument();
+    const trace = lastPlotProps?.data?.[0];
+    expect(trace?.x).toEqual([1]);
+    expect(trace?.y).toEqual([0.5]);
+  });
+
+  it('test_chart_when_multiple_runs_then_plots_ascending_by_run_number', () => {
+    // API returns runs newest-first; the chart must sort them ascending.
+    const runs = [makeRun(3, stats(0.75)), makeRun(2, stats(0.5)), makeRun(1, stats(0.2))];
+    const { getByTestId } = render(<RunPassRateChart runs={runs} />);
+
+    expect(getByTestId('plot')).toBeInTheDocument();
+    const trace = lastPlotProps?.data?.[0];
+    expect(trace?.x).toEqual([1, 2, 3]);
+    expect(trace?.y).toEqual([0.2, 0.5, 0.75]);
+  });
+
+  it('test_chart_when_run_lacks_pass_rate_then_excluded_from_trend', () => {
+    // A still-running run reports progress but no pass_rate; it must be dropped
+    // so the x-axis reflects only the runs that actually completed.
+    const runs = [
+      makeRun(3, null, 'running'),
+      makeRun(2, stats(0.6)),
+      makeRun(1, stats(0.4)),
+    ];
+    render(<RunPassRateChart runs={runs} />);
+
+    const trace = lastPlotProps?.data?.[0];
+    expect(trace?.x).toEqual([1, 2]);
+    expect(trace?.y).toEqual([0.4, 0.6]);
+  });
+
+  it('test_chart_when_no_run_has_pass_rate_then_renders_nothing', () => {
+    // Every run failed / is still running, so none has a pass_rate to plot.
+    const runs = [makeRun(2, null, 'failed'), makeRun(1, null, 'running')];
+    const { container, queryByTestId } = render(<RunPassRateChart runs={runs} />);
+    expect(container).toBeEmptyDOMElement();
+    expect(queryByTestId('plot')).toBeNull();
+  });
+});

--- a/ui/frontend/src/types/react-plotly.js.d.ts
+++ b/ui/frontend/src/types/react-plotly.js.d.ts
@@ -1,0 +1,27 @@
+// Ambient type declaration for react-plotly.js.
+//
+// The package ships without its own types and there is no @types/react-plotly.js
+// installed, so TypeScript treats the import as implicitly `any` (TS7016). This
+// gives the default-exported <Plot> component a real, if loose, prop shape — the
+// underlying plotly.js types are not available in this project, so trace/layout/
+// config objects are typed as open records rather than fully modelled.
+declare module 'react-plotly.js' {
+  import { Component, CSSProperties } from 'react';
+
+  export interface PlotParams {
+    data: Array<Record<string, unknown>>;
+    layout?: Record<string, unknown>;
+    config?: Record<string, unknown>;
+    frames?: Array<Record<string, unknown>>;
+    style?: CSSProperties;
+    className?: string;
+    useResizeHandler?: boolean;
+    divId?: string;
+    onInitialized?: (figure: unknown, graphDiv: HTMLElement) => void;
+    onUpdate?: (figure: unknown, graphDiv: HTMLElement) => void;
+    onPurge?: (figure: unknown, graphDiv: HTMLElement) => void;
+    onError?: (err: unknown) => void;
+  }
+
+  export default class Plot extends Component<PlotParams> {}
+}


### PR DESCRIPTION
## Description

Adds a pass-rate trend line chart to the **Admin → Testing → Experiments → (experiment detail)** view. The chart sits above the runs list and plots **pass rate (y-axis)** against **run number (x-axis)**, styled to match the rest of the app.

It picks up the live/polled runs array, so it always reflects how many runs actually executed and their real run numbers.

The chart is placed above the "Runs (N)" list in the experiment detail view.

### Behaviour
- X-axis = actual `run_number`; Y-axis = `pass_rate` (0–100%).
- Runs are sorted ascending by run number (the API returns them newest-first).
- Only runs with a recorded `pass_rate` are plotted. Runs that are still running or failed (`pass_rate: null`) are excluded rather than shown as 0%.
- A single completed run renders as one marker; the chart is hidden only when **no** run has a pass rate (e.g. every run failed).

### Implementation notes
- New `RunPassRateChart` component using the existing `react-plotly.js` dependency (same config pattern as `Pipeline.tsx`).
- Added a local ambient type declaration `src/types/react-plotly.js.d.ts` so the import type-checks **without** the `// @ts-ignore` used in `Pipeline.tsx` (project rules forbid suppressions), and without adding a new dependency.
- Added a global jest stub for `react-plotly.js` via `moduleNameMapper` so any test that renders the chart doesn't try to load the full plotly.js bundle under jsdom.

## Type of Change
- [x] New feature

## Testing
- [x] `RunPassRateChart` unit tests (ascending sort, exclusion of runs without a pass rate, single-run point, all-failed → no chart).
- [x] Full frontend suite: **66 suites / 509 tests pass**.
- [x] `tsc --noEmit` clean; dev server compiles with no new warnings.
- [x] Manually verified against local data: charts now render for single-run and multi-run experiments; the all-failed-but-one experiment shows the single completed point.
- [x] `pre-commit run` passes on all changed files.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] New tests added
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
