### PR TITLE
fix(auth): working logout + robust session refresh for OAuth-only deployments

### DIFF
--- a/tests/unit/test_auth_logout.py
+++ b/tests/unit/test_auth_logout.py
@@ -1,0 +1,90 @@
+"""Unit tests for the OAuth-only cookie logout route.
+
+In OAuth-only deployments (``DISABLE_EMAIL_LOGIN=true``) the email/password
+auth router — which normally carries ``/cookie-login/logout`` — is not mounted,
+so a standalone logout is registered instead. These tests verify that route
+exists, clears the auth cookie, and still requires a valid session. The route
+is registered at import time from the env var, so the module is reloaded per
+mode.
+"""
+
+import importlib
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+COOKIE_NAME = "evidencelab_auth"
+LOGOUT_PATH = "/auth/cookie-login/logout"
+
+
+@pytest.fixture
+def oauth_only_auth_routes(monkeypatch):
+    """Reload the auth routes module in OAuth-only mode, then restore it.
+
+    Args:
+        monkeypatch: pytest fixture used to set ``DISABLE_EMAIL_LOGIN``.
+
+    Yields:
+        module: The reloaded ``ui.backend.routes.auth`` module.
+    """
+    monkeypatch.setenv("DISABLE_EMAIL_LOGIN", "true")
+    from ui.backend.routes import auth as auth_routes
+
+    yield importlib.reload(auth_routes)
+
+    # Restore the module to its env-default state so other tests are unaffected.
+    monkeypatch.undo()
+    importlib.reload(auth_routes)
+
+
+def _build_app(auth_routes, *, authenticated: bool) -> FastAPI:
+    """Mount the auth router, optionally overriding auth to authenticated.
+
+    Args:
+        auth_routes: The (reloaded) auth routes module.
+        authenticated: When True, treat requests as an authenticated user.
+
+    Returns:
+        FastAPI: The configured application.
+    """
+    from ui.backend.auth.users import current_active_user
+
+    app = FastAPI()
+    app.include_router(auth_routes.router, prefix="/auth")
+    if authenticated:
+        app.dependency_overrides[current_active_user] = lambda: SimpleNamespace(
+            id="user-1"
+        )
+    return app
+
+
+@pytest.mark.unit
+def test_cookie_logout_route_registered_in_oauth_only_mode(oauth_only_auth_routes):
+    """The standalone logout route exists when email login is disabled."""
+    paths = {route.path for route in oauth_only_auth_routes.router.routes}
+    assert "/cookie-login/logout" in paths
+
+
+@pytest.mark.unit
+def test_cookie_logout_when_authenticated_clears_cookie(oauth_only_auth_routes):
+    """An authenticated logout returns 204 and expires the auth cookie."""
+    client = TestClient(_build_app(oauth_only_auth_routes, authenticated=True))
+
+    resp = client.post(LOGOUT_PATH)
+
+    assert resp.status_code == 204
+    set_cookie = resp.headers.get("set-cookie", "").lower()
+    assert f"{COOKIE_NAME}=" in set_cookie
+    assert "max-age=0" in set_cookie
+
+
+@pytest.mark.unit
+def test_cookie_logout_requires_authentication(oauth_only_auth_routes):
+    """Logout without a valid session is rejected (nothing to clear)."""
+    client = TestClient(_build_app(oauth_only_auth_routes, authenticated=False))
+
+    resp = client.post(LOGOUT_PATH)
+
+    assert resp.status_code == 401

--- a/ui/backend/routes/auth.py
+++ b/ui/backend/routes/auth.py
@@ -111,6 +111,37 @@ router.include_router(
 
 
 # ---------------------------------------------------------------------------
+# Logout
+#
+# The email/password auth router mounted above carries the cookie logout
+# endpoint (/cookie-login/logout) — but only when email login is enabled. In
+# OAuth-only deployments (DISABLE_EMAIL_LOGIN=true) that router is absent, yet
+# the frontend still needs to clear the auth cookie on sign-out and on idle
+# logout. Register a standalone logout that works for any cookie session, but
+# only when the built-in one is not mounted, to avoid a duplicate route.
+# ---------------------------------------------------------------------------
+
+if DISABLE_EMAIL_LOGIN:
+
+    @router.post("/cookie-login/logout", tags=["auth"])
+    async def cookie_logout(user: User = Depends(current_active_user)):
+        """Clear the auth cookie for the current cookie session.
+
+        Mirrors the built-in cookie logout for OAuth-only deployments where the
+        email/password auth router that normally provides it is not mounted.
+        Requires a valid session cookie; the stateless JWT needs no server-side
+        revocation, so clearing the cookie is sufficient.
+
+        Args:
+            user: The authenticated user, resolved from the existing auth cookie.
+
+        Returns:
+            Response: A 204 response carrying a cookie-clearing ``Set-Cookie``.
+        """
+        return await cookie_backend.transport.get_logout_response()
+
+
+# ---------------------------------------------------------------------------
 # Sliding-session refresh
 #
 # Re-issues the httpOnly auth cookie (and a fresh JWT) for the currently

--- a/ui/frontend/src/hooks/useAuth.ts
+++ b/ui/frontend/src/hooks/useAuth.ts
@@ -211,22 +211,29 @@ export function useAuthState(): AuthContextValue {
 
   // ---- Sliding-session refresh ----------------------------------------
   // While authenticated, periodically re-issue the auth cookie so an active
-  // user's token never expires mid-session.  We only refresh when the user
-  // interacted within the last interval, so a genuinely idle session still
-  // lapses (and the idle-logout effect above clears it).  The interval is
-  // half the server token lifetime, guaranteeing a refresh before expiry.
+  // user's token never expires mid-session.  Three things keep this robust:
+  //   1. Refresh once on mount — a page opened with a still-valid but aging
+  //      cookie (reopened tab, back-navigation) is re-slid immediately instead
+  //      of being left to expire before the first interval fires.
+  //   2. Refresh at a quarter of the token lifetime, so there are two refresh
+  //      opportunities before expiry — one skipped tick never loses the session.
+  //   3. Skip a refresh only when the user is genuinely idle (no activity within
+  //      the whole idle-timeout window), NOT merely quiet for one interval — so
+  //      an active user who is reading (no clicks/scroll) still stays logged in.
   useEffect(() => {
     if (!USER_MODULE || !state.isAuthenticated) return;
 
     const intervalMs = Math.max(
       MIN_REFRESH_INTERVAL_MS,
-      Math.floor(sessionConfig.tokenLifetimeMs / 2)
+      Math.floor(sessionConfig.tokenLifetimeMs / 4)
     );
 
     const tick = async () => {
-      // Skip when idle (no activity within the last interval) — let the cookie
-      // lapse and the idle-logout fire.
-      if (Date.now() - lastActivityRef.current >= intervalMs) return;
+      // Skip only when the session has gone fully idle — the idle-logout effect
+      // above owns ending it.  Otherwise keep the cookie fresh.
+      if (Date.now() - lastActivityRef.current >= sessionConfig.idleTimeoutMs) {
+        return;
+      }
       try {
         await axios.post(`${API_BASE_URL}/auth/refresh`);
       } catch {
@@ -235,9 +242,14 @@ export function useAuthState(): AuthContextValue {
       }
     };
 
+    tick(); // re-slide immediately; don't wait a full interval to start
     const intervalId = setInterval(tick, intervalMs);
     return () => clearInterval(intervalId);
-  }, [state.isAuthenticated, sessionConfig.tokenLifetimeMs]);
+  }, [
+    state.isAuthenticated,
+    sessionConfig.tokenLifetimeMs,
+    sessionConfig.idleTimeoutMs,
+  ]);
 
   const clearVerificationMessage = useCallback(() => {
     setVerificationMessage(null);

--- a/ui/frontend/src/tests/useAuthSession.test.tsx
+++ b/ui/frontend/src/tests/useAuthSession.test.tsx
@@ -326,7 +326,19 @@ describe('useAuthState — sliding-session refresh', () => {
     (axios.post as jest.Mock).mockResolvedValue({ data: {} });
   });
 
-  it('posts /auth/refresh while the user is active', async () => {
+  it('refreshes immediately on mount to re-slide an aging cookie', async () => {
+    // A page opened with a still-valid but aging cookie must re-slide right
+    // away, not wait a full interval (during which it could expire).
+    render(<AuthTestHarness />);
+    await flushPromises();
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/refresh'),
+    );
+  });
+
+  it('keeps refreshing an active session across refresh intervals', async () => {
     jest.useFakeTimers();
     render(<AuthTestHarness />);
     await flushPromises();
@@ -334,11 +346,9 @@ describe('useAuthState — sliding-session refresh', () => {
     expect(screen.getByTestId('authenticated').textContent).toBe('true');
     (axios.post as jest.Mock).mockClear();
 
-    // Keep the session active just before the refresh interval fires.
-    act(() => { jest.advanceTimersByTime(20 * 60 * 1000); });
+    // Cross one refresh interval (a quarter of the 1h default lifetime = 15m).
     act(() => { window.dispatchEvent(new MouseEvent('mousedown')); });
-    // Cross the 30-minute refresh interval (half the 1h default lifetime).
-    await act(async () => { jest.advanceTimersByTime(15 * 60 * 1000); });
+    await act(async () => { jest.advanceTimersByTime(16 * 60 * 1000); });
 
     expect(axios.post).toHaveBeenCalledWith(
       expect.stringContaining('/auth/refresh'),
@@ -346,7 +356,10 @@ describe('useAuthState — sliding-session refresh', () => {
     jest.useRealTimers();
   });
 
-  it('does NOT post /auth/refresh when the user is idle', async () => {
+  it('refreshes a quiet-but-not-idle session (reading, no clicks)', async () => {
+    // Regression: a user reading without mouse/keyboard/scroll activity for
+    // longer than one refresh interval must still have their token refreshed,
+    // as long as they are within the idle-timeout window.
     jest.useFakeTimers();
     render(<AuthTestHarness />);
     await flushPromises();
@@ -354,8 +367,27 @@ describe('useAuthState — sliding-session refresh', () => {
     expect(screen.getByTestId('authenticated').textContent).toBe('true');
     (axios.post as jest.Mock).mockClear();
 
-    // No activity at all — advance across two refresh intervals.
-    await act(async () => { jest.advanceTimersByTime(59 * 60 * 1000); });
+    // No activity, but still inside the 1h idle window — advance two intervals.
+    await act(async () => { jest.advanceTimersByTime(31 * 60 * 1000); });
+
+    const refreshCalls = (axios.post as jest.Mock).mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('/auth/refresh'),
+    );
+    expect(refreshCalls.length).toBeGreaterThan(0);
+    jest.useRealTimers();
+  });
+
+  it('stops refreshing once the session goes idle-expired', async () => {
+    jest.useFakeTimers();
+    render(<AuthTestHarness />);
+    await flushPromises();
+
+    // No activity: idle-logout fires at the 1h idle timeout, ending the session.
+    await act(async () => { jest.advanceTimersByTime(60 * 60 * 1000 + 100); });
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+    (axios.post as jest.Mock).mockClear();
+
+    await act(async () => { jest.advanceTimersByTime(30 * 60 * 1000); });
 
     const refreshCalls = (axios.post as jest.Mock).mock.calls.filter(
       ([url]) => typeof url === 'string' && url.includes('/auth/refresh'),


### PR DESCRIPTION
## Why

On the WFP dev deployment (OAuth-only, `DISABLE_EMAIL_LOGIN=true`), superuser **Aurelie** reported that clicking **Admin** and **Saved Research** did nothing — consistently, only for her, with a **clean browser console**. Tracing it end to end:

- She's a valid, active, verified **superuser**; her `/users/me/effective-settings` returns **200** (the group-feature-toggles merge is fine).
- **Saved Research has no superuser gate** yet also fails → this is an **API-session** problem, not a permissions/feature problem. The frontend keeps just enough `user` state to render the menu, but her authenticated calls intermittently **401**, so the panels come up empty (silent, no console error).

Two real backend/session bugs produce exactly this, and this PR fixes both.

## Fixes

### 1. Logout was 404-ing in OAuth-only mode
The cookie logout route is carried by the email/password auth router, which is only mounted when email login is enabled. With `DISABLE_EMAIL_LOGIN=true`, `POST /api/auth/cookie-login/logout` **404s** — but the frontend still calls it on sign-out **and on idle-logout**, so the auth cookie is never cleared server-side and sessions can't be cleanly reset. Added a standalone `/cookie-login/logout` route, registered **only** in OAuth-only mode (no duplicate when the built-in one exists). Requires a valid cookie; clears it (stateless JWT needs no server-side revocation).

### 2. Sliding-session refresh let active sessions die at the 1h token lifetime
Observed: `/api/auth/refresh` fired only twice all day, both 401 → sessions just hard-expired at the 1-hour mark, so features "work for a while, then stop." Root causes in `useAuth.ts`:
- First refresh only ran a **full 30m interval after mount** — a page opened with an aging cookie could expire before it fired.
- Refresh was **skipped whenever there was no activity within one interval**, even for an active user who is *reading* (no clicks/scroll).

Now the refresh:
- runs **once on mount** to re-slide an aging cookie immediately,
- runs at a **quarter of the token lifetime** for headroom (a single skipped/failed tick no longer loses the session),
- skips **only when the session is genuinely idle** (past the idle-timeout window) — the idle-logout effect remains authoritative for ending idle sessions.

## Tests
- **`tests/unit/test_auth_logout.py`** (new): logout route is registered in OAuth-only mode, returns 204 and clears the cookie when authenticated, and 401s without a session. ✅ 5/5 backend auth tests pass.
- **`useAuthSession.test.tsx`** (updated): mount-refresh, active-across-intervals, quiet-but-not-idle (reading) refresh, and no-refresh-after-idle-logout. ✅ 20/20 frontend auth tests pass.

Lint/format/mypy/bandit/detect-secrets/code-metrics all pass via pre-commit.

## Deploy note
`DISABLE_EMAIL_LOGIN=true` on this env, so both fixes are exercised in production. After merge, rebuild the `api` (logout route) and `ui` (refresh) images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)