### PR TITLE
fix(ui): pin docx to 9.6.1 to unblock the production build

### DIFF
--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "ajv": "^8.20.0",
         "ajv-keywords": "^5.1.0",
         "axios": "^1.18.1",
-        "docx": "^9.7.1",
+        "docx": "9.6.1",
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
         "pdfjs-dist": "^3.11.174",
@@ -8275,9 +8275,9 @@
       }
     },
     "node_modules/docx": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
-      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -9,7 +9,7 @@
     "ajv": "^8.20.0",
     "ajv-keywords": "^5.1.0",
     "axios": "^1.18.1",
-    "docx": "^9.7.1",
+    "docx": "9.6.1",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
     "pdfjs-dist": "^3.11.174",


### PR DESCRIPTION
## Problem
`docker compose -f docker-compose.prod.yml ... up -d --build` fails in the `ui` builder stage at `npm run build`:

```
SyntaxError: /app/node_modules/docx/dist/index.mjs: When using '@babel/plugin-transform-parameters',
it's not possible to compile `super()` in an arrow function with default or rest parameters
without compiling classes. Please add '@babel/plugin-transform-classes' to your Babel configuration.
```

## Cause
Dependabot **#387 bumped docx 9.6.1 → 9.7.1** *after* the last working build (June 30). docx 9.7.1's bundled ESM (`dist/index.mjs`, `ImageRun` class) uses a rest-param arrow that calls `super()`. `babel-preset-react-app`'s `transform-parameters` can't compile that unless classes are also transformed — and CRA (plain `react-scripts`, no craco) doesn't run `transform-classes` alongside it.

## Why not "just modernise browserslist"
Tempting, but Babel's compat data shows `transform-parameters` is required for **Safari / iOS < 16.3** — i.e. real iPhone users. Dropping them to sidestep the transform is not acceptable.

## Fix
Pin `docx` to the last known-good **9.6.1** (exact). Restores the June-30 working build with **no browser-support loss** and **no new build tooling**. Lockfile delta is docx-only; `npm ci --legacy-peer-deps` stays in sync.

**Verified:** `npm run build` succeeds with 9.6.1 and fails with 9.7.1 (reproduced against the exact `package-lock.json` the Docker `npm ci` uses).

## Follow-up
Hold docx at 9.6.1 until it ships a CRA-compatible bundle, or migrate the frontend to a bundler (craco/vite) that can inject `@babel/plugin-transform-classes`. A dependabot ignore rule for docx major/minor would prevent a repeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)