### PR TITLE
feat: admin TOC Validator screen (339595)

### DIFF
--- a/docs/admin/toc-validator.md
+++ b/docs/admin/toc-validator.md
@@ -1,0 +1,109 @@
+# TOC Validator
+
+The **TOC Validator** (Admin → TOC Validator) checks that document body content is
+not accidentally hidden from search because of how its sections are tagged.
+
+## Why this matters
+
+Search has a **content type** filter (Search / Content settings). By default it only
+returns chunks whose section type is one of the "real content" types:
+
+```
+executive_summary, context, methodology, findings, conclusions, recommendations, other
+```
+
+Every other section type — `front_matter`, `acronyms`, `annexes`, `appendix`,
+`bibliography`, `introduction` — is **excluded by default**.
+
+Section tagging is automatic (done at upload by the TOC classifier). If a section
+that is really part of the report body is mis-tagged as, say, `annexes`, that content
+silently disappears from default search results. Users never see it and never know
+it is missing.
+
+Each document also carries a **human-set** page range in its source metadata:
+
+```
+Introduction - before beginning of Annexes (start_page_number, end_page_number)  ->  (14, 56)
+```
+
+That range is the ground truth for "where the real body content lives".
+
+## What the validator checks
+
+For each selected document it:
+
+1. reads the human-set body page range from the document's source metadata;
+2. reads the section tags from the classified table of contents (the same tags shown
+   in the **Contents** view of a document);
+3. flags every section whose page falls inside the body range but whose section type
+   is **not** in the default-included set.
+
+A flagged section is body content that would be excluded from default search.
+
+> The validator only **checks** the current classification. It never re-runs the
+> classifier and never changes tags. Fixing a bad tag is a deliberate manual step —
+> see [Fixing a bad classification](#fixing-a-bad-classification).
+
+### Verdicts
+
+| Verdict | Meaning |
+|---|---|
+| **Pass** | Every section inside the body range uses a default-included type. |
+| **Fail** | At least one section inside the body range uses an excluded type. |
+| **Skipped** | The document has no body page range, or no classified contents. |
+| **Not tested** | The document has not been validated yet. |
+
+## Using the screen
+
+1. Open **Admin → TOC Validator** (superuser only).
+2. Optionally filter the list by title.
+3. Select documents with the row checkboxes, the header checkbox (selects the current
+   page), or **Select all** (selects every document matching the current filter).
+4. Click **Run validation**. Results are saved against each document, so they persist
+   and are shown the next time the screen is opened.
+5. Rows whose verdict was added or changed by the run are highlighted and marked
+   **updated**.
+
+Each row has **Metadata** and **Contents** links, the same as the Documents Library,
+so a flagged result can be checked against the actual document.
+
+## Interpreting results
+
+A **Fail** means the classifier's labels disagree with the human page range. It does
+not by itself say which of the two is wrong — the page range could be off, just as
+the tag could be. Use the **Contents** and **Metadata** views to decide.
+
+Two patterns are worth separating:
+
+* **`introduction` flagged across most documents.** This is systemic, not per-document
+  mis-tagging: the body range starts at the introduction, and `introduction` is not in
+  the default-included set (nor is it offered as a filter option in Search settings).
+  The fix is a decision about the defaults, not about individual documents.
+* **`annexes` / `acronyms` / `bibliography` / `front_matter` inside the body range.**
+  These are genuine mis-tags worth investigating per document — for example a report
+  whose *Findings* and *Recommendations* chapters were labelled `annexes` because their
+  headings contained cross-references such as "(EQs 1-5, Annex 8)".
+
+## Fixing a bad classification
+
+From a flagged row, open **Contents**, correct the section type, and save. Editing the
+classification automatically re-validates that document so the verdict updates.
+
+## Where results are stored
+
+Results are stored per document in the data source's document row, under the
+`sys_toc_validation` field (recorded alongside the timestamp and the user who ran the
+check). No database migration is required — the per-data-source `docs_<source>` tables
+create `sys_*` fields on write.
+
+## Running the same check offline
+
+The identical validation logic is available as a standalone script for bulk reporting
+across a whole data source, producing an Excel report:
+
+```bash
+python tests/evaluation/section_inclusion/check_included_section_types.py --data-source wfp
+```
+
+See `tests/evaluation/section_inclusion/README.md`. Both the screen and the script use
+the same logic in `pipeline/validation/section_inclusion.py`.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,6 +29,7 @@
         { "title": "Pipeline Configuration", "path": "admin/pipeline-configuration.md" },
         { "title": "User Administration", "path": "admin/user-administration.md" },
         { "title": "Evaluation Harness", "path": "admin/evaluation.md" },
+        { "title": "TOC Validator", "path": "admin/toc-validator.md" },
         { "title": "API", "path": "admin/api-keys.md" },
         { "title": "System Monitoring", "path": "admin/system-monitoring.md" },
         { "title": "MCP Server", "path": "admin/mcp-server.md" },

--- a/pipeline/validation/__init__.py
+++ b/pipeline/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Document validation checks (section inclusion, ...)."""

--- a/pipeline/validation/section_inclusion.py
+++ b/pipeline/validation/section_inclusion.py
@@ -1,0 +1,230 @@
+"""Section-inclusion validation.
+
+Checks that every section inside a document's human-set main-body page range is
+tagged with a section type that Search *includes* by default. A body section
+tagged with an excluded type (e.g. ``annexes``) silently disappears from default
+search results, so surfacing it lets an editor fix the classification.
+
+Inputs come from a document row as returned by ``PostgresClient.fetch_docs`` /
+``fetch_all_docs``:
+
+* body page range -> ``src_doc_raw_metadata[INTRO_RANGE_FIELD]``, e.g. ``"(11, 62)"``
+* section tags    -> ``sys_data["sys_toc_classified"]`` (the "Contents" tab tags)
+
+This module holds only pure logic (no DB, no I/O) so it can be reused by the
+backend service, the evaluation script, and unit tests alike.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Mirrors DEFAULT_SECTION_TYPES in ui/frontend/src/utils/searchUrl.ts — the
+# section types that Search includes by default. Everything else is excluded.
+DEFAULT_INCLUDED_SECTION_TYPES: Tuple[str, ...] = (
+    "executive_summary",
+    "context",
+    "methodology",
+    "findings",
+    "conclusions",
+    "recommendations",
+    "other",
+)
+
+# Source-metadata field holding the human-set body page range, e.g. "(11, 62)".
+INTRO_RANGE_FIELD = (
+    "Introduction - before beginning of Annexes (start_page_number, end_page_number)"
+)
+
+# Matches classified-TOC lines, e.g.:
+#   "[H1] 1. Introduction | introduction | page 11"
+#   "[H2] Table des Matieres | front_matter | page 3 (i) [Front]"
+# The trailing bracket marker ([Front], [FM], ...) and the roman-numeral page
+# alias are both optional.
+_TOC_CLASSIFIED_PATTERN = re.compile(
+    r"^\s*\[H(?P<level>\d+)\]\s*(?P<title>.*?)\s*\|\s*(?P<label>[^|]+?)"
+    r"(?:\s*\|\s*page\s*(?P<page>\d+)(?:\s*\([^)]+\))?)?"
+    r"(?:\s*\[[^\]]*\])?\s*$",
+    flags=re.IGNORECASE,
+)
+
+# One parsed classified-TOC entry: {"title": str, "label": str, "page": int|None}.
+Section = Dict[str, Any]
+
+
+def _parse_page_value(value: Any) -> Optional[int]:
+    """Coerce a single page value (int/float/numeric-string) to int."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def parse_page_range(raw_value: Any) -> Tuple[Optional[int], Optional[int]]:
+    """Parse the body page range from the shapes it can take.
+
+    In practice the stored value is a string like ``"(11, 62)"``, but tuples,
+    lists, dicts and bare ints are handled too. Returns ``(start, end)``; either
+    element may be ``None`` if it could not be determined.
+    """
+    if raw_value is None:
+        return None, None
+
+    if isinstance(raw_value, (list, tuple)) and len(raw_value) >= 2:
+        return _parse_page_value(raw_value[0]), _parse_page_value(raw_value[1])
+
+    if isinstance(raw_value, dict):
+        start = raw_value.get("start_page_number", raw_value.get("start"))
+        end = raw_value.get("end_page_number", raw_value.get("end"))
+        return _parse_page_value(start), _parse_page_value(end)
+
+    if isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool):
+        page = _parse_page_value(raw_value)
+        return page, page
+
+    if isinstance(raw_value, str):
+        numbers = [int(val) for val in re.findall(r"\d+", raw_value)]
+        if len(numbers) >= 2:
+            return numbers[0], numbers[1]
+        if len(numbers) == 1:
+            return numbers[0], numbers[0]
+
+    return None, None
+
+
+def parse_toc_classified(toc_text: str) -> List[Section]:
+    """Parse classified-TOC text into ``{title, label, page}`` entries."""
+    if not toc_text:
+        return []
+
+    entries: List[Section] = []
+    for raw_line in toc_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = _TOC_CLASSIFIED_PATTERN.match(line)
+        if not match:
+            continue
+        page_text = match.group("page")
+        entries.append(
+            {
+                "title": (match.group("title") or "").strip(),
+                "label": (match.group("label") or "").strip().lower(),
+                "page": int(page_text) if page_text and page_text.isdigit() else None,
+            }
+        )
+    return entries
+
+
+def sections_in_range(
+    entries: Iterable[Section], start_page: int, end_page: int
+) -> List[Section]:
+    """Return entries whose page falls within ``[start_page, end_page]``."""
+    return [
+        entry
+        for entry in entries
+        if entry.get("page") is not None and start_page <= entry["page"] <= end_page
+    ]
+
+
+def find_excluded_sections(
+    entries: Iterable[Section],
+    start_page: int,
+    end_page: int,
+    included: Iterable[str] = DEFAULT_INCLUDED_SECTION_TYPES,
+) -> List[Section]:
+    """Return in-range entries whose section type is excluded from Search by default.
+
+    A section is a violation when its label is not in ``included`` — that content
+    lives in the main body but would be filtered out of default search results.
+    """
+    included_set = set(included)
+    return [
+        entry
+        for entry in sections_in_range(entries, start_page, end_page)
+        if entry.get("label") not in included_set
+    ]
+
+
+def get_document_title(doc: Dict[str, Any]) -> str:
+    """Best-effort document title from a doc row."""
+    raw = doc.get("src_doc_raw_metadata") or {}
+    return (
+        doc.get("map_title")
+        or doc.get("title")
+        or raw.get("Title evaluation")
+        or raw.get("title")
+        or "Unknown"
+    )
+
+
+def get_intro_range_field(doc: Dict[str, Any]) -> Any:
+    """Read the human-set body page range from a doc row."""
+    raw = doc.get("src_doc_raw_metadata") or {}
+    return raw.get(INTRO_RANGE_FIELD)
+
+
+def get_toc_classified(doc: Dict[str, Any]) -> str:
+    """Read the classified TOC text from a doc row (sys_data or top level)."""
+    sys_data = doc.get("sys_data") or {}
+    return sys_data.get("sys_toc_classified") or doc.get("sys_toc_classified") or ""
+
+
+def _verdict(reasons: List[str], excluded: List[Section]) -> str:
+    if reasons:
+        return "skipped"
+    return "fail" if excluded else "pass"
+
+
+def evaluate_document(
+    doc: Dict[str, Any],
+    included: Iterable[str] = DEFAULT_INCLUDED_SECTION_TYPES,
+) -> Dict[str, Any]:
+    """Evaluate one document row and return a structured validation result.
+
+    Result keys: ``status`` (pass/fail/skipped), ``range_start``, ``range_end``,
+    ``sections_in_range``, ``num_excluded``, ``excluded_section_types`` (sorted
+    unique labels), ``excluded_sections`` (list of ``{title, label, page}``), and
+    ``reasons`` (why a document was skipped, if any).
+    """
+    start_page, end_page = parse_page_range(get_intro_range_field(doc))
+    entries = parse_toc_classified(get_toc_classified(doc))
+
+    reasons: List[str] = []
+    if not entries:
+        reasons.append("missing_toc_classified")
+    if start_page is None or end_page is None:
+        reasons.append("missing_metadata_range")
+
+    excluded: List[Section] = []
+    in_range = 0
+    if not reasons and start_page is not None and end_page is not None:
+        in_range = len(sections_in_range(entries, start_page, end_page))
+        excluded = find_excluded_sections(entries, start_page, end_page, included)
+
+    excluded_types = sorted(
+        {str(sec.get("label") or "(unlabeled)") for sec in excluded}
+    )
+    return {
+        "status": _verdict(reasons, excluded),
+        "range_start": start_page,
+        "range_end": end_page,
+        "sections_in_range": in_range,
+        "num_excluded": len(excluded),
+        "excluded_section_types": excluded_types,
+        "excluded_sections": excluded,
+        "reasons": reasons,
+    }
+
+
+def describe_excluded_sections(sections: List[Section]) -> str:
+    """One-line human-readable summary of violating sections for reports."""
+    parts = [
+        f"[{sec.get('label') or '(unlabeled)'}] {sec.get('title', '')} (p.{sec.get('page')})"
+        for sec in sections
+    ]
+    return "; ".join(parts)

--- a/tests/evaluation/section_inclusion/README.md
+++ b/tests/evaluation/section_inclusion/README.md
@@ -1,0 +1,99 @@
+# Section Inclusion Evaluation
+
+Verifies that main-body content is not accidentally excluded from default Search
+results because of how its sections are tagged.
+
+## Why
+
+Search has a **content type** filter (Search / Content settings). By default it
+only returns chunks whose `tag_section_type` is one of the "real content" types:
+
+```
+executive_summary, context, methodology, findings, conclusions, recommendations, other
+```
+
+This list mirrors `DEFAULT_SECTION_TYPES` in
+[`ui/frontend/src/utils/searchUrl.ts`](../../../ui/frontend/src/utils/searchUrl.ts).
+Every other section type — `front_matter`, `acronyms`, `annexes`, `appendix`,
+`bibliography`, `introduction`, … — is **excluded by default**.
+
+Section tagging is automatic (done at upload by the TOC classifier). If a section
+that is really part of the body gets mis-tagged as, e.g., `annexes`, that content
+silently disappears from default search results.
+
+Each document carries a **human-set** page range in its source metadata:
+
+```
+Introduction - before beginning of Annexes (start_page_number, end_page_number)  ->  (13, 67)
+```
+
+That range is the ground-truth for "where the real body content lives".
+
+## What the script checks
+
+For every document it:
+
+1. reads the human-set body page range from source metadata;
+2. reads the classified table of contents (`sys_toc_classified`) — the same
+   "Contents" section tags shown in the document viewer;
+3. flags every section whose page falls inside the body range but whose section
+   type is **not** in the default-included set.
+
+A flagged section is body content that would be accidentally excluded from
+default search.
+
+Both inputs come from the Postgres sidecar table `docs_<data_source>` (via
+`PostgresClient.fetch_all_docs()`): the page range from the
+`src_doc_raw_metadata` JSONB column, the section tags from
+`sys_data -> 'sys_toc_classified'`. Qdrant is not used — its document payload
+carries only `map_*` / `tag_*` fields.
+
+### Verdicts
+
+- **pass** — every section inside the body range has a default-included type.
+- **fail** — at least one section inside the body range has an excluded type.
+- **skipped** — the document has no body range or no classified TOC.
+
+> Note: `introduction` is not in the default-included set, so a section still
+> tagged `introduction` inside the body range is reported as a (real) finding —
+> that introduction content is excluded from default search.
+
+## Usage
+
+```bash
+# Check all documents in a data source
+python tests/evaluation/section_inclusion/check_included_section_types.py --data-source wfp
+
+# Check a sample of N documents
+python tests/evaluation/section_inclusion/check_included_section_types.py --records 20
+
+# Check a single document by doc id
+python tests/evaluation/section_inclusion/check_included_section_types.py --file-id <id>
+
+# Custom output path
+python tests/evaluation/section_inclusion/check_included_section_types.py --output results.xlsx
+```
+
+Requires Postgres with the target table (`docs_<data_source>`) and the usual
+`.env`. It is a standalone script, not a pytest test. Easiest way to run it is
+inside the pipeline container, which already has the dependencies:
+
+```bash
+docker compose exec -T pipeline python \
+  tests/evaluation/section_inclusion/check_included_section_types.py --data-source wfp
+```
+
+## Output
+
+- Console: per-document `FAIL` lines plus a summary (pass/fail/skipped counts and
+  a tally of which excluded section types show up inside body ranges).
+- Excel (`.xlsx`, default `logs/section_inclusion_eval.xlsx`) with one row per
+  document: `doc_id`, `title`, `metadata_range`, `range_start`, `range_end`,
+  `sections_in_range`, `num_excluded`, `excluded_section_types`,
+  `excluded_details`, `status`, `reasons`.
+
+## Tests
+
+Pure logic (range parsing, TOC parsing, exclusion detection, verdict) is unit
+tested in
+[`tests/unit/test_check_included_section_types.py`](../../unit/test_check_included_section_types.py).

--- a/tests/evaluation/section_inclusion/check_included_section_types.py
+++ b/tests/evaluation/section_inclusion/check_included_section_types.py
@@ -3,31 +3,10 @@
 Check that every section inside a document's main-body page range is tagged with
 a section type that is *included* by default in Search / Content settings.
 
-Background
-----------
-Search has a "content type" filter. By default it only returns chunks whose
-``tag_section_type`` is one of the "real content" types
-(``DEFAULT_INCLUDED_SECTION_TYPES`` below, mirrored from the frontend constant
-``DEFAULT_SECTION_TYPES`` in ``ui/frontend/src/utils/searchUrl.ts``). Any other
-section type (front_matter, acronyms, annexes, appendix, bibliography,
-introduction, ...) is *excluded* by default.
-
-Section tagging is automatic (done at upload by the TOC classifier), so a body
-section that is mis-tagged as, say, ``annexes`` silently disappears from default
-search results. Each document also carries a human-set page range in its source
-metadata:
-
-    "Introduction - before beginning of Annexes (start_page_number, end_page_number)"
-
-That range is the ground-truth for "where the real body content lives". This
-script flags every classified-TOC section whose page falls inside that range but
-whose section type is NOT in the default-included set — i.e. body content that
-would be accidentally excluded from default search.
-
-Data sources (all from the Postgres sidecar, ``docs_<data_source>``):
-  * body page range -> ``src_doc_raw_metadata[INTRO_RANGE_FIELD]``, e.g. "(11, 62)"
-  * section tags    -> ``sys_data["sys_toc_classified"]``, the same tags shown in
-                       the "Contents" tab of the document viewer.
+The validation logic lives in ``pipeline.validation.section_inclusion`` (shared
+with the backend TOC validator). This script is the standalone/offline runner: it
+reads documents from the Postgres sidecar, evaluates each one, writes an xlsx
+report and prints a summary. See this directory's README for the full rationale.
 
 Usage
 -----
@@ -47,45 +26,22 @@ Usage
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(PROJECT_ROOT))  # noqa: E402
 
-# Mirrors DEFAULT_SECTION_TYPES in ui/frontend/src/utils/searchUrl.ts — the
-# section types that Search includes by default. Everything else is excluded.
-DEFAULT_INCLUDED_SECTION_TYPES = (
-    "executive_summary",
-    "context",
-    "methodology",
-    "findings",
-    "conclusions",
-    "recommendations",
-    "other",
+from pipeline.validation.section_inclusion import (  # noqa: E402
+    describe_excluded_sections,
+    evaluate_document,
+    get_document_title,
+    get_intro_range_field,
 )
 
-# Source-metadata field holding the human-set body page range, e.g. "(11, 62)".
-INTRO_RANGE_FIELD = (
-    "Introduction - before beginning of Annexes (start_page_number, end_page_number)"
-)
-
-# Only look at documents that finished indexing.
+# Only report on documents that finished indexing.
 ALLOWED_STATUSES = {"indexed", "tagged"}
-
-# Matches classified-TOC lines, e.g.:
-#   "[H1] 1. Introduction | introduction | page 11"
-#   "[H2] Table des Matières | front_matter | page 3 (i) [Front]"
-# The trailing bracket marker ([Front], [FM], ...) and the roman-numeral page
-# alias are both optional.
-TOC_CLASSIFIED_PATTERN = re.compile(
-    r"^\s*\[H(?P<level>\d+)\]\s*(?P<title>.*?)\s*\|\s*(?P<label>[^|]+?)"
-    r"(?:\s*\|\s*page\s*(?P<page>\d+)(?:\s*\([^)]+\))?)?"
-    r"(?:\s*\[[^\]]*\])?\s*$",
-    flags=re.IGNORECASE,
-)
 
 
 def parse_args() -> argparse.Namespace:
@@ -122,181 +78,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-# --------------------------------------------------------------------------- #
-# Pure logic (unit-tested in tests/unit/test_check_included_section_types.py)
-# --------------------------------------------------------------------------- #
-def _parse_page_value(value: Any) -> Optional[int]:
-    """Coerce a single page value (int/float/numeric-string) to int."""
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, (int, float)):
-        return int(value)
-    if isinstance(value, str) and value.strip().isdigit():
-        return int(value.strip())
-    return None
-
-
-def parse_page_range(raw_value: Any) -> Tuple[Optional[int], Optional[int]]:
-    """Parse the body page range from the shapes it can take.
-
-    In practice the stored value is a string like ``"(11, 62)"``, but tuples,
-    lists, dicts and bare ints are handled too. Returns ``(start, end)``; either
-    element may be ``None`` if it could not be determined.
-    """
-    if raw_value is None:
-        return None, None
-
-    if isinstance(raw_value, (list, tuple)) and len(raw_value) >= 2:
-        return _parse_page_value(raw_value[0]), _parse_page_value(raw_value[1])
-
-    if isinstance(raw_value, dict):
-        start = raw_value.get("start_page_number", raw_value.get("start"))
-        end = raw_value.get("end_page_number", raw_value.get("end"))
-        return _parse_page_value(start), _parse_page_value(end)
-
-    if isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool):
-        page = _parse_page_value(raw_value)
-        return page, page
-
-    if isinstance(raw_value, str):
-        numbers = [int(val) for val in re.findall(r"\d+", raw_value)]
-        if len(numbers) >= 2:
-            return numbers[0], numbers[1]
-        if len(numbers) == 1:
-            return numbers[0], numbers[0]
-
-    return None, None
-
-
-def parse_toc_classified(toc_text: str) -> List[Dict[str, Any]]:
-    """Parse classified-TOC text into ``{title, label, page}`` entries."""
-    if not toc_text:
-        return []
-
-    entries: List[Dict[str, Any]] = []
-    for raw_line in toc_text.splitlines():
-        line = raw_line.strip()
-        if not line:
-            continue
-        match = TOC_CLASSIFIED_PATTERN.match(line)
-        if not match:
-            continue
-        page_text = match.group("page")
-        entries.append(
-            {
-                "title": (match.group("title") or "").strip(),
-                "label": (match.group("label") or "").strip().lower(),
-                "page": int(page_text) if page_text and page_text.isdigit() else None,
-            }
-        )
-    return entries
-
-
-def find_excluded_sections(
-    entries: Iterable[Dict[str, Any]],
-    start_page: int,
-    end_page: int,
-    included: Iterable[str] = DEFAULT_INCLUDED_SECTION_TYPES,
-) -> List[Dict[str, Any]]:
-    """Return TOC entries whose page is in ``[start_page, end_page]`` and whose
-    section type would be excluded from Search by default.
-
-    A section is a violation when its label is not in ``included`` — that content
-    lives in the main body but would be filtered out of default search results.
-    """
-    included_set = set(included)
-    violations: List[Dict[str, Any]] = []
-    for entry in entries:
-        page = entry.get("page")
-        if page is None or not (start_page <= page <= end_page):
-            continue
-        if entry.get("label") not in included_set:
-            violations.append(entry)
-    return violations
-
-
-def _describe_sections(sections: List[Dict[str, Any]]) -> str:
-    """Human-readable one-line summary of violating sections for the report."""
-    parts = []
-    for sec in sections:
-        label = sec.get("label") or "(unlabeled)"
-        parts.append(f"[{label}] {sec.get('title', '')} (p.{sec.get('page')})")
-    return "; ".join(parts)
-
-
-# --------------------------------------------------------------------------- #
-# Document accessors (rows as returned by PostgresClient.fetch_all_docs())
-# --------------------------------------------------------------------------- #
-def get_document_title(doc: dict) -> str:
-    raw = doc.get("src_doc_raw_metadata") or {}
-    return (
-        doc.get("map_title")
-        or raw.get("Title evaluation")
-        or raw.get("title")
-        or "Unknown"
-    )
-
-
-def get_toc_classified(doc: dict) -> str:
-    sys_data = doc.get("sys_data") or {}
-    return sys_data.get("sys_toc_classified") or doc.get("sys_toc_classified") or ""
-
-
-def get_intro_range_field(doc: dict) -> Any:
-    raw = doc.get("src_doc_raw_metadata") or {}
-    return raw.get(INTRO_RANGE_FIELD)
-
-
-def _count_sections_in_range(
-    entries: List[Dict[str, Any]], start_page: Optional[int], end_page: Optional[int]
-) -> int:
-    if start_page is None or end_page is None:
-        return 0
-    return sum(
-        1
-        for entry in entries
-        if entry.get("page") is not None and start_page <= entry["page"] <= end_page
-    )
-
-
-def evaluate_document(doc: dict) -> Dict[str, Any]:
-    """Evaluate a single document row, returning a flat result row."""
-    intro_range_raw = get_intro_range_field(doc)
-    start_page, end_page = parse_page_range(intro_range_raw)
-    entries = parse_toc_classified(get_toc_classified(doc))
-
-    reasons: List[str] = []
-    if not entries:
-        reasons.append("missing_toc_classified")
-    if start_page is None or end_page is None:
-        reasons.append("missing_metadata_range")
-
-    violations: List[Dict[str, Any]] = []
-    if not reasons:
-        violations = find_excluded_sections(entries, start_page, end_page)
-
-    if reasons:
-        status = "skipped"
-    elif violations:
-        status = "fail"
-    else:
-        status = "pass"
-
-    excluded_types = sorted({sec.get("label") or "(unlabeled)" for sec in violations})
-    return {
-        "title": get_document_title(doc),
-        "metadata_range": str(intro_range_raw),
-        "range_start": start_page,
-        "range_end": end_page,
-        "sections_in_range": _count_sections_in_range(entries, start_page, end_page),
-        "num_excluded": len(violations),
-        "excluded_section_types": ", ".join(excluded_types),
-        "excluded_details": _describe_sections(violations),
-        "status": status,
-        "reasons": ", ".join(reasons),
-    }
-
-
 def select_documents(
     docs: List[Dict[str, Any]], limit: Optional[int], file_id: Optional[str]
 ) -> List[Dict[str, Any]]:
@@ -311,9 +92,25 @@ def select_documents(
     return eligible[:limit] if limit else eligible
 
 
-# --------------------------------------------------------------------------- #
-# Reporting
-# --------------------------------------------------------------------------- #
+def build_report_row(doc: Dict[str, Any], data_source: str) -> Dict[str, Any]:
+    """Evaluate one doc and flatten the result into a report row."""
+    result = evaluate_document(doc)
+    return {
+        "doc_id": str(doc.get("id")),
+        "title": get_document_title(doc),
+        "data_source": data_source,
+        "metadata_range": str(get_intro_range_field(doc)),
+        "range_start": result["range_start"],
+        "range_end": result["range_end"],
+        "sections_in_range": result["sections_in_range"],
+        "num_excluded": result["num_excluded"],
+        "excluded_section_types": ", ".join(result["excluded_section_types"]),
+        "excluded_details": describe_excluded_sections(result["excluded_sections"]),
+        "status": result["status"],
+        "reasons": ", ".join(result["reasons"]),
+    }
+
+
 REPORT_HEADERS = [
     "doc_id",
     "title",
@@ -363,6 +160,12 @@ def _print_summary(counts: Dict[str, int], excluded_tally: Dict[str, int]) -> No
     print("=" * 60)
 
 
+def _tally_excluded(row: Dict[str, Any], excluded_tally: Dict[str, int]) -> None:
+    for label in row["excluded_section_types"].split(", "):
+        if label:
+            excluded_tally[label] = excluded_tally.get(label, 0) + 1
+
+
 def main() -> None:
     from pipeline.db import PostgresClient
 
@@ -377,18 +180,13 @@ def main() -> None:
     excluded_tally: Dict[str, int] = {}
 
     for doc in select_documents(pg.fetch_all_docs(), args.records, args.file_id):
-        result = evaluate_document(doc)
-        counts[result["status"]] += 1
-        for label in result["excluded_section_types"].split(", "):
-            if label:
-                excluded_tally[label] = excluded_tally.get(label, 0) + 1
-        ws.append(
-            [str(doc.get("id")), result["title"], args.data_source]
-            + [result[key] for key in REPORT_HEADERS[3:]]
-        )
-        if result["status"] == "fail":
-            print(f"FAIL {str(doc.get('id'))[:8]}  {result['title'][:60]}")
-            print(f"     {result['excluded_details'][:200]}")
+        row = build_report_row(doc, args.data_source)
+        counts[row["status"]] += 1
+        _tally_excluded(row, excluded_tally)
+        ws.append([row[key] for key in REPORT_HEADERS])
+        if row["status"] == "fail":
+            print(f"FAIL {row['doc_id'][:8]}  {row['title'][:60]}")
+            print(f"     {row['excluded_details'][:200]}")
 
     wb.save(str(output_path))
     _print_summary(counts, excluded_tally)

--- a/tests/evaluation/section_inclusion/check_included_section_types.py
+++ b/tests/evaluation/section_inclusion/check_included_section_types.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""
+Check that every section inside a document's main-body page range is tagged with
+a section type that is *included* by default in Search / Content settings.
+
+Background
+----------
+Search has a "content type" filter. By default it only returns chunks whose
+``tag_section_type`` is one of the "real content" types
+(``DEFAULT_INCLUDED_SECTION_TYPES`` below, mirrored from the frontend constant
+``DEFAULT_SECTION_TYPES`` in ``ui/frontend/src/utils/searchUrl.ts``). Any other
+section type (front_matter, acronyms, annexes, appendix, bibliography,
+introduction, ...) is *excluded* by default.
+
+Section tagging is automatic (done at upload by the TOC classifier), so a body
+section that is mis-tagged as, say, ``annexes`` silently disappears from default
+search results. Each document also carries a human-set page range in its source
+metadata:
+
+    "Introduction - before beginning of Annexes (start_page_number, end_page_number)"
+
+That range is the ground-truth for "where the real body content lives". This
+script flags every classified-TOC section whose page falls inside that range but
+whose section type is NOT in the default-included set — i.e. body content that
+would be accidentally excluded from default search.
+
+Data sources (all from the Postgres sidecar, ``docs_<data_source>``):
+  * body page range -> ``src_doc_raw_metadata[INTRO_RANGE_FIELD]``, e.g. "(11, 62)"
+  * section tags    -> ``sys_data["sys_toc_classified"]``, the same tags shown in
+                       the "Contents" tab of the document viewer.
+
+Usage
+-----
+    # Check all documents in a data source
+    python tests/evaluation/section_inclusion/check_included_section_types.py --data-source wfp
+
+    # Check a sample of N documents
+    python tests/evaluation/section_inclusion/check_included_section_types.py --records 20
+
+    # Check a single document by doc id
+    python tests/evaluation/section_inclusion/check_included_section_types.py --file-id <id>
+
+    # Custom output path
+    python tests/evaluation/section_inclusion/check_included_section_types.py --output results.xlsx
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(PROJECT_ROOT))  # noqa: E402
+
+# Mirrors DEFAULT_SECTION_TYPES in ui/frontend/src/utils/searchUrl.ts — the
+# section types that Search includes by default. Everything else is excluded.
+DEFAULT_INCLUDED_SECTION_TYPES = (
+    "executive_summary",
+    "context",
+    "methodology",
+    "findings",
+    "conclusions",
+    "recommendations",
+    "other",
+)
+
+# Source-metadata field holding the human-set body page range, e.g. "(11, 62)".
+INTRO_RANGE_FIELD = (
+    "Introduction - before beginning of Annexes (start_page_number, end_page_number)"
+)
+
+# Only look at documents that finished indexing.
+ALLOWED_STATUSES = {"indexed", "tagged"}
+
+# Matches classified-TOC lines, e.g.:
+#   "[H1] 1. Introduction | introduction | page 11"
+#   "[H2] Table des Matières | front_matter | page 3 (i) [Front]"
+# The trailing bracket marker ([Front], [FM], ...) and the roman-numeral page
+# alias are both optional.
+TOC_CLASSIFIED_PATTERN = re.compile(
+    r"^\s*\[H(?P<level>\d+)\]\s*(?P<title>.*?)\s*\|\s*(?P<label>[^|]+?)"
+    r"(?:\s*\|\s*page\s*(?P<page>\d+)(?:\s*\([^)]+\))?)?"
+    r"(?:\s*\[[^\]]*\])?\s*$",
+    flags=re.IGNORECASE,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Flag sections in the main-body page range that are tagged with a "
+            "section type excluded from Search by default."
+        ),
+    )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--records",
+        type=int,
+        default=None,
+        help="Number of documents to process (default: all)",
+    )
+    group.add_argument(
+        "--file-id",
+        type=str,
+        help="Process a single document by doc id",
+    )
+    parser.add_argument(
+        "--data-source",
+        type=str,
+        default="wfp",
+        help="Data source / table suffix (default: wfp)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=str(PROJECT_ROOT / "logs" / "section_inclusion_eval.xlsx"),
+        help="Output Excel (.xlsx) file path",
+    )
+    return parser.parse_args()
+
+
+# --------------------------------------------------------------------------- #
+# Pure logic (unit-tested in tests/unit/test_check_included_section_types.py)
+# --------------------------------------------------------------------------- #
+def _parse_page_value(value: Any) -> Optional[int]:
+    """Coerce a single page value (int/float/numeric-string) to int."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return None
+
+
+def parse_page_range(raw_value: Any) -> Tuple[Optional[int], Optional[int]]:
+    """Parse the body page range from the shapes it can take.
+
+    In practice the stored value is a string like ``"(11, 62)"``, but tuples,
+    lists, dicts and bare ints are handled too. Returns ``(start, end)``; either
+    element may be ``None`` if it could not be determined.
+    """
+    if raw_value is None:
+        return None, None
+
+    if isinstance(raw_value, (list, tuple)) and len(raw_value) >= 2:
+        return _parse_page_value(raw_value[0]), _parse_page_value(raw_value[1])
+
+    if isinstance(raw_value, dict):
+        start = raw_value.get("start_page_number", raw_value.get("start"))
+        end = raw_value.get("end_page_number", raw_value.get("end"))
+        return _parse_page_value(start), _parse_page_value(end)
+
+    if isinstance(raw_value, (int, float)) and not isinstance(raw_value, bool):
+        page = _parse_page_value(raw_value)
+        return page, page
+
+    if isinstance(raw_value, str):
+        numbers = [int(val) for val in re.findall(r"\d+", raw_value)]
+        if len(numbers) >= 2:
+            return numbers[0], numbers[1]
+        if len(numbers) == 1:
+            return numbers[0], numbers[0]
+
+    return None, None
+
+
+def parse_toc_classified(toc_text: str) -> List[Dict[str, Any]]:
+    """Parse classified-TOC text into ``{title, label, page}`` entries."""
+    if not toc_text:
+        return []
+
+    entries: List[Dict[str, Any]] = []
+    for raw_line in toc_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        match = TOC_CLASSIFIED_PATTERN.match(line)
+        if not match:
+            continue
+        page_text = match.group("page")
+        entries.append(
+            {
+                "title": (match.group("title") or "").strip(),
+                "label": (match.group("label") or "").strip().lower(),
+                "page": int(page_text) if page_text and page_text.isdigit() else None,
+            }
+        )
+    return entries
+
+
+def find_excluded_sections(
+    entries: Iterable[Dict[str, Any]],
+    start_page: int,
+    end_page: int,
+    included: Iterable[str] = DEFAULT_INCLUDED_SECTION_TYPES,
+) -> List[Dict[str, Any]]:
+    """Return TOC entries whose page is in ``[start_page, end_page]`` and whose
+    section type would be excluded from Search by default.
+
+    A section is a violation when its label is not in ``included`` — that content
+    lives in the main body but would be filtered out of default search results.
+    """
+    included_set = set(included)
+    violations: List[Dict[str, Any]] = []
+    for entry in entries:
+        page = entry.get("page")
+        if page is None or not (start_page <= page <= end_page):
+            continue
+        if entry.get("label") not in included_set:
+            violations.append(entry)
+    return violations
+
+
+def _describe_sections(sections: List[Dict[str, Any]]) -> str:
+    """Human-readable one-line summary of violating sections for the report."""
+    parts = []
+    for sec in sections:
+        label = sec.get("label") or "(unlabeled)"
+        parts.append(f"[{label}] {sec.get('title', '')} (p.{sec.get('page')})")
+    return "; ".join(parts)
+
+
+# --------------------------------------------------------------------------- #
+# Document accessors (rows as returned by PostgresClient.fetch_all_docs())
+# --------------------------------------------------------------------------- #
+def get_document_title(doc: dict) -> str:
+    raw = doc.get("src_doc_raw_metadata") or {}
+    return (
+        doc.get("map_title")
+        or raw.get("Title evaluation")
+        or raw.get("title")
+        or "Unknown"
+    )
+
+
+def get_toc_classified(doc: dict) -> str:
+    sys_data = doc.get("sys_data") or {}
+    return sys_data.get("sys_toc_classified") or doc.get("sys_toc_classified") or ""
+
+
+def get_intro_range_field(doc: dict) -> Any:
+    raw = doc.get("src_doc_raw_metadata") or {}
+    return raw.get(INTRO_RANGE_FIELD)
+
+
+def _count_sections_in_range(
+    entries: List[Dict[str, Any]], start_page: Optional[int], end_page: Optional[int]
+) -> int:
+    if start_page is None or end_page is None:
+        return 0
+    return sum(
+        1
+        for entry in entries
+        if entry.get("page") is not None and start_page <= entry["page"] <= end_page
+    )
+
+
+def evaluate_document(doc: dict) -> Dict[str, Any]:
+    """Evaluate a single document row, returning a flat result row."""
+    intro_range_raw = get_intro_range_field(doc)
+    start_page, end_page = parse_page_range(intro_range_raw)
+    entries = parse_toc_classified(get_toc_classified(doc))
+
+    reasons: List[str] = []
+    if not entries:
+        reasons.append("missing_toc_classified")
+    if start_page is None or end_page is None:
+        reasons.append("missing_metadata_range")
+
+    violations: List[Dict[str, Any]] = []
+    if not reasons:
+        violations = find_excluded_sections(entries, start_page, end_page)
+
+    if reasons:
+        status = "skipped"
+    elif violations:
+        status = "fail"
+    else:
+        status = "pass"
+
+    excluded_types = sorted({sec.get("label") or "(unlabeled)" for sec in violations})
+    return {
+        "title": get_document_title(doc),
+        "metadata_range": str(intro_range_raw),
+        "range_start": start_page,
+        "range_end": end_page,
+        "sections_in_range": _count_sections_in_range(entries, start_page, end_page),
+        "num_excluded": len(violations),
+        "excluded_section_types": ", ".join(excluded_types),
+        "excluded_details": _describe_sections(violations),
+        "status": status,
+        "reasons": ", ".join(reasons),
+    }
+
+
+def select_documents(
+    docs: List[Dict[str, Any]], limit: Optional[int], file_id: Optional[str]
+) -> List[Dict[str, Any]]:
+    """Filter fetched docs down to the ones this run should evaluate."""
+    if file_id:
+        selected = [doc for doc in docs if str(doc.get("id")) == str(file_id)]
+        if not selected:
+            raise ValueError(f"Document {file_id} not found")
+        return selected
+
+    eligible = [doc for doc in docs if doc.get("sys_status") in ALLOWED_STATUSES]
+    return eligible[:limit] if limit else eligible
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+REPORT_HEADERS = [
+    "doc_id",
+    "title",
+    "data_source",
+    "metadata_range",
+    "range_start",
+    "range_end",
+    "sections_in_range",
+    "num_excluded",
+    "excluded_section_types",
+    "excluded_details",
+    "status",
+    "reasons",
+]
+
+
+def _create_workbook():
+    import openpyxl
+    from openpyxl.styles import Alignment, Font, PatternFill
+
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Section Inclusion"
+    ws.append(REPORT_HEADERS)
+    header_fill = PatternFill(
+        start_color="DCE6F1", end_color="DCE6F1", fill_type="solid"
+    )
+    for cell in ws[1]:
+        cell.fill = header_fill
+        cell.font = Font(bold=True)
+        cell.alignment = Alignment(wrap_text=True, vertical="top")
+    return wb, ws
+
+
+def _print_summary(counts: Dict[str, int], excluded_tally: Dict[str, int]) -> None:
+    total = sum(counts.values())
+    print("\n" + "=" * 60)
+    print(f"Documents processed : {total}")
+    print(f"  pass    : {counts['pass']}")
+    print(f"  fail    : {counts['fail']}  (body content excluded by default)")
+    print(f"  skipped : {counts['skipped']}  (no range / no classified TOC)")
+    if excluded_tally:
+        print("\nExcluded section types found inside body ranges:")
+        print("(documents affected, per section type)")
+        for label, count in sorted(excluded_tally.items(), key=lambda kv: -kv[1]):
+            print(f"  {label:<20} {count}")
+    print("=" * 60)
+
+
+def main() -> None:
+    from pipeline.db import PostgresClient
+
+    args = parse_args()
+    pg = PostgresClient(args.data_source)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    wb, ws = _create_workbook()
+
+    counts = {"pass": 0, "fail": 0, "skipped": 0}
+    excluded_tally: Dict[str, int] = {}
+
+    for doc in select_documents(pg.fetch_all_docs(), args.records, args.file_id):
+        result = evaluate_document(doc)
+        counts[result["status"]] += 1
+        for label in result["excluded_section_types"].split(", "):
+            if label:
+                excluded_tally[label] = excluded_tally.get(label, 0) + 1
+        ws.append(
+            [str(doc.get("id")), result["title"], args.data_source]
+            + [result[key] for key in REPORT_HEADERS[3:]]
+        )
+        if result["status"] == "fail":
+            print(f"FAIL {str(doc.get('id'))[:8]}  {result['title'][:60]}")
+            print(f"     {result['excluded_details'][:200]}")
+
+    wb.save(str(output_path))
+    _print_summary(counts, excluded_tally)
+    print(f"\nReport written to: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_check_included_section_types.py
+++ b/tests/unit/test_check_included_section_types.py
@@ -1,8 +1,7 @@
-"""Unit tests for the section-inclusion evaluation script.
+"""Unit tests for the section-inclusion evaluation script glue.
 
-Covers the pure logic: page-range parsing, classified-TOC parsing, detecting
-sections in the body range tagged with default-excluded section types, and the
-per-document evaluation verdict.
+The validation logic itself is covered by tests/unit/test_section_inclusion.py;
+here we test the script-only helpers (document selection, report-row building).
 """
 
 import importlib.util
@@ -27,186 +26,9 @@ _spec.loader.exec_module(mod)
 
 pytestmark = pytest.mark.unit
 
-
-class TestParsePageRange:
-    def test_parse_page_range_when_tuple_then_start_end(self):
-        assert mod.parse_page_range((13, 67)) == (13, 67)
-
-    def test_parse_page_range_when_list_then_start_end(self):
-        assert mod.parse_page_range([13, 67]) == (13, 67)
-
-    def test_parse_page_range_when_string_then_extracts_numbers(self):
-        assert mod.parse_page_range("(13, 67)") == (13, 67)
-
-    def test_parse_page_range_when_dict_then_named_keys(self):
-        raw = {"start_page_number": 13, "end_page_number": 67}
-        assert mod.parse_page_range(raw) == (13, 67)
-
-    def test_parse_page_range_when_single_int_then_same_start_end(self):
-        assert mod.parse_page_range(42) == (42, 42)
-
-    def test_parse_page_range_when_none_then_none_pair(self):
-        assert mod.parse_page_range(None) == (None, None)
-
-    def test_parse_page_range_when_empty_string_then_none_pair(self):
-        assert mod.parse_page_range("n/a") == (None, None)
-
-    def test_parse_page_range_when_bool_not_treated_as_int(self):
-        # bool is a subclass of int; must not be coerced to a page number.
-        assert mod.parse_page_range(True) == (None, None)
-
-
-class TestParseTocClassified:
-    def test_parse_toc_classified_when_empty_then_no_entries(self):
-        assert mod.parse_toc_classified("") == []
-
-    def test_parse_toc_classified_when_lines_then_label_and_page(self):
-        toc = (
-            "[H1] Introduction | introduction | page 13\n"
-            "  [H2] Methods | methodology | page 20\n"
-            "[H1] Annexes | annexes | page 68\n"
-        )
-        entries = mod.parse_toc_classified(toc)
-        assert len(entries) == 3
-        assert entries[0] == {
-            "title": "Introduction",
-            "label": "introduction",
-            "page": 13,
-        }
-        assert entries[1]["label"] == "methodology"
-        assert entries[2]["page"] == 68
-
-    def test_parse_toc_classified_when_no_page_then_page_none(self):
-        entries = mod.parse_toc_classified("[H1] Foreword | front_matter")
-        assert entries == [{"title": "Foreword", "label": "front_matter", "page": None}]
-
-    def test_parse_toc_classified_ignores_unparseable_lines(self):
-        entries = mod.parse_toc_classified("garbage line without pipes")
-        assert entries == []
-
-    def test_parse_toc_classified_when_trailing_front_marker_then_parsed(self):
-        # Real WFP rows end with a bracket marker such as [Front].
-        entries = mod.parse_toc_classified(
-            "[H1] Rapport de l'évaluation | front_matter | page 1 [Front]"
-        )
-        assert entries == [
-            {"title": "Rapport de l'évaluation", "label": "front_matter", "page": 1}
-        ]
-
-    def test_parse_toc_classified_when_roman_alias_and_marker_then_parsed(self):
-        entries = mod.parse_toc_classified(
-            "[H2] Résumé Exécutif | executive_summary | page 6 (i) [Front]"
-        )
-        assert entries == [
-            {"title": "Résumé Exécutif", "label": "executive_summary", "page": 6}
-        ]
-
-
-class TestFindExcludedSections:
-    def _entries(self):
-        return [
-            {"title": "Front", "label": "front_matter", "page": 5},  # before range
-            {"title": "Findings", "label": "findings", "page": 20},  # included
-            {
-                "title": "Hidden Annex",
-                "label": "annexes",
-                "page": 40,
-            },  # excluded, in range
-            {
-                "title": "Intro",
-                "label": "introduction",
-                "page": 15,
-            },  # excluded, in range
-            {"title": "Real Annex", "label": "annexes", "page": 80},  # after range
-        ]
-
-    def test_find_excluded_sections_flags_excluded_labels_in_range(self):
-        result = mod.find_excluded_sections(self._entries(), 13, 67)
-        labels = sorted(sec["label"] for sec in result)
-        assert labels == ["annexes", "introduction"]
-
-    def test_find_excluded_sections_ignores_included_labels(self):
-        result = mod.find_excluded_sections(self._entries(), 13, 67)
-        assert all(sec["label"] != "findings" for sec in result)
-
-    def test_find_excluded_sections_ignores_out_of_range_pages(self):
-        result = mod.find_excluded_sections(self._entries(), 13, 67)
-        pages = {sec["page"] for sec in result}
-        assert 5 not in pages and 80 not in pages
-
-    def test_find_excluded_sections_when_all_included_then_empty(self):
-        entries = [{"title": "F", "label": "findings", "page": 30}]
-        assert mod.find_excluded_sections(entries, 13, 67) == []
-
-    def test_find_excluded_sections_inclusive_of_boundaries(self):
-        entries = [
-            {"title": "Start", "label": "acronyms", "page": 13},
-            {"title": "End", "label": "acronyms", "page": 67},
-        ]
-        result = mod.find_excluded_sections(entries, 13, 67)
-        assert len(result) == 2
-
-    def test_find_excluded_sections_skips_entries_without_page(self):
-        entries = [{"title": "X", "label": "annexes", "page": None}]
-        assert mod.find_excluded_sections(entries, 13, 67) == []
-
-    def test_find_excluded_sections_custom_included_set(self):
-        entries = [{"title": "M", "label": "methodology", "page": 20}]
-        # methodology excluded when it is not in the custom included set
-        result = mod.find_excluded_sections(entries, 13, 67, included=["findings"])
-        assert len(result) == 1
-
-
-class TestEvaluateDocument:
-    def _payload(self, toc, page_range):
-        """Build a doc row shaped like PostgresClient.fetch_all_docs() returns."""
-        return {
-            "id": "doc-1",
-            "sys_status": "indexed",
-            "sys_data": {"sys_toc_classified": toc},
-            "src_doc_raw_metadata": {mod.INTRO_RANGE_FIELD: page_range},
-            "map_title": "Test Doc",
-        }
-
-    def test_evaluate_document_when_body_annex_then_fail(self):
-        toc = "[H1] Intro | context | page 13\n" "[H1] Misfiled | annexes | page 40\n"
-        result = mod.evaluate_document(self._payload(toc, (13, 67)))
-        assert result["status"] == "fail"
-        assert result["num_excluded"] == 1
-        assert "annexes" in result["excluded_section_types"]
-        assert result["sections_in_range"] == 2
-
-    def test_evaluate_document_when_all_included_then_pass(self):
-        toc = "[H1] Findings | findings | page 30\n"
-        result = mod.evaluate_document(self._payload(toc, (13, 67)))
-        assert result["status"] == "pass"
-        assert result["num_excluded"] == 0
-
-    def test_evaluate_document_when_no_range_then_skipped(self):
-        result = mod.evaluate_document(
-            self._payload("[H1] F | findings | page 30", None)
-        )
-        assert result["status"] == "skipped"
-        assert "missing_metadata_range" in result["reasons"]
-
-    def test_evaluate_document_when_no_toc_then_skipped(self):
-        result = mod.evaluate_document(self._payload("", (13, 67)))
-        assert result["status"] == "skipped"
-        assert "missing_toc_classified" in result["reasons"]
-
-    def test_evaluate_document_when_range_is_string_then_parsed(self):
-        # Real stored shape is a string such as "(11, 62)".
-        toc = "[H1] Misfiled | annexes | page 40\n"
-        result = mod.evaluate_document(self._payload(toc, "(11, 62)"))
-        assert result["range_start"] == 11
-        assert result["range_end"] == 62
-        assert result["status"] == "fail"
-
-    def test_evaluate_document_uses_map_title(self):
-        result = mod.evaluate_document(
-            self._payload("[H1] F | findings | page 30", "(13, 67)")
-        )
-        assert result["title"] == "Test Doc"
+INTRO_FIELD = (
+    "Introduction - before beginning of Annexes (start_page_number, end_page_number)"
+)
 
 
 class TestSelectDocuments:
@@ -232,3 +54,38 @@ class TestSelectDocuments:
     def test_select_documents_when_file_id_missing_then_raises(self):
         with pytest.raises(ValueError, match="not found"):
             mod.select_documents(self._docs(), None, "zzz")
+
+
+class TestBuildReportRow:
+    def _doc(self, toc, page_range):
+        return {
+            "id": "doc-1",
+            "sys_status": "indexed",
+            "sys_data": {"sys_toc_classified": toc},
+            "src_doc_raw_metadata": {INTRO_FIELD: page_range},
+            "map_title": "Test Doc",
+        }
+
+    def test_build_report_row_when_body_annex_then_fail_row(self):
+        toc = "[H1] Intro | context | page 13\n[H1] Misfiled | annexes | page 40\n"
+        row = mod.build_report_row(self._doc(toc, "(13, 67)"), "wfp")
+        assert row["status"] == "fail"
+        assert row["doc_id"] == "doc-1"
+        assert row["title"] == "Test Doc"
+        assert row["data_source"] == "wfp"
+        assert row["range_start"] == 13
+        assert row["excluded_section_types"] == "annexes"
+        assert "[annexes] Misfiled (p.40)" in row["excluded_details"]
+
+    def test_build_report_row_has_all_report_headers(self):
+        row = mod.build_report_row(
+            self._doc("[H1] F | findings | page 30", "(13, 67)"), "wfp"
+        )
+        assert set(row.keys()) == set(mod.REPORT_HEADERS)
+
+    def test_build_report_row_when_no_range_then_skipped(self):
+        row = mod.build_report_row(
+            self._doc("[H1] F | findings | page 30", None), "wfp"
+        )
+        assert row["status"] == "skipped"
+        assert "missing_metadata_range" in row["reasons"]

--- a/tests/unit/test_check_included_section_types.py
+++ b/tests/unit/test_check_included_section_types.py
@@ -1,0 +1,234 @@
+"""Unit tests for the section-inclusion evaluation script.
+
+Covers the pure logic: page-range parsing, classified-TOC parsing, detecting
+sections in the body range tagged with default-excluded section types, and the
+per-document evaluation verdict.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# The script lives under tests/evaluation/ and is not an importable package, so
+# load it by path.
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "evaluation"
+    / "section_inclusion"
+    / "check_included_section_types.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "check_included_section_types", _SCRIPT_PATH
+)
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+pytestmark = pytest.mark.unit
+
+
+class TestParsePageRange:
+    def test_parse_page_range_when_tuple_then_start_end(self):
+        assert mod.parse_page_range((13, 67)) == (13, 67)
+
+    def test_parse_page_range_when_list_then_start_end(self):
+        assert mod.parse_page_range([13, 67]) == (13, 67)
+
+    def test_parse_page_range_when_string_then_extracts_numbers(self):
+        assert mod.parse_page_range("(13, 67)") == (13, 67)
+
+    def test_parse_page_range_when_dict_then_named_keys(self):
+        raw = {"start_page_number": 13, "end_page_number": 67}
+        assert mod.parse_page_range(raw) == (13, 67)
+
+    def test_parse_page_range_when_single_int_then_same_start_end(self):
+        assert mod.parse_page_range(42) == (42, 42)
+
+    def test_parse_page_range_when_none_then_none_pair(self):
+        assert mod.parse_page_range(None) == (None, None)
+
+    def test_parse_page_range_when_empty_string_then_none_pair(self):
+        assert mod.parse_page_range("n/a") == (None, None)
+
+    def test_parse_page_range_when_bool_not_treated_as_int(self):
+        # bool is a subclass of int; must not be coerced to a page number.
+        assert mod.parse_page_range(True) == (None, None)
+
+
+class TestParseTocClassified:
+    def test_parse_toc_classified_when_empty_then_no_entries(self):
+        assert mod.parse_toc_classified("") == []
+
+    def test_parse_toc_classified_when_lines_then_label_and_page(self):
+        toc = (
+            "[H1] Introduction | introduction | page 13\n"
+            "  [H2] Methods | methodology | page 20\n"
+            "[H1] Annexes | annexes | page 68\n"
+        )
+        entries = mod.parse_toc_classified(toc)
+        assert len(entries) == 3
+        assert entries[0] == {
+            "title": "Introduction",
+            "label": "introduction",
+            "page": 13,
+        }
+        assert entries[1]["label"] == "methodology"
+        assert entries[2]["page"] == 68
+
+    def test_parse_toc_classified_when_no_page_then_page_none(self):
+        entries = mod.parse_toc_classified("[H1] Foreword | front_matter")
+        assert entries == [{"title": "Foreword", "label": "front_matter", "page": None}]
+
+    def test_parse_toc_classified_ignores_unparseable_lines(self):
+        entries = mod.parse_toc_classified("garbage line without pipes")
+        assert entries == []
+
+    def test_parse_toc_classified_when_trailing_front_marker_then_parsed(self):
+        # Real WFP rows end with a bracket marker such as [Front].
+        entries = mod.parse_toc_classified(
+            "[H1] Rapport de l'évaluation | front_matter | page 1 [Front]"
+        )
+        assert entries == [
+            {"title": "Rapport de l'évaluation", "label": "front_matter", "page": 1}
+        ]
+
+    def test_parse_toc_classified_when_roman_alias_and_marker_then_parsed(self):
+        entries = mod.parse_toc_classified(
+            "[H2] Résumé Exécutif | executive_summary | page 6 (i) [Front]"
+        )
+        assert entries == [
+            {"title": "Résumé Exécutif", "label": "executive_summary", "page": 6}
+        ]
+
+
+class TestFindExcludedSections:
+    def _entries(self):
+        return [
+            {"title": "Front", "label": "front_matter", "page": 5},  # before range
+            {"title": "Findings", "label": "findings", "page": 20},  # included
+            {
+                "title": "Hidden Annex",
+                "label": "annexes",
+                "page": 40,
+            },  # excluded, in range
+            {
+                "title": "Intro",
+                "label": "introduction",
+                "page": 15,
+            },  # excluded, in range
+            {"title": "Real Annex", "label": "annexes", "page": 80},  # after range
+        ]
+
+    def test_find_excluded_sections_flags_excluded_labels_in_range(self):
+        result = mod.find_excluded_sections(self._entries(), 13, 67)
+        labels = sorted(sec["label"] for sec in result)
+        assert labels == ["annexes", "introduction"]
+
+    def test_find_excluded_sections_ignores_included_labels(self):
+        result = mod.find_excluded_sections(self._entries(), 13, 67)
+        assert all(sec["label"] != "findings" for sec in result)
+
+    def test_find_excluded_sections_ignores_out_of_range_pages(self):
+        result = mod.find_excluded_sections(self._entries(), 13, 67)
+        pages = {sec["page"] for sec in result}
+        assert 5 not in pages and 80 not in pages
+
+    def test_find_excluded_sections_when_all_included_then_empty(self):
+        entries = [{"title": "F", "label": "findings", "page": 30}]
+        assert mod.find_excluded_sections(entries, 13, 67) == []
+
+    def test_find_excluded_sections_inclusive_of_boundaries(self):
+        entries = [
+            {"title": "Start", "label": "acronyms", "page": 13},
+            {"title": "End", "label": "acronyms", "page": 67},
+        ]
+        result = mod.find_excluded_sections(entries, 13, 67)
+        assert len(result) == 2
+
+    def test_find_excluded_sections_skips_entries_without_page(self):
+        entries = [{"title": "X", "label": "annexes", "page": None}]
+        assert mod.find_excluded_sections(entries, 13, 67) == []
+
+    def test_find_excluded_sections_custom_included_set(self):
+        entries = [{"title": "M", "label": "methodology", "page": 20}]
+        # methodology excluded when it is not in the custom included set
+        result = mod.find_excluded_sections(entries, 13, 67, included=["findings"])
+        assert len(result) == 1
+
+
+class TestEvaluateDocument:
+    def _payload(self, toc, page_range):
+        """Build a doc row shaped like PostgresClient.fetch_all_docs() returns."""
+        return {
+            "id": "doc-1",
+            "sys_status": "indexed",
+            "sys_data": {"sys_toc_classified": toc},
+            "src_doc_raw_metadata": {mod.INTRO_RANGE_FIELD: page_range},
+            "map_title": "Test Doc",
+        }
+
+    def test_evaluate_document_when_body_annex_then_fail(self):
+        toc = "[H1] Intro | context | page 13\n" "[H1] Misfiled | annexes | page 40\n"
+        result = mod.evaluate_document(self._payload(toc, (13, 67)))
+        assert result["status"] == "fail"
+        assert result["num_excluded"] == 1
+        assert "annexes" in result["excluded_section_types"]
+        assert result["sections_in_range"] == 2
+
+    def test_evaluate_document_when_all_included_then_pass(self):
+        toc = "[H1] Findings | findings | page 30\n"
+        result = mod.evaluate_document(self._payload(toc, (13, 67)))
+        assert result["status"] == "pass"
+        assert result["num_excluded"] == 0
+
+    def test_evaluate_document_when_no_range_then_skipped(self):
+        result = mod.evaluate_document(
+            self._payload("[H1] F | findings | page 30", None)
+        )
+        assert result["status"] == "skipped"
+        assert "missing_metadata_range" in result["reasons"]
+
+    def test_evaluate_document_when_no_toc_then_skipped(self):
+        result = mod.evaluate_document(self._payload("", (13, 67)))
+        assert result["status"] == "skipped"
+        assert "missing_toc_classified" in result["reasons"]
+
+    def test_evaluate_document_when_range_is_string_then_parsed(self):
+        # Real stored shape is a string such as "(11, 62)".
+        toc = "[H1] Misfiled | annexes | page 40\n"
+        result = mod.evaluate_document(self._payload(toc, "(11, 62)"))
+        assert result["range_start"] == 11
+        assert result["range_end"] == 62
+        assert result["status"] == "fail"
+
+    def test_evaluate_document_uses_map_title(self):
+        result = mod.evaluate_document(
+            self._payload("[H1] F | findings | page 30", "(13, 67)")
+        )
+        assert result["title"] == "Test Doc"
+
+
+class TestSelectDocuments:
+    def _docs(self):
+        return [
+            {"id": "a", "sys_status": "indexed"},
+            {"id": "b", "sys_status": "parse_failed"},
+            {"id": "c", "sys_status": "indexed"},
+        ]
+
+    def test_select_documents_filters_by_status(self):
+        selected = mod.select_documents(self._docs(), None, None)
+        assert [d["id"] for d in selected] == ["a", "c"]
+
+    def test_select_documents_applies_limit(self):
+        selected = mod.select_documents(self._docs(), 1, None)
+        assert [d["id"] for d in selected] == ["a"]
+
+    def test_select_documents_by_file_id(self):
+        selected = mod.select_documents(self._docs(), None, "c")
+        assert [d["id"] for d in selected] == ["c"]
+
+    def test_select_documents_when_file_id_missing_then_raises(self):
+        with pytest.raises(ValueError, match="not found"):
+            mod.select_documents(self._docs(), None, "zzz")

--- a/tests/unit/test_section_inclusion.py
+++ b/tests/unit/test_section_inclusion.py
@@ -1,0 +1,205 @@
+"""Unit tests for pipeline.validation.section_inclusion (pure logic)."""
+
+import pytest
+
+from pipeline.validation import section_inclusion as si
+
+pytestmark = pytest.mark.unit
+
+
+class TestParsePageRange:
+    def test_parse_page_range_when_tuple_then_start_end(self):
+        assert si.parse_page_range((13, 67)) == (13, 67)
+
+    def test_parse_page_range_when_list_then_start_end(self):
+        assert si.parse_page_range([13, 67]) == (13, 67)
+
+    def test_parse_page_range_when_string_then_extracts_numbers(self):
+        assert si.parse_page_range("(13, 67)") == (13, 67)
+
+    def test_parse_page_range_when_dict_then_named_keys(self):
+        raw = {"start_page_number": 13, "end_page_number": 67}
+        assert si.parse_page_range(raw) == (13, 67)
+
+    def test_parse_page_range_when_single_int_then_same_start_end(self):
+        assert si.parse_page_range(42) == (42, 42)
+
+    def test_parse_page_range_when_none_then_none_pair(self):
+        assert si.parse_page_range(None) == (None, None)
+
+    def test_parse_page_range_when_empty_string_then_none_pair(self):
+        assert si.parse_page_range("n/a") == (None, None)
+
+    def test_parse_page_range_when_bool_not_treated_as_int(self):
+        # bool is a subclass of int; must not be coerced to a page number.
+        assert si.parse_page_range(True) == (None, None)
+
+
+class TestParseTocClassified:
+    def test_parse_toc_classified_when_empty_then_no_entries(self):
+        assert si.parse_toc_classified("") == []
+
+    def test_parse_toc_classified_when_lines_then_label_and_page(self):
+        toc = (
+            "[H1] Introduction | introduction | page 13\n"
+            "  [H2] Methods | methodology | page 20\n"
+            "[H1] Annexes | annexes | page 68\n"
+        )
+        entries = si.parse_toc_classified(toc)
+        assert len(entries) == 3
+        assert entries[0] == {
+            "title": "Introduction",
+            "label": "introduction",
+            "page": 13,
+        }
+        assert entries[1]["label"] == "methodology"
+        assert entries[2]["page"] == 68
+
+    def test_parse_toc_classified_when_no_page_then_page_none(self):
+        entries = si.parse_toc_classified("[H1] Foreword | front_matter")
+        assert entries == [{"title": "Foreword", "label": "front_matter", "page": None}]
+
+    def test_parse_toc_classified_ignores_unparseable_lines(self):
+        assert si.parse_toc_classified("garbage line without pipes") == []
+
+    def test_parse_toc_classified_when_trailing_front_marker_then_parsed(self):
+        # Real WFP rows end with a bracket marker such as [Front].
+        entries = si.parse_toc_classified(
+            "[H1] Rapport de l'evaluation | front_matter | page 1 [Front]"
+        )
+        assert entries == [
+            {"title": "Rapport de l'evaluation", "label": "front_matter", "page": 1}
+        ]
+
+    def test_parse_toc_classified_when_roman_alias_and_marker_then_parsed(self):
+        entries = si.parse_toc_classified(
+            "[H2] Resume Executif | executive_summary | page 6 (i) [Front]"
+        )
+        assert entries == [
+            {"title": "Resume Executif", "label": "executive_summary", "page": 6}
+        ]
+
+
+class TestFindExcludedSections:
+    def _entries(self):
+        return [
+            {"title": "Front", "label": "front_matter", "page": 5},  # before range
+            {"title": "Findings", "label": "findings", "page": 20},  # included
+            {"title": "Hidden Annex", "label": "annexes", "page": 40},  # in range
+            {"title": "Intro", "label": "introduction", "page": 15},  # in range
+            {"title": "Real Annex", "label": "annexes", "page": 80},  # after range
+        ]
+
+    def test_find_excluded_sections_flags_excluded_labels_in_range(self):
+        result = si.find_excluded_sections(self._entries(), 13, 67)
+        assert sorted(sec["label"] for sec in result) == ["annexes", "introduction"]
+
+    def test_find_excluded_sections_ignores_included_labels(self):
+        result = si.find_excluded_sections(self._entries(), 13, 67)
+        assert all(sec["label"] != "findings" for sec in result)
+
+    def test_find_excluded_sections_ignores_out_of_range_pages(self):
+        result = si.find_excluded_sections(self._entries(), 13, 67)
+        pages = {sec["page"] for sec in result}
+        assert 5 not in pages and 80 not in pages
+
+    def test_find_excluded_sections_when_all_included_then_empty(self):
+        entries = [{"title": "F", "label": "findings", "page": 30}]
+        assert si.find_excluded_sections(entries, 13, 67) == []
+
+    def test_find_excluded_sections_inclusive_of_boundaries(self):
+        entries = [
+            {"title": "Start", "label": "acronyms", "page": 13},
+            {"title": "End", "label": "acronyms", "page": 67},
+        ]
+        assert len(si.find_excluded_sections(entries, 13, 67)) == 2
+
+    def test_find_excluded_sections_skips_entries_without_page(self):
+        entries = [{"title": "X", "label": "annexes", "page": None}]
+        assert si.find_excluded_sections(entries, 13, 67) == []
+
+    def test_find_excluded_sections_custom_included_set(self):
+        entries = [{"title": "M", "label": "methodology", "page": 20}]
+        result = si.find_excluded_sections(entries, 13, 67, included=["findings"])
+        assert len(result) == 1
+
+
+class TestSectionsInRange:
+    def test_sections_in_range_filters_by_page(self):
+        entries = [
+            {"title": "a", "label": "x", "page": 10},
+            {"title": "b", "label": "y", "page": 20},
+            {"title": "c", "label": "z", "page": None},
+        ]
+        result = si.sections_in_range(entries, 15, 25)
+        assert [e["title"] for e in result] == ["b"]
+
+
+class TestEvaluateDocument:
+    def _doc(self, toc, page_range):
+        """A doc row shaped like PostgresClient.fetch_docs() returns."""
+        return {
+            "id": "doc-1",
+            "sys_status": "indexed",
+            "sys_data": {"sys_toc_classified": toc},
+            "src_doc_raw_metadata": {si.INTRO_RANGE_FIELD: page_range},
+            "map_title": "Test Doc",
+        }
+
+    def test_evaluate_document_when_body_annex_then_fail(self):
+        toc = "[H1] Intro | context | page 13\n[H1] Misfiled | annexes | page 40\n"
+        result = si.evaluate_document(self._doc(toc, (13, 67)))
+        assert result["status"] == "fail"
+        assert result["num_excluded"] == 1
+        assert result["excluded_section_types"] == ["annexes"]
+        assert result["sections_in_range"] == 2
+        assert result["excluded_sections"][0]["title"] == "Misfiled"
+
+    def test_evaluate_document_when_all_included_then_pass(self):
+        toc = "[H1] Findings | findings | page 30\n"
+        result = si.evaluate_document(self._doc(toc, (13, 67)))
+        assert result["status"] == "pass"
+        assert result["num_excluded"] == 0
+
+    def test_evaluate_document_when_no_range_then_skipped(self):
+        result = si.evaluate_document(self._doc("[H1] F | findings | page 30", None))
+        assert result["status"] == "skipped"
+        assert "missing_metadata_range" in result["reasons"]
+
+    def test_evaluate_document_when_no_toc_then_skipped(self):
+        result = si.evaluate_document(self._doc("", (13, 67)))
+        assert result["status"] == "skipped"
+        assert "missing_toc_classified" in result["reasons"]
+
+    def test_evaluate_document_when_range_is_string_then_parsed(self):
+        toc = "[H1] Misfiled | annexes | page 40\n"
+        result = si.evaluate_document(self._doc(toc, "(11, 62)"))
+        assert result["range_start"] == 11
+        assert result["range_end"] == 62
+        assert result["status"] == "fail"
+
+    def test_evaluate_document_reads_toc_from_top_level(self):
+        doc = {
+            "id": "doc-2",
+            "sys_toc_classified": "[H1] A | annexes | page 40",
+            "src_doc_raw_metadata": {si.INTRO_RANGE_FIELD: (13, 67)},
+            "map_title": "Top Level",
+        }
+        result = si.evaluate_document(doc)
+        assert result["status"] == "fail"
+
+
+class TestAccessors:
+    def test_get_document_title_prefers_map_title(self):
+        assert si.get_document_title({"map_title": "T"}) == "T"
+
+    def test_get_document_title_falls_back_to_raw(self):
+        doc = {"src_doc_raw_metadata": {"Title evaluation": "Eval"}}
+        assert si.get_document_title(doc) == "Eval"
+
+    def test_get_document_title_when_missing_then_unknown(self):
+        assert si.get_document_title({}) == "Unknown"
+
+    def test_describe_excluded_sections_formats_each(self):
+        sections = [{"title": "Ch 4", "label": "annexes", "page": 40}]
+        assert si.describe_excluded_sections(sections) == "[annexes] Ch 4 (p.40)"

--- a/tests/unit/test_toc_validator_service.py
+++ b/tests/unit/test_toc_validator_service.py
@@ -1,0 +1,85 @@
+"""Unit tests for the TOC validator backend service."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipeline.validation.section_inclusion import INTRO_RANGE_FIELD
+from ui.backend.services import toc_validator as service
+
+pytestmark = pytest.mark.unit
+
+
+def _doc(toc, page_range):
+    return {
+        "sys_status": "indexed",
+        "sys_data": {"sys_toc_classified": toc},
+        "src_doc_raw_metadata": {INTRO_RANGE_FIELD: page_range},
+        "map_title": "Doc",
+    }
+
+
+class TestRunValidation:
+    def test_run_validation_persists_and_returns_results(self):
+        pg = MagicMock()
+        pg.fetch_docs.return_value = {
+            "d1": _doc("[H1] Misfiled | annexes | page 40", "(13, 67)"),
+        }
+        results = service.run_validation(
+            pg, ["d1"], validated_by="admin@x.io", validated_at="2026-01-01T00:00:00Z"
+        )
+        assert len(results) == 1
+        row = results[0]
+        assert row["doc_id"] == "d1"
+        assert row["status"] == "fail"
+        assert row["excluded_section_types"] == ["annexes"]
+        assert row["validated_by"] == "admin@x.io"
+        assert row["validated_at"] == "2026-01-01T00:00:00Z"
+
+        # Persisted via merge_doc_sys_fields under the sys_toc_validation field.
+        pg.merge_doc_sys_fields.assert_called_once()
+        _, kwargs = pg.merge_doc_sys_fields.call_args
+        assert kwargs["doc_id"] == "d1"
+        assert kwargs["sys_fields"][service.SYS_FIELD]["status"] == "fail"
+
+    def test_run_validation_skips_unknown_doc_ids(self):
+        pg = MagicMock()
+        pg.fetch_docs.return_value = {}
+        results = service.run_validation(pg, ["missing"], validated_by=None)
+        assert results == []
+        pg.merge_doc_sys_fields.assert_not_called()
+
+    def test_run_validation_stamps_when_no_timestamp_given(self):
+        pg = MagicMock()
+        pg.fetch_docs.return_value = {
+            "d1": _doc("[H1] F | findings | page 30", "(13, 67)")
+        }
+        results = service.run_validation(pg, ["d1"])
+        assert results[0]["status"] == "pass"
+        assert results[0]["validated_at"]  # non-empty ISO timestamp
+
+    def test_run_validation_preserves_requested_order(self):
+        pg = MagicMock()
+        pg.fetch_docs.return_value = {
+            "a": _doc("[H1] F | findings | page 30", "(13, 67)"),
+            "b": _doc("[H1] X | annexes | page 40", "(13, 67)"),
+        }
+        results = service.run_validation(pg, ["b", "a"])
+        assert [r["doc_id"] for r in results] == ["b", "a"]
+
+
+class TestGetStoredResults:
+    def test_get_stored_results_returns_only_validated(self):
+        pg = MagicMock()
+        pg.fetch_doc_sys_fields.return_value = {
+            "d1": {"sys_toc_validation": {"status": "fail"}},
+            "d2": {"sys_status": "indexed"},  # never validated
+        }
+        results = service.get_stored_results(pg)
+        assert list(results.keys()) == ["d1"]
+        assert results["d1"]["status"] == "fail"
+
+    def test_get_stored_results_when_none_then_empty(self):
+        pg = MagicMock()
+        pg.fetch_doc_sys_fields.return_value = {}
+        assert service.get_stored_results(pg) == {}

--- a/ui/backend/main.py
+++ b/ui/backend/main.py
@@ -858,6 +858,7 @@ if USER_MODULE:
     from ui.backend.routes import ratings as ratings_routes
     from ui.backend.routes import research as research_routes
     from ui.backend.routes import testing as testing_routes
+    from ui.backend.routes import toc_validator as toc_validator_routes
 
     app.include_router(ratings_routes.router, prefix="/ratings", tags=["ratings"])
     app.include_router(activity_routes.router, prefix="/activity", tags=["activity"])
@@ -866,6 +867,9 @@ if USER_MODULE:
     app.include_router(mcp_audit_routes.router, prefix="/mcp-audit", tags=["mcp-audit"])
     app.include_router(llm_usage_routes.router, prefix="/llm-usage", tags=["llm-usage"])
     app.include_router(testing_routes.router, prefix="/testing", tags=["testing"])
+    app.include_router(
+        toc_validator_routes.router, prefix="/toc-validator", tags=["toc-validator"]
+    )
     logger.info("User module enabled (USER_MODULE=%s)", USER_MODULE_MODE)
 
     # Auto-promote first superuser on startup (if configured)

--- a/ui/backend/routes/toc_validator.py
+++ b/ui/backend/routes/toc_validator.py
@@ -1,0 +1,95 @@
+"""Admin TOC validator — superuser-only routes.
+
+Runs the section-inclusion check over selected documents and persists the result
+on each document. Checks the *current* classification only (no re-tagging); the
+work is pure string parsing so it runs synchronously in a threadpool. Every
+endpoint is gated with ``Depends(current_superuser)`` and rate-limited. Errors
+are returned generically per SECURITY.md; full detail is logged server-side.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel, Field
+
+from ui.backend.auth.models import User
+from ui.backend.auth.users import current_superuser
+from ui.backend.services import toc_validator as service
+from ui.backend.utils.app_limits import get_rate_limits, limiter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+_RL_SEARCH, _RL_DEFAULT, _RL_AI = get_rate_limits()
+
+# Cap how many documents one request may validate (defence-in-depth alongside
+# the request-body-size middleware).
+MAX_DOC_IDS = 2000
+
+
+class TocValidatorRunRequest(BaseModel):
+    data_source: Optional[str] = None
+    doc_ids: List[str] = Field(..., min_length=1, max_length=MAX_DOC_IDS)
+
+
+class TocValidatorRunResponse(BaseModel):
+    results: List[Dict[str, Any]]
+
+
+class TocValidatorResultsResponse(BaseModel):
+    results: Dict[str, Dict[str, Any]]
+
+
+def _get_pg(data_source: Optional[str]):
+    """Resolve a PostgresClient for the data source, validating it first."""
+    from ui.backend.utils.app_state import get_pg_for_source
+
+    try:
+        return get_pg_for_source(data_source)
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid data_source: {data_source}"
+        )
+    except Exception:
+        logger.exception("data_source validation failed")
+        raise HTTPException(status_code=400, detail="Invalid data_source")
+
+
+@router.post("/run", response_model=TocValidatorRunResponse, tags=["toc-validator"])
+@limiter.limit(_RL_DEFAULT)
+async def run_validation(
+    request: Request,
+    body: TocValidatorRunRequest,
+    admin: User = Depends(current_superuser),
+) -> TocValidatorRunResponse:
+    """Validate the given documents and persist each result."""
+    pg = _get_pg(body.data_source)
+    try:
+        results = await run_in_threadpool(
+            service.run_validation, pg, body.doc_ids, admin.email
+        )
+    except Exception:
+        logger.exception("TOC validation run failed")
+        raise HTTPException(status_code=500, detail="TOC validation failed")
+    return TocValidatorRunResponse(results=results)
+
+
+@router.get(
+    "/results", response_model=TocValidatorResultsResponse, tags=["toc-validator"]
+)
+@limiter.limit(_RL_DEFAULT)
+async def get_results(
+    request: Request,
+    data_source: Optional[str] = Query(None),
+    admin: User = Depends(current_superuser),
+) -> TocValidatorResultsResponse:
+    """Return previously-stored validation results for a data source."""
+    pg = _get_pg(data_source)
+    try:
+        results = await run_in_threadpool(service.get_stored_results, pg, None)
+    except Exception:
+        logger.exception("Fetching TOC validation results failed")
+        raise HTTPException(status_code=500, detail="Could not load results")
+    return TocValidatorResultsResponse(results=results)

--- a/ui/backend/services/toc_validator.py
+++ b/ui/backend/services/toc_validator.py
@@ -1,0 +1,83 @@
+"""TOC validator service.
+
+Runs the section-inclusion check (``pipeline.validation.section_inclusion``) over
+documents and persists the result on each document row under the
+``sys_toc_validation`` field (merged into ``sys_data`` via
+``PostgresClient.merge_doc_sys_fields`` — the same mechanism used for
+``sys_toc_approved``). No schema migration is required: the per-source
+``docs_<source>`` tables auto-create ``sys_*`` columns on write.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pipeline.db import PostgresClient
+from pipeline.validation.section_inclusion import evaluate_document
+
+# Field name stored on each document row (in sys_data + its own column).
+SYS_FIELD = "sys_toc_validation"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_result(
+    doc: Dict[str, Any],
+    doc_id: str,
+    validated_by: Optional[str],
+    validated_at: str,
+) -> Dict[str, Any]:
+    """Evaluate a document row and shape the persisted/returned result."""
+    evaluation = evaluate_document(doc)
+    return {
+        "doc_id": str(doc_id),
+        "status": evaluation["status"],
+        "range_start": evaluation["range_start"],
+        "range_end": evaluation["range_end"],
+        "sections_in_range": evaluation["sections_in_range"],
+        "num_excluded": evaluation["num_excluded"],
+        "excluded_section_types": evaluation["excluded_section_types"],
+        "excluded_sections": evaluation["excluded_sections"],
+        "reasons": evaluation["reasons"],
+        "validated_at": validated_at,
+        "validated_by": validated_by,
+    }
+
+
+def run_validation(
+    pg: PostgresClient,
+    doc_ids: List[str],
+    validated_by: Optional[str] = None,
+    validated_at: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Validate each document, persist the result, and return the results.
+
+    Unknown ``doc_ids`` (not present in the table) are skipped silently.
+    """
+    stamp = validated_at or _now_iso()
+    docs = pg.fetch_docs(doc_ids)
+    results: List[Dict[str, Any]] = []
+    for doc_id in doc_ids:
+        doc = docs.get(str(doc_id))
+        if doc is None:
+            continue
+        result = build_result(doc, str(doc_id), validated_by, stamp)
+        pg.merge_doc_sys_fields(doc_id=str(doc_id), sys_fields={SYS_FIELD: result})
+        results.append(result)
+    return results
+
+
+def get_stored_results(
+    pg: PostgresClient, doc_ids: Optional[List[str]] = None
+) -> Dict[str, Dict[str, Any]]:
+    """Return previously-stored validation results keyed by doc_id."""
+    sys_map = pg.fetch_doc_sys_fields(doc_ids)
+    results: Dict[str, Dict[str, Any]] = {}
+    for doc_id, sys_data in sys_map.items():
+        stored = (sys_data or {}).get(SYS_FIELD)
+        if stored:
+            results[str(doc_id)] = stored
+    return results

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -12103,3 +12103,110 @@ a.admin-citation-clickable:hover {
 .testing-case-editor-wrap {
   display: contents;
 }
+
+/* ---------------------------------------------------------------------------
+   Admin: TOC Validator
+   --------------------------------------------------------------------------- */
+.toc-validator-toolbar {
+  display: flex;
+  gap: var(--spacing-sm);
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: var(--spacing-lg);
+}
+
+.toc-validator-toolbar .admin-search-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.45rem 0.65rem;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  background: var(--white);
+}
+
+.toc-validator-toolbar .admin-search-input:focus {
+  outline: none;
+  border-color: var(--brand-primary);
+}
+
+.toc-validator-spacer {
+  flex: 1;
+}
+
+.toc-validator-select-col {
+  width: 32px;
+  text-align: center;
+}
+
+.toc-validator-empty {
+  text-align: center;
+  padding: var(--spacing-lg);
+  color: var(--gray-500);
+}
+
+.toc-validator-pagination {
+  display: flex;
+  gap: var(--spacing-md);
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--spacing-lg);
+}
+
+.toc-validator-row-changed {
+  background: #eff6ff;
+}
+
+/* Verdict cell — reuses .status-badge; adds verdict-specific colours. */
+.toc-validation-cell {
+  min-width: 190px;
+}
+
+.status-pass {
+  background: var(--color-success);
+  color: white;
+}
+
+.status-fail {
+  background: var(--color-danger);
+  color: white;
+}
+
+.status-skipped {
+  background: var(--gray-400);
+  color: white;
+}
+
+.status-untested {
+  background: transparent;
+  color: var(--gray-500);
+  border: 1px dashed var(--gray-300);
+}
+
+.toc-validation-detail {
+  font-size: 0.78rem;
+  color: var(--gray-600);
+  margin-top: 4px;
+}
+
+.toc-validation-meta {
+  font-size: 0.72rem;
+  color: var(--gray-500);
+  margin-top: 2px;
+}
+
+/* Link-styled buttons (accessible alternative to href="#" action links). */
+button.doc-link {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0 var(--spacing-sm) 0 0;
+  font: inherit;
+  color: var(--color-link);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+button.doc-link:hover {
+  color: var(--color-link-hover);
+}

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -12210,3 +12210,22 @@ button.doc-link {
 button.doc-link:hover {
   color: var(--color-link-hover);
 }
+
+/* TOC Validator — filterable column header layout + popover backdrop. */
+.toc-validator-table th .toc-th-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-xs);
+}
+
+.toc-validator-table .filter-icon-button {
+  flex-shrink: 0;
+}
+
+/* Click-away layer; sits just under .filter-popover (z-index: 1000). */
+.filter-popover-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -2998,7 +2998,11 @@ function App() {
         onTabChange={handleTabChange}
       />
 
-      <AdminPanel isActive={activeTab === 'admin'} />
+      <AdminPanel
+        isActive={activeTab === 'admin'}
+        dataSource={dataSource}
+        dataSourceConfig={currentDataSourceConfig}
+      />
 
       <AppFooter>
         <button

--- a/ui/frontend/src/components/admin/AdminPanel.tsx
+++ b/ui/frontend/src/components/admin/AdminPanel.tsx
@@ -9,10 +9,13 @@ import LlmUsageManager from './LlmUsageManager';
 import McpAuditLog from './McpAuditLog';
 import RatingsManager from './RatingsManager';
 import TestingManager from './TestingManager';
+import TocValidatorManager from './TocValidatorManager';
 import UserManager from './UserManager';
 
 interface AdminPanelProps {
   isActive: boolean;
+  dataSource?: string;
+  dataSourceConfig?: import('../../App').DataSourceConfigItem;
 }
 
 type AdminTab =
@@ -24,7 +27,8 @@ type AdminTab =
   | 'llm-usage'
   | 'mcp-audit'
   | 'api-keys'
-  | 'testing';
+  | 'testing'
+  | 'toc-validator';
 
 const TAB_USERS: AdminTab = 'users';
 const TAB_GROUPS: AdminTab = 'groups';
@@ -35,12 +39,17 @@ const TAB_LLM_USAGE: AdminTab = 'llm-usage';
 const TAB_MCP_AUDIT: AdminTab = 'mcp-audit';
 const TAB_API_KEYS: AdminTab = 'api-keys';
 const TAB_TESTING: AdminTab = 'testing';
+const TAB_TOC_VALIDATOR: AdminTab = 'toc-validator';
 const ACTIVE_CLASS = 'admin-tab-active';
 
 const tabClass = (tab: AdminTab, current: AdminTab) =>
   `admin-tab ${tab === current ? ACTIVE_CLASS : ''}`;
 
-const AdminPanel: React.FC<AdminPanelProps> = ({ isActive }) => {
+const AdminPanel: React.FC<AdminPanelProps> = ({
+  isActive,
+  dataSource = '',
+  dataSourceConfig,
+}) => {
   const { user } = useAuth();
   const [tab, setTab] = useState<AdminTab>(TAB_USERS);
 
@@ -105,6 +114,12 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ isActive }) => {
           >
             Testing
           </button>
+          <button
+            className={tabClass(tab, TAB_TOC_VALIDATOR)}
+            onClick={() => setTab(TAB_TOC_VALIDATOR)}
+          >
+            TOC Validator
+          </button>
         </div>
       </div>
       <div className="admin-tab-content">
@@ -117,6 +132,12 @@ const AdminPanel: React.FC<AdminPanelProps> = ({ isActive }) => {
         {tab === TAB_MCP_AUDIT && <McpAuditLog />}
         {tab === TAB_API_KEYS && <ApiKeyManager />}
         {tab === TAB_TESTING && <TestingManager />}
+        {tab === TAB_TOC_VALIDATOR && (
+          <TocValidatorManager
+            dataSource={dataSource}
+            dataSourceConfig={dataSourceConfig}
+          />
+        )}
       </div>
     </div>
   );

--- a/ui/frontend/src/components/admin/TocValidationResultCell.tsx
+++ b/ui/frontend/src/components/admin/TocValidationResultCell.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import type { TocValidationResult } from '../../types/api';
+
+interface TocValidationResultCellProps {
+  result?: TocValidationResult;
+  /** True when this row's result was added or changed by the most recent run. */
+  changed?: boolean;
+}
+
+const STATUS_LABEL = new Map<string, string>([
+  ['pass', 'Pass'],
+  ['fail', 'Fail'],
+  ['skipped', 'Skipped'],
+]);
+
+const formatTimestamp = (iso: string): string => {
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? iso : parsed.toLocaleString();
+};
+
+/** Short explanation of why a document could not be validated. */
+const REASON_LABEL = new Map<string, string>([
+  ['missing_metadata_range', 'no body page range in metadata'],
+  ['missing_toc_classified', 'no classified contents'],
+]);
+
+const describeReasons = (reasons: string[]): string =>
+  reasons.map((reason) => REASON_LABEL.get(reason) || reason).join(', ');
+
+/**
+ * Renders a document's TOC validation verdict: status chip, what was flagged,
+ * and when it was last checked. Shows "Not tested" when there is no result yet.
+ */
+export const TocValidationResultCell: React.FC<TocValidationResultCellProps> = ({
+  result,
+  changed,
+}) => {
+  if (!result) {
+    return (
+      <td className="toc-validation-cell">
+        <span className="status-badge status-untested">Not tested</span>
+      </td>
+    );
+  }
+
+  return (
+    <td className="toc-validation-cell">
+      <span className={`status-badge status-${result.status}`}>
+        {STATUS_LABEL.get(result.status) || result.status}
+      </span>
+      {changed && <span className="badge badge-default">updated</span>}
+      {result.status === 'fail' && (
+        <div className="toc-validation-detail" title={
+          result.excluded_sections
+            .map((sec) => `[${sec.label}] ${sec.title} (p.${sec.page})`)
+            .join('\n')
+        }>
+          {result.num_excluded} excluded section
+          {result.num_excluded === 1 ? '' : 's'}: {result.excluded_section_types.join(', ')}
+        </div>
+      )}
+      {result.status === 'skipped' && result.reasons.length > 0 && (
+        <div className="toc-validation-detail">{describeReasons(result.reasons)}</div>
+      )}
+      {result.status === 'pass' && (
+        <div className="toc-validation-detail">
+          {result.sections_in_range} section
+          {result.sections_in_range === 1 ? '' : 's'} in range, all included
+        </div>
+      )}
+      <div className="toc-validation-meta">{formatTimestamp(result.validated_at)}</div>
+    </td>
+  );
+};
+
+export default TocValidationResultCell;

--- a/ui/frontend/src/components/admin/TocValidatorFilterPopover.tsx
+++ b/ui/frontend/src/components/admin/TocValidatorFilterPopover.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import type { FilterColumn } from './useTocValidator';
+
+/** Friendly labels for the review-verdict filter options. */
+const REVIEW_LABELS: Record<string, string> = {
+  pass: 'Pass',
+  fail: 'Fail',
+  skipped: 'Skipped',
+  untested: 'Not tested',
+};
+
+const COLUMN_LABELS: Record<FilterColumn, string> = {
+  title: 'title',
+  organization: 'organization',
+  status: 'status',
+  review: 'review',
+};
+
+const formatOption = (column: FilterColumn, value: string): string =>
+  column === 'review' ? REVIEW_LABELS[value] || value : value;
+
+interface TocValidatorFilterPopoverProps {
+  column: FilterColumn;
+  position: { top: number; left: number };
+  currentValue: string;
+  options: string[];
+  onApply: (column: FilterColumn, value: string) => void;
+  onClear: (column: FilterColumn) => void;
+  onClose: () => void;
+}
+
+/** Text filter (title) — reuses the Documents Library popover styling. */
+const TextFilter: React.FC<{
+  column: FilterColumn;
+  currentValue: string;
+  onApply: (column: FilterColumn, value: string) => void;
+  onClear: (column: FilterColumn) => void;
+}> = ({ column, currentValue, onApply, onClear }) => {
+  const [text, setText] = React.useState(currentValue);
+  return (
+    <div className="filter-text-input">
+      <input
+        type="text"
+        placeholder="Enter search text..."
+        value={text}
+        onChange={(event) => setText(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') onApply(column, text.trim());
+        }}
+        autoFocus
+      />
+      <div className="filter-actions">
+        <button className="filter-apply-button" onClick={() => onApply(column, text.trim())}>
+          Apply
+        </button>
+        {currentValue && (
+          <button className="filter-clear-button" onClick={() => onClear(column)}>
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/** Checkbox multiselect (organization / status / review). */
+const MultiselectFilter: React.FC<{
+  column: FilterColumn;
+  currentValue: string;
+  options: string[];
+  onApply: (column: FilterColumn, value: string) => void;
+  onClear: (column: FilterColumn) => void;
+}> = ({ column, currentValue, options, onApply, onClear }) => {
+  const [selected, setSelected] = React.useState<Set<string>>(
+    () => new Set(currentValue ? currentValue.split(',').map((v) => v.trim()) : [])
+  );
+
+  const toggle = (value: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) next.delete(value);
+      else next.add(value);
+      return next;
+    });
+
+  const toggleAll = () =>
+    setSelected((prev) => (prev.size === options.length ? new Set() : new Set(options)));
+
+  const allSelected = options.length > 0 && selected.size === options.length;
+  const someSelected = selected.size > 0 && selected.size < options.length;
+
+  return (
+    <div className="filter-multiselect">
+      <div className="filter-multiselect-options">
+        <label className="filter-checkbox-item filter-select-all">
+          <input
+            type="checkbox"
+            checked={allSelected}
+            ref={(el) => {
+              if (el) el.indeterminate = someSelected;
+            }}
+            onChange={toggleAll}
+          />
+          <span>Select all</span>
+        </label>
+        {options.map((option) => (
+          <label key={option} className="filter-checkbox-item">
+            <input
+              type="checkbox"
+              checked={selected.has(option)}
+              onChange={() => toggle(option)}
+            />
+            <span>{formatOption(column, option)}</span>
+          </label>
+        ))}
+      </div>
+      <div className="filter-actions">
+        <button
+          className="filter-apply-button"
+          onClick={() => onApply(column, Array.from(selected).join(','))}
+        >
+          Apply{selected.size > 0 ? ` (${selected.size})` : ''}
+        </button>
+        {currentValue && (
+          <button className="filter-clear-button" onClick={() => onClear(column)}>
+            Clear
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const TocValidatorFilterPopover: React.FC<TocValidatorFilterPopoverProps> = ({
+  column,
+  position,
+  currentValue,
+  options,
+  onApply,
+  onClear,
+  onClose,
+}) => (
+  <>
+    <div className="filter-popover-backdrop" onClick={onClose} />
+    <div
+      className="filter-popover"
+      style={{ position: 'absolute', top: `${position.top}px`, left: `${position.left}px` }}
+    >
+      <div className="filter-popover-header">
+        <span>Filter {COLUMN_LABELS[column]}</span>
+        <button className="filter-popover-close" onClick={onClose} aria-label="Close filter">
+          ×
+        </button>
+      </div>
+      <div className="filter-popover-content">
+        {column === 'title' ? (
+          <TextFilter
+            column={column}
+            currentValue={currentValue}
+            onApply={onApply}
+            onClear={onClear}
+          />
+        ) : (
+          <MultiselectFilter
+            column={column}
+            currentValue={currentValue}
+            options={options}
+            onApply={onApply}
+            onClear={onClear}
+          />
+        )}
+      </div>
+    </div>
+  </>
+);
+
+export default TocValidatorFilterPopover;

--- a/ui/frontend/src/components/admin/TocValidatorManager.tsx
+++ b/ui/frontend/src/components/admin/TocValidatorManager.tsx
@@ -148,6 +148,15 @@ export const TocValidatorManager: React.FC<TocValidatorManagerProps> = ({
         allOnPageSelected={allOnPageSelected}
         onOpenMetadata={handleOpenMetadata}
         onOpenToc={handleOpenToc}
+        columnFilters={state.columnFilters}
+        activeFilterColumn={state.activeFilterColumn}
+        filterPosition={state.filterPosition}
+        onFilterClick={state.openFilter}
+        onApplyFilter={state.applyFilter}
+        onClearFilter={state.clearFilter}
+        hasActiveFilter={state.hasActiveFilter}
+        getCategoricalOptions={state.getCategoricalOptions}
+        onCloseFilter={state.closeFilter}
       />
 
       <div className="toc-validator-pagination">

--- a/ui/frontend/src/components/admin/TocValidatorManager.tsx
+++ b/ui/frontend/src/components/admin/TocValidatorManager.tsx
@@ -1,0 +1,194 @@
+import axios from 'axios';
+import React, { useCallback, useState } from 'react';
+import API_BASE_URL from '../../config';
+import { MetadataModal } from '../documents/MetadataModal';
+import TocModal from '../TocModal';
+import TocValidatorTable from './TocValidatorTable';
+import { docKey, useTocValidator } from './useTocValidator';
+
+interface TocValidatorManagerProps {
+  dataSource?: string;
+  dataSourceConfig?: import('../../App').DataSourceConfigItem;
+}
+
+interface TocModalState {
+  open: boolean;
+  docId: string;
+  toc: string;
+  loading: boolean;
+}
+
+const EMPTY_TOC_STATE: TocModalState = {
+  open: false,
+  docId: '',
+  toc: '',
+  loading: false,
+};
+
+/**
+ * Admin screen: list documents, validate that every section inside each
+ * document's human-set main-body page range uses a section type that Search
+ * includes by default, and open the metadata / contents views to verify or fix
+ * a classification manually.
+ */
+export const TocValidatorManager: React.FC<TocValidatorManagerProps> = ({
+  dataSource = '',
+  dataSourceConfig,
+}) => {
+  const state = useTocValidator(dataSource);
+  const [metadataDoc, setMetadataDoc] = useState<any>(null);
+  const [tocState, setTocState] = useState<TocModalState>(EMPTY_TOC_STATE);
+
+  const metadataPanelFields =
+    dataSourceConfig?.metadata_panel_fields || dataSourceConfig?.filter_fields || {};
+
+  const handleOpenMetadata = useCallback((doc: any) => setMetadataDoc(doc), []);
+
+  const handleOpenToc = useCallback(
+    async (doc: any) => {
+      const docId = docKey(doc);
+      const seeded = doc.toc_classified || doc.sys_toc_classified || doc.toc || '';
+      setTocState({ open: true, docId, toc: seeded, loading: true });
+      try {
+        const response = await axios.get<any>(`${API_BASE_URL}/document/${docId}`, {
+          params: { data_source: dataSource || undefined },
+        });
+        const data = response.data || {};
+        setTocState({
+          open: true,
+          docId,
+          toc: data.toc_classified || data.sys_toc_classified || seeded,
+          loading: false,
+        });
+      } catch (err) {
+        setTocState((prev) => ({ ...prev, loading: false }));
+      }
+    },
+    [dataSource]
+  );
+
+  const closeToc = useCallback(() => setTocState(EMPTY_TOC_STATE), []);
+
+  // Editing the classification changes the answer, so re-check the document.
+  const handleTocUpdated = useCallback(
+    (newToc: string) => {
+      setTocState((prev) => ({ ...prev, toc: newToc }));
+      if (tocState.docId) state.revalidate(tocState.docId);
+    },
+    [state, tocState.docId]
+  );
+
+  const pageIds = state.documents.map(docKey);
+  const allOnPageSelected =
+    pageIds.length > 0 && pageIds.every((id) => state.selectedIds.has(id));
+  const selectedCount = state.selectedIds.size;
+  // Map lookup keeps the table free of dynamic object indexing.
+  const resultsByDocId = React.useMemo(
+    () => new Map(Object.entries(state.results)),
+    [state.results]
+  );
+
+  return (
+    <div className="admin-section toc-validator">
+      <p className="text-muted">
+        Checks that every section inside each document&apos;s main-body page range
+        (&ldquo;Introduction &ndash; before beginning of Annexes&rdquo;) is tagged with a
+        section type that Search includes by default.
+      </p>
+
+      {state.error && <div className="auth-error">{state.error}</div>}
+
+      <div className="admin-controls toc-validator-toolbar">
+        <input
+          type="text"
+          className="admin-search-input"
+          placeholder="Filter by title..."
+          value={state.search}
+          onChange={(event) => {
+            state.setPage(1);
+            state.setSearch(event.target.value);
+          }}
+        />
+        <p className="text-muted" style={{ margin: 0 }}>
+          {selectedCount} selected
+        </p>
+        <button
+          className="btn-sm"
+          onClick={state.selectAllMatching}
+          disabled={state.loading || state.running}
+        >
+          Select all {state.total}
+        </button>
+        <button
+          className="btn-sm"
+          onClick={state.clearSelection}
+          disabled={selectedCount === 0}
+        >
+          Clear
+        </button>
+        <button
+          className="btn-sm btn-primary"
+          style={{ marginLeft: 'auto' }}
+          onClick={state.runValidation}
+          disabled={selectedCount === 0 || state.running}
+        >
+          {state.running ? 'Validating…' : `Run validation (${selectedCount})`}
+        </button>
+      </div>
+
+      {state.loading && <div className="admin-loading">Loading…</div>}
+
+      <TocValidatorTable
+        documents={state.documents}
+        results={resultsByDocId}
+        changedIds={state.changedIds}
+        selectedIds={state.selectedIds}
+        onToggle={state.toggle}
+        onTogglePage={state.togglePage}
+        allOnPageSelected={allOnPageSelected}
+        onOpenMetadata={handleOpenMetadata}
+        onOpenToc={handleOpenToc}
+      />
+
+      <div className="toc-validator-pagination">
+        <button
+          className="btn-sm"
+          onClick={() => state.setPage(Math.max(1, state.page - 1))}
+          disabled={state.page <= 1}
+        >
+          Previous
+        </button>
+        <span className="text-muted">
+          Page {state.page} of {state.totalPages}
+        </span>
+        <button
+          className="btn-sm"
+          onClick={() => state.setPage(Math.min(state.totalPages, state.page + 1))}
+          disabled={state.page >= state.totalPages}
+        >
+          Next
+        </button>
+      </div>
+
+      <MetadataModal
+        isOpen={Boolean(metadataDoc)}
+        onClose={() => setMetadataDoc(null)}
+        metadataDoc={metadataDoc}
+        metadataPanelFields={metadataPanelFields}
+        onOpenToc={handleOpenToc}
+      />
+
+      <TocModal
+        isOpen={tocState.open}
+        onClose={closeToc}
+        toc={tocState.toc}
+        docId={tocState.docId}
+        dataSource={dataSource}
+        loading={tocState.loading}
+        onTocUpdated={handleTocUpdated}
+      />
+    </div>
+  );
+};
+
+export default TocValidatorManager;

--- a/ui/frontend/src/components/admin/TocValidatorTable.tsx
+++ b/ui/frontend/src/components/admin/TocValidatorTable.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import type { TocValidationResult } from '../../types/api';
+import TocValidationResultCell from './TocValidationResultCell';
+
+interface TocValidatorTableProps {
+  documents: any[];
+  results: Map<string, TocValidationResult>;
+  changedIds: Set<string>;
+  selectedIds: Set<string>;
+  onToggle: (docId: string) => void;
+  onTogglePage: () => void;
+  allOnPageSelected: boolean;
+  onOpenMetadata: (doc: any) => void;
+  onOpenToc: (doc: any) => void;
+}
+
+const docKey = (doc: any): string => String(doc.doc_id || doc.id || '');
+
+/** Per-row Metadata / Contents links, mirroring the Documents Library. */
+const DocumentLinksCell: React.FC<{
+  doc: any;
+  onOpenMetadata: (doc: any) => void;
+  onOpenToc: (doc: any) => void;
+}> = ({ doc, onOpenMetadata, onOpenToc }) => (
+  <td className="doc-links">
+    <button
+      type="button"
+      className="doc-link"
+      title="Display all fields for this document"
+      onClick={() => onOpenMetadata(doc)}
+    >
+      Metadata
+    </button>
+    {doc.toc && (
+      <button
+        type="button"
+        className="doc-link"
+        title="Display document table of contents and section tags"
+        onClick={() => onOpenToc(doc)}
+      >
+        Contents
+      </button>
+    )}
+  </td>
+);
+
+export const TocValidatorTable: React.FC<TocValidatorTableProps> = ({
+  documents,
+  results,
+  changedIds,
+  selectedIds,
+  onToggle,
+  onTogglePage,
+  allOnPageSelected,
+  onOpenMetadata,
+  onOpenToc,
+}) => (
+  <table className="admin-table toc-validator-table">
+    <thead>
+      <tr>
+        <th className="toc-validator-select-col">
+          <input
+            type="checkbox"
+            checked={allOnPageSelected}
+            onChange={onTogglePage}
+            aria-label="Select all documents on this page"
+          />
+        </th>
+        <th>Title</th>
+        <th>Organization</th>
+        <th>Status</th>
+        <th>Validation</th>
+        <th>Links</th>
+      </tr>
+    </thead>
+    <tbody>
+      {documents.map((doc) => {
+        const key = docKey(doc);
+        const status = doc.status || doc.sys_status || 'downloaded';
+        const rowClass = [
+          selectedIds.has(key) ? 'admin-row-selected' : '',
+          changedIds.has(key) ? 'toc-validator-row-changed' : '',
+        ]
+          .filter(Boolean)
+          .join(' ');
+        return (
+          <tr key={key} className={rowClass}>
+            <td className="toc-validator-select-col">
+              <input
+                type="checkbox"
+                checked={selectedIds.has(key)}
+                onChange={() => onToggle(key)}
+                aria-label={`Select ${doc.map_title || doc.title || key}`}
+              />
+            </td>
+            <td>{doc.map_title || doc.title || '(untitled)'}</td>
+            <td>{doc.organization || doc.map_organization || '-'}</td>
+            <td>
+              <span
+                className={`status-badge status-${status} ${
+                  status === 'indexed' ? 'status-badge-success' : ''
+                }`}
+              >
+                {status}
+              </span>
+            </td>
+            <TocValidationResultCell
+              result={results.get(key)}
+              changed={changedIds.has(key)}
+            />
+            <DocumentLinksCell
+              doc={doc}
+              onOpenMetadata={onOpenMetadata}
+              onOpenToc={onOpenToc}
+            />
+          </tr>
+        );
+      })}
+      {documents.length === 0 && (
+        <tr>
+          <td colSpan={6} className="toc-validator-empty">
+            No documents found.
+          </td>
+        </tr>
+      )}
+    </tbody>
+  </table>
+);
+
+export default TocValidatorTable;

--- a/ui/frontend/src/components/admin/TocValidatorTable.tsx
+++ b/ui/frontend/src/components/admin/TocValidatorTable.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import type { TocValidationResult } from '../../types/api';
 import TocValidationResultCell from './TocValidationResultCell';
+import TocValidatorFilterPopover from './TocValidatorFilterPopover';
+import type { FilterColumn } from './useTocValidator';
 
 interface TocValidatorTableProps {
   documents: any[];
@@ -12,9 +14,53 @@ interface TocValidatorTableProps {
   allOnPageSelected: boolean;
   onOpenMetadata: (doc: any) => void;
   onOpenToc: (doc: any) => void;
+  // Column filtering
+  columnFilters: Record<string, string>;
+  activeFilterColumn: FilterColumn | null;
+  filterPosition: { top: number; left: number };
+  onFilterClick: (column: FilterColumn, event: React.MouseEvent<HTMLButtonElement>) => void;
+  onApplyFilter: (column: FilterColumn, value: string) => void;
+  onClearFilter: (column: FilterColumn) => void;
+  hasActiveFilter: (column: FilterColumn) => boolean;
+  getCategoricalOptions: (column: FilterColumn) => string[];
+  onCloseFilter: () => void;
 }
 
 const docKey = (doc: any): string => String(doc.doc_id || doc.id || '');
+
+/** Funnel icon, matching the Documents Library header filter button. */
+const FunnelIcon: React.FC = () => (
+  <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M0.5 1.5h11l-4.5 5.25v3.75l-2 1.5v-5.25l-4.5-5.25z"
+      stroke="currentColor"
+      strokeWidth="1"
+      fill="none"
+    />
+  </svg>
+);
+
+/** Column header with a filter funnel button. */
+const FilterableHeader: React.FC<{
+  column: FilterColumn;
+  label: string;
+  onFilterClick: (column: FilterColumn, event: React.MouseEvent<HTMLButtonElement>) => void;
+  hasActiveFilter: (column: FilterColumn) => boolean;
+}> = ({ column, label, onFilterClick, hasActiveFilter }) => (
+  <th>
+    <div className="toc-th-inner">
+      <span>{label}</span>
+      <button
+        type="button"
+        className={`filter-icon-button ${hasActiveFilter(column) ? 'active' : ''}`}
+        onClick={(event) => onFilterClick(column, event)}
+        aria-label={`Filter ${label.toLowerCase()}`}
+      >
+        <FunnelIcon />
+      </button>
+    </div>
+  </th>
+);
 
 /** Per-row Metadata / Contents links, mirroring the Documents Library. */
 const DocumentLinksCell: React.FC<{
@@ -54,77 +100,119 @@ export const TocValidatorTable: React.FC<TocValidatorTableProps> = ({
   allOnPageSelected,
   onOpenMetadata,
   onOpenToc,
+  columnFilters,
+  activeFilterColumn,
+  filterPosition,
+  onFilterClick,
+  onApplyFilter,
+  onClearFilter,
+  hasActiveFilter,
+  getCategoricalOptions,
+  onCloseFilter,
 }) => (
-  <table className="admin-table toc-validator-table">
-    <thead>
-      <tr>
-        <th className="toc-validator-select-col">
-          <input
-            type="checkbox"
-            checked={allOnPageSelected}
-            onChange={onTogglePage}
-            aria-label="Select all documents on this page"
-          />
-        </th>
-        <th>Title</th>
-        <th>Organization</th>
-        <th>Status</th>
-        <th>Validation</th>
-        <th>Links</th>
-      </tr>
-    </thead>
-    <tbody>
-      {documents.map((doc) => {
-        const key = docKey(doc);
-        const status = doc.status || doc.sys_status || 'downloaded';
-        const rowClass = [
-          selectedIds.has(key) ? 'admin-row-selected' : '',
-          changedIds.has(key) ? 'toc-validator-row-changed' : '',
-        ]
-          .filter(Boolean)
-          .join(' ');
-        return (
-          <tr key={key} className={rowClass}>
-            <td className="toc-validator-select-col">
-              <input
-                type="checkbox"
-                checked={selectedIds.has(key)}
-                onChange={() => onToggle(key)}
-                aria-label={`Select ${doc.map_title || doc.title || key}`}
-              />
-            </td>
-            <td>{doc.map_title || doc.title || '(untitled)'}</td>
-            <td>{doc.organization || doc.map_organization || '-'}</td>
-            <td>
-              <span
-                className={`status-badge status-${status} ${
-                  status === 'indexed' ? 'status-badge-success' : ''
-                }`}
-              >
-                {status}
-              </span>
-            </td>
-            <TocValidationResultCell
-              result={results.get(key)}
-              changed={changedIds.has(key)}
-            />
-            <DocumentLinksCell
-              doc={doc}
-              onOpenMetadata={onOpenMetadata}
-              onOpenToc={onOpenToc}
-            />
-          </tr>
-        );
-      })}
-      {documents.length === 0 && (
+  <>
+    <table className="admin-table toc-validator-table">
+      <thead>
         <tr>
-          <td colSpan={6} className="toc-validator-empty">
-            No documents found.
-          </td>
+          <th className="toc-validator-select-col">
+            <input
+              type="checkbox"
+              checked={allOnPageSelected}
+              onChange={onTogglePage}
+              aria-label="Select all documents on this page"
+            />
+          </th>
+          <FilterableHeader
+            column="title"
+            label="Title"
+            onFilterClick={onFilterClick}
+            hasActiveFilter={hasActiveFilter}
+          />
+          <FilterableHeader
+            column="organization"
+            label="Organization"
+            onFilterClick={onFilterClick}
+            hasActiveFilter={hasActiveFilter}
+          />
+          <FilterableHeader
+            column="status"
+            label="Status"
+            onFilterClick={onFilterClick}
+            hasActiveFilter={hasActiveFilter}
+          />
+          <FilterableHeader
+            column="review"
+            label="Table of Contents review"
+            onFilterClick={onFilterClick}
+            hasActiveFilter={hasActiveFilter}
+          />
+          <th>Links</th>
         </tr>
-      )}
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        {documents.map((doc) => {
+          const key = docKey(doc);
+          const status = doc.status || doc.sys_status || 'downloaded';
+          const rowClass = [
+            selectedIds.has(key) ? 'admin-row-selected' : '',
+            changedIds.has(key) ? 'toc-validator-row-changed' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+          return (
+            <tr key={key} className={rowClass}>
+              <td className="toc-validator-select-col">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(key)}
+                  onChange={() => onToggle(key)}
+                  aria-label={`Select ${doc.map_title || doc.title || key}`}
+                />
+              </td>
+              <td>{doc.map_title || doc.title || '(untitled)'}</td>
+              <td>{doc.organization || doc.map_organization || '-'}</td>
+              <td>
+                <span
+                  className={`status-badge status-${status} ${
+                    status === 'indexed' ? 'status-badge-success' : ''
+                  }`}
+                >
+                  {status}
+                </span>
+              </td>
+              <TocValidationResultCell
+                result={results.get(key)}
+                changed={changedIds.has(key)}
+              />
+              <DocumentLinksCell
+                doc={doc}
+                onOpenMetadata={onOpenMetadata}
+                onOpenToc={onOpenToc}
+              />
+            </tr>
+          );
+        })}
+        {documents.length === 0 && (
+          <tr>
+            <td colSpan={6} className="toc-validator-empty">
+              No documents found.
+            </td>
+          </tr>
+        )}
+      </tbody>
+    </table>
+    {activeFilterColumn && (
+      <TocValidatorFilterPopover
+        column={activeFilterColumn}
+        position={filterPosition}
+        currentValue={columnFilters[activeFilterColumn] || ''}
+        options={getCategoricalOptions(activeFilterColumn)}
+        onApply={onApplyFilter}
+        onClear={onClearFilter}
+        onClose={onCloseFilter}
+      />
+    )}
+  </>
 );
 
 export default TocValidatorTable;

--- a/ui/frontend/src/components/admin/useTocValidator.ts
+++ b/ui/frontend/src/components/admin/useTocValidator.ts
@@ -1,0 +1,226 @@
+import axios from 'axios';
+import { useCallback, useEffect, useState } from 'react';
+import API_BASE_URL from '../../config';
+import type { TocValidationResult } from '../../types/api';
+
+const PAGE_SIZE = 25;
+/** Max page size the /documents endpoint allows — used when collecting all ids. */
+const MAX_PAGE_SIZE = 100;
+
+export const docKey = (doc: any): string => String(doc.doc_id || doc.id || '');
+
+interface DocumentsResponse {
+  documents?: any[];
+  total?: number;
+  total_pages?: number;
+}
+
+/**
+ * Returns true when the two results differ in a way worth highlighting to the
+ * user (a brand new result, or a changed verdict / excluded-section count).
+ */
+const hasChanged = (
+  previous: TocValidationResult | undefined,
+  next: TocValidationResult
+): boolean => {
+  if (!previous) return true;
+  return (
+    previous.status !== next.status ||
+    previous.num_excluded !== next.num_excluded ||
+    previous.excluded_section_types.join(',') !== next.excluded_section_types.join(',')
+  );
+};
+
+/** State + actions for the admin TOC validator screen. */
+export const useTocValidator = (dataSource: string) => {
+  const [documents, setDocuments] = useState<any[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [results, setResults] = useState<Record<string, TocValidationResult>>({});
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [changedIds, setChangedIds] = useState<Set<string>>(new Set());
+  const [running, setRunning] = useState(false);
+
+  const loadDocuments = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        page: String(page),
+        page_size: String(PAGE_SIZE),
+      });
+      if (dataSource) params.set('data_source', dataSource);
+      if (search.trim()) params.set('search', search.trim());
+      const response = await axios.get<DocumentsResponse>(
+        `${API_BASE_URL}/documents?${params.toString()}`
+      );
+      setDocuments(response.data.documents || []);
+      setTotalPages(response.data.total_pages || 1);
+      setTotal(response.data.total || 0);
+    } catch (err) {
+      setError('Could not load documents.');
+    } finally {
+      setLoading(false);
+    }
+  }, [dataSource, page, search]);
+
+  const loadResults = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (dataSource) params.set('data_source', dataSource);
+      const response = await axios.get<{ results: Record<string, TocValidationResult> }>(
+        `${API_BASE_URL}/toc-validator/results?${params.toString()}`
+      );
+      setResults(response.data.results || {});
+    } catch (err) {
+      setError('Could not load previous validation results.');
+    }
+  }, [dataSource]);
+
+  useEffect(() => {
+    loadDocuments();
+  }, [loadDocuments]);
+
+  useEffect(() => {
+    loadResults();
+  }, [loadResults]);
+
+  // A data source change invalidates any selection from the previous source.
+  useEffect(() => {
+    setSelectedIds(new Set());
+    setChangedIds(new Set());
+    setPage(1);
+  }, [dataSource]);
+
+  const toggle = useCallback((docId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(docId)) {
+        next.delete(docId);
+      } else {
+        next.add(docId);
+      }
+      return next;
+    });
+  }, []);
+
+  const togglePage = useCallback(() => {
+    const pageIds = documents.map(docKey);
+    const allSelected = pageIds.length > 0 && pageIds.every((id) => selectedIds.has(id));
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      pageIds.forEach((id) => (allSelected ? next.delete(id) : next.add(id)));
+      return next;
+    });
+  }, [documents, selectedIds]);
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
+
+  /** Select every document matching the current search, across all pages. */
+  const selectAllMatching = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const ids: string[] = [];
+      let current = 1;
+      let pages = 1;
+      do {
+        const params = new URLSearchParams({
+          page: String(current),
+          page_size: String(MAX_PAGE_SIZE),
+        });
+        if (dataSource) params.set('data_source', dataSource);
+        if (search.trim()) params.set('search', search.trim());
+        const response = await axios.get<DocumentsResponse>(
+          `${API_BASE_URL}/documents?${params.toString()}`
+        );
+        (response.data.documents || []).forEach((doc) => ids.push(docKey(doc)));
+        pages = response.data.total_pages || 1;
+        current += 1;
+      } while (current <= pages);
+      setSelectedIds(new Set(ids));
+    } catch (err) {
+      setError('Could not select all documents.');
+    } finally {
+      setLoading(false);
+    }
+  }, [dataSource, search]);
+
+  const runValidation = useCallback(async () => {
+    const docIds = Array.from(selectedIds);
+    if (docIds.length === 0) return;
+    setRunning(true);
+    setError(null);
+    try {
+      const response = await axios.post<{ results: TocValidationResult[] }>(
+        `${API_BASE_URL}/toc-validator/run`,
+        { data_source: dataSource || null, doc_ids: docIds }
+      );
+      const returned = response.data.results || [];
+      const changed = new Set<string>();
+      setResults((prev) => {
+        const next = { ...prev };
+        returned.forEach((result) => {
+          if (hasChanged(prev[result.doc_id], result)) changed.add(result.doc_id);
+          next[result.doc_id] = result;
+        });
+        return next;
+      });
+      setChangedIds(changed);
+    } catch (err) {
+      setError('Validation run failed.');
+    } finally {
+      setRunning(false);
+    }
+  }, [dataSource, selectedIds]);
+
+  /** Re-validate a single document (used after its classification is edited). */
+  const revalidate = useCallback(
+    async (docId: string) => {
+      try {
+        const response = await axios.post<{ results: TocValidationResult[] }>(
+          `${API_BASE_URL}/toc-validator/run`,
+          { data_source: dataSource || null, doc_ids: [docId] }
+        );
+        const result = (response.data.results || [])[0];
+        if (result) {
+          setResults((prev) => ({ ...prev, [result.doc_id]: result }));
+          setChangedIds((prev) => new Set(prev).add(result.doc_id));
+        }
+      } catch (err) {
+        setError('Could not re-validate document.');
+      }
+    },
+    [dataSource]
+  );
+
+  return {
+    documents,
+    page,
+    totalPages,
+    total,
+    search,
+    loading,
+    error,
+    results,
+    selectedIds,
+    changedIds,
+    running,
+    setPage,
+    setSearch,
+    toggle,
+    togglePage,
+    clearSelection,
+    selectAllMatching,
+    runValidation,
+    revalidate,
+    reloadDocuments: loadDocuments,
+  };
+};
+
+export default useTocValidator;

--- a/ui/frontend/src/components/admin/useTocValidator.ts
+++ b/ui/frontend/src/components/admin/useTocValidator.ts
@@ -1,19 +1,30 @@
 import axios from 'axios';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import API_BASE_URL from '../../config';
 import type { TocValidationResult } from '../../types/api';
 
 const PAGE_SIZE = 25;
-/** Max page size the /documents endpoint allows — used when collecting all ids. */
+/** Max page size the /documents endpoint allows — used when loading every doc. */
 const MAX_PAGE_SIZE = 100;
 
 export const docKey = (doc: any): string => String(doc.doc_id || doc.id || '');
 
+/** Column accessors — kept together so filtering and options stay consistent. */
+export const docTitle = (doc: any): string => doc.map_title || doc.title || '';
+export const docOrg = (doc: any): string =>
+  doc.organization || doc.map_organization || '';
+export const docStatus = (doc: any): string =>
+  doc.status || doc.sys_status || 'downloaded';
+
+/** The four filterable columns; drives header rendering and options. */
+export type FilterColumn = 'title' | 'organization' | 'status' | 'review';
+
 interface DocumentsResponse {
   documents?: any[];
-  total?: number;
   total_pages?: number;
 }
+
+const NONE_LABEL = '(none)';
 
 /**
  * Returns true when the two results differ in a way worth highlighting to the
@@ -31,15 +42,42 @@ const hasChanged = (
   );
 };
 
+const reviewOf = (
+  doc: any,
+  results: Record<string, TocValidationResult>
+): string => results[docKey(doc)]?.status || 'untested';
+
+/** A document passes a single column filter (comma-joined selected values). */
+const passesColumn = (
+  doc: any,
+  column: FilterColumn,
+  raw: string,
+  results: Record<string, TocValidationResult>
+): boolean => {
+  if (!raw) return true;
+  if (column === 'title') {
+    return docTitle(doc).toLowerCase().includes(raw.toLowerCase());
+  }
+  const selected = new Set(raw.split(',').map((v) => v.trim()));
+  if (column === 'organization') return selected.has(docOrg(doc) || NONE_LABEL);
+  if (column === 'status') return selected.has(docStatus(doc));
+  return selected.has(reviewOf(doc, results));
+};
+
 /** State + actions for the admin TOC validator screen. */
 export const useTocValidator = (dataSource: string) => {
-  const [documents, setDocuments] = useState<any[]>([]);
+  const [allDocuments, setAllDocuments] = useState<any[]>([]);
   const [page, setPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
-  const [total, setTotal] = useState(0);
   const [search, setSearch] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
+  const [activeFilterColumn, setActiveFilterColumn] = useState<FilterColumn | null>(null);
+  const [filterPosition, setFilterPosition] = useState<{ top: number; left: number }>({
+    top: 0,
+    left: 0,
+  });
 
   const [results, setResults] = useState<Record<string, TocValidationResult>>({});
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -50,24 +88,29 @@ export const useTocValidator = (dataSource: string) => {
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams({
-        page: String(page),
-        page_size: String(PAGE_SIZE),
-      });
-      if (dataSource) params.set('data_source', dataSource);
-      if (search.trim()) params.set('search', search.trim());
-      const response = await axios.get<DocumentsResponse>(
-        `${API_BASE_URL}/documents?${params.toString()}`
-      );
-      setDocuments(response.data.documents || []);
-      setTotalPages(response.data.total_pages || 1);
-      setTotal(response.data.total || 0);
+      const collected: any[] = [];
+      let current = 1;
+      let pages = 1;
+      do {
+        const params = new URLSearchParams({
+          page: String(current),
+          page_size: String(MAX_PAGE_SIZE),
+        });
+        if (dataSource) params.set('data_source', dataSource);
+        const response = await axios.get<DocumentsResponse>(
+          `${API_BASE_URL}/documents?${params.toString()}`
+        );
+        (response.data.documents || []).forEach((doc) => collected.push(doc));
+        pages = response.data.total_pages || 1;
+        current += 1;
+      } while (current <= pages);
+      setAllDocuments(collected);
     } catch (err) {
       setError('Could not load documents.');
     } finally {
       setLoading(false);
     }
-  }, [dataSource, page, search]);
+  }, [dataSource]);
 
   const loadResults = useCallback(async () => {
     try {
@@ -90,21 +133,92 @@ export const useTocValidator = (dataSource: string) => {
     loadResults();
   }, [loadResults]);
 
-  // A data source change invalidates any selection from the previous source.
+  // A data source change invalidates selection and filters from the old source.
   useEffect(() => {
     setSelectedIds(new Set());
     setChangedIds(new Set());
+    setColumnFilters({});
+    setSearch('');
     setPage(1);
   }, [dataSource]);
+
+  // Filtered set (search box + every active column filter), in load order.
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return allDocuments.filter((doc) => {
+      if (query && !docTitle(doc).toLowerCase().includes(query)) return false;
+      return (Object.keys(columnFilters) as FilterColumn[]).every((column) =>
+        passesColumn(doc, column, columnFilters[column], results)
+      );
+    });
+  }, [allDocuments, search, columnFilters, results]);
+
+  const total = filtered.length;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  const documents = useMemo(
+    () => filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+    [filtered, page]
+  );
+
+  // Keep the current page in range as filters shrink the result set.
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [page, totalPages]);
+
+  /** Distinct values for a categorical column's filter popover. */
+  const getCategoricalOptions = useCallback(
+    (column: FilterColumn): string[] => {
+      if (column === 'review') return ['pass', 'fail', 'skipped', 'untested'];
+      const accessor = column === 'organization' ? docOrg : docStatus;
+      const values = new Set<string>();
+      allDocuments.forEach((doc) => values.add(accessor(doc) || NONE_LABEL));
+      return Array.from(values).sort();
+    },
+    [allDocuments]
+  );
+
+  const openFilter = useCallback(
+    (column: FilterColumn, event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      if (activeFilterColumn === column) {
+        setActiveFilterColumn(null);
+        return;
+      }
+      const rect = event.currentTarget.getBoundingClientRect();
+      setFilterPosition({
+        top: rect.bottom + window.scrollY + 5,
+        left: rect.left + window.scrollX - 150,
+      });
+      setActiveFilterColumn(column);
+    },
+    [activeFilterColumn]
+  );
+
+  const applyFilter = useCallback((column: FilterColumn, value: string) => {
+    setColumnFilters((prev) => {
+      const next = { ...prev };
+      if (value) next[column] = value;
+      else delete next[column];
+      return next;
+    });
+    setPage(1);
+    setActiveFilterColumn(null);
+  }, []);
+
+  const clearFilter = useCallback((column: FilterColumn) => applyFilter(column, ''), [
+    applyFilter,
+  ]);
+
+  const hasActiveFilter = useCallback(
+    (column: FilterColumn): boolean => Boolean(columnFilters[column]),
+    [columnFilters]
+  );
 
   const toggle = useCallback((docId: string) => {
     setSelectedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(docId)) {
-        next.delete(docId);
-      } else {
-        next.add(docId);
-      }
+      if (next.has(docId)) next.delete(docId);
+      else next.add(docId);
       return next;
     });
   }, []);
@@ -121,35 +235,10 @@ export const useTocValidator = (dataSource: string) => {
 
   const clearSelection = useCallback(() => setSelectedIds(new Set()), []);
 
-  /** Select every document matching the current search, across all pages. */
-  const selectAllMatching = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const ids: string[] = [];
-      let current = 1;
-      let pages = 1;
-      do {
-        const params = new URLSearchParams({
-          page: String(current),
-          page_size: String(MAX_PAGE_SIZE),
-        });
-        if (dataSource) params.set('data_source', dataSource);
-        if (search.trim()) params.set('search', search.trim());
-        const response = await axios.get<DocumentsResponse>(
-          `${API_BASE_URL}/documents?${params.toString()}`
-        );
-        (response.data.documents || []).forEach((doc) => ids.push(docKey(doc)));
-        pages = response.data.total_pages || 1;
-        current += 1;
-      } while (current <= pages);
-      setSelectedIds(new Set(ids));
-    } catch (err) {
-      setError('Could not select all documents.');
-    } finally {
-      setLoading(false);
-    }
-  }, [dataSource, search]);
+  /** Select every document matching the current search + column filters. */
+  const selectAllMatching = useCallback(() => {
+    setSelectedIds(new Set(filtered.map(docKey)));
+  }, [filtered]);
 
   const runValidation = useCallback(async () => {
     const docIds = Array.from(selectedIds);
@@ -211,8 +300,17 @@ export const useTocValidator = (dataSource: string) => {
     selectedIds,
     changedIds,
     running,
+    columnFilters,
+    activeFilterColumn,
+    filterPosition,
     setPage,
     setSearch,
+    openFilter,
+    applyFilter,
+    clearFilter,
+    hasActiveFilter,
+    getCategoricalOptions,
+    closeFilter: () => setActiveFilterColumn(null),
     toggle,
     togglePage,
     clearSelection,

--- a/ui/frontend/src/tests/tocValidator.test.tsx
+++ b/ui/frontend/src/tests/tocValidator.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
+import type { TocValidationResult } from '../types/api';
+
+jest.mock('../config', () => ({
+  __esModule: true,
+  default: '/api',
+  USER_MODULE: true,
+  USER_FEEDBACK: false,
+}));
+
+// The reused document modals pull heavy deps; the validator only needs to know
+// it hands them the right document.
+jest.mock('../components/documents/MetadataModal', () => ({
+  __esModule: true,
+  MetadataModal: ({ isOpen, metadataDoc }: any) =>
+    isOpen ? <div data-testid="metadata-modal">{metadataDoc?.map_title}</div> : null,
+}));
+
+jest.mock('../components/TocModal', () => ({
+  __esModule: true,
+  default: ({ isOpen, docId }: any) =>
+    isOpen ? <div data-testid="toc-modal">{docId}</div> : null,
+}));
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: (...args: any[]) => mockGet(...args),
+    post: (...args: any[]) => mockPost(...args),
+  },
+}));
+
+import TocValidationResultCell from '../components/admin/TocValidationResultCell';
+import TocValidatorManager from '../components/admin/TocValidatorManager';
+
+const DOCS = [
+  { doc_id: 'd1', map_title: 'Zambia Country Programme', organization: 'WFP', status: 'indexed', toc: 'x' },
+  { doc_id: 'd2', map_title: 'Yemen Emergency Response', organization: 'WFP', status: 'indexed' },
+];
+
+const failResult: TocValidationResult = {
+  doc_id: 'd1',
+  status: 'fail',
+  range_start: 14,
+  range_end: 56,
+  sections_in_range: 17,
+  num_excluded: 13,
+  excluded_section_types: ['annexes', 'introduction'],
+  excluded_sections: [{ title: 'Recommendations', label: 'annexes', page: 50 }],
+  reasons: [],
+  validated_at: '2026-07-20T10:00:00Z',
+  validated_by: 'admin@wfp.org',
+};
+
+const renderCell = (result?: TocValidationResult, changed?: boolean) =>
+  render(
+    <table>
+      <tbody>
+        <tr>
+          <TocValidationResultCell result={result} changed={changed} />
+        </tr>
+      </tbody>
+    </table>
+  );
+
+describe('TocValidationResultCell', () => {
+  test('shows Not tested when there is no result', () => {
+    renderCell(undefined);
+    expect(screen.getByText('Not tested')).toBeInTheDocument();
+  });
+
+  test('shows fail status with excluded section types', () => {
+    renderCell(failResult);
+    expect(screen.getByText('Fail')).toBeInTheDocument();
+    expect(screen.getByText(/13 excluded sections/)).toBeInTheDocument();
+    expect(screen.getByText(/annexes, introduction/)).toBeInTheDocument();
+  });
+
+  test('shows pass status with in-range section count', () => {
+    renderCell({ ...failResult, status: 'pass', num_excluded: 0, excluded_section_types: [] });
+    expect(screen.getByText('Pass')).toBeInTheDocument();
+    expect(screen.getByText(/17 sections in range, all included/)).toBeInTheDocument();
+  });
+
+  test('shows readable reason when skipped', () => {
+    renderCell({ ...failResult, status: 'skipped', reasons: ['missing_metadata_range'] });
+    expect(screen.getByText('Skipped')).toBeInTheDocument();
+    expect(screen.getByText(/no body page range in metadata/)).toBeInTheDocument();
+  });
+
+  test('shows updated badge when result changed in the last run', () => {
+    renderCell(failResult, true);
+    expect(screen.getByText('updated')).toBeInTheDocument();
+  });
+});
+
+describe('TocValidatorManager', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/toc-validator/results')) {
+        return Promise.resolve({ data: { results: {} } });
+      }
+      if (url.includes('/documents')) {
+        return Promise.resolve({
+          data: { documents: DOCS, total: 2, total_pages: 1 },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+  });
+
+  test('lists documents with a not-tested verdict initially', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    expect(await screen.findByText('Zambia Country Programme')).toBeInTheDocument();
+    expect(screen.getByText('Yemen Emergency Response')).toBeInTheDocument();
+    expect(screen.getAllByText('Not tested')).toHaveLength(2);
+  });
+
+  test('shows previously stored results on load', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/toc-validator/results')) {
+        return Promise.resolve({ data: { results: { d1: failResult } } });
+      }
+      return Promise.resolve({ data: { documents: DOCS, total: 2, total_pages: 1 } });
+    });
+    render(<TocValidatorManager dataSource="wfp" />);
+    expect(await screen.findByText('Fail')).toBeInTheDocument();
+    expect(screen.getAllByText('Not tested')).toHaveLength(1);
+  });
+
+  test('run button is disabled until documents are selected', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    await screen.findByText('Zambia Country Programme');
+    expect(screen.getByRole('button', { name: /Run validation \(0\)/ })).toBeDisabled();
+  });
+
+  test('selecting a document and running validation shows the new verdict', async () => {
+    mockPost.mockResolvedValue({ data: { results: [failResult] } });
+    render(<TocValidatorManager dataSource="wfp" />);
+    await screen.findByText('Zambia Country Programme');
+
+    fireEvent.click(screen.getByLabelText('Select Zambia Country Programme'));
+    const runButton = screen.getByRole('button', { name: /Run validation \(1\)/ });
+    expect(runButton).toBeEnabled();
+    fireEvent.click(runButton);
+
+    await waitFor(() => expect(screen.getByText('Fail')).toBeInTheDocument());
+    expect(mockPost).toHaveBeenCalledWith('/api/toc-validator/run', {
+      data_source: 'wfp',
+      doc_ids: ['d1'],
+    });
+    // Newly added result is highlighted as changed.
+    expect(screen.getByText('updated')).toBeInTheDocument();
+  });
+
+  test('select-all-on-page checkbox selects every row', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    await screen.findByText('Zambia Country Programme');
+    fireEvent.click(screen.getByLabelText('Select all documents on this page'));
+    expect(screen.getByRole('button', { name: /Run validation \(2\)/ })).toBeEnabled();
+  });
+
+  test('opens the metadata modal from the row link', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    const row = (await screen.findByText('Zambia Country Programme')).closest('tr') as HTMLElement;
+    fireEvent.click(within(row).getByText('Metadata'));
+    expect(await screen.findByTestId('metadata-modal')).toHaveTextContent(
+      'Zambia Country Programme'
+    );
+  });
+
+  test('opens the contents modal only when the document has a TOC', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    const withToc = (await screen.findByText('Zambia Country Programme')).closest(
+      'tr'
+    ) as HTMLElement;
+    const withoutToc = screen.getByText('Yemen Emergency Response').closest('tr') as HTMLElement;
+
+    expect(within(withoutToc).queryByText('Contents')).not.toBeInTheDocument();
+    fireEvent.click(within(withToc).getByText('Contents'));
+    expect(await screen.findByTestId('toc-modal')).toHaveTextContent('d1');
+  });
+
+  test('shows an error when the validation run fails', async () => {
+    mockPost.mockRejectedValue(new Error('boom'));
+    render(<TocValidatorManager dataSource="wfp" />);
+    await screen.findByText('Zambia Country Programme');
+    fireEvent.click(screen.getByLabelText('Select Zambia Country Programme'));
+    fireEvent.click(screen.getByRole('button', { name: /Run validation \(1\)/ }));
+    expect(await screen.findByText('Validation run failed.')).toBeInTheDocument();
+  });
+});

--- a/ui/frontend/src/tests/tocValidator.test.tsx
+++ b/ui/frontend/src/tests/tocValidator.test.tsx
@@ -165,6 +165,54 @@ describe('TocValidatorManager', () => {
     expect(screen.getByRole('button', { name: /Run validation \(2\)/ })).toBeEnabled();
   });
 
+  test('renames the verdict column to Table of Contents review', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    await screen.findByText('Zambia Country Programme');
+    expect(screen.getByText('Table of Contents review')).toBeInTheDocument();
+    expect(screen.queryByText('Validation')).not.toBeInTheDocument();
+  });
+
+  test('every filterable column header exposes a filter button', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    await screen.findByText('Zambia Country Programme');
+    [
+      'Filter title',
+      'Filter organization',
+      'Filter status',
+      'Filter table of contents review',
+    ].forEach((label) => {
+      expect(screen.getByLabelText(label)).toBeInTheDocument();
+    });
+  });
+
+  test('a status column filter narrows the visible rows', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/toc-validator/results')) {
+        return Promise.resolve({ data: { results: {} } });
+      }
+      return Promise.resolve({
+        data: {
+          documents: [
+            ...DOCS,
+            { doc_id: 'd3', map_title: 'Draft Report', organization: 'WFP', status: 'parsed' },
+          ],
+          total_pages: 1,
+        },
+      });
+    });
+    render(<TocValidatorManager dataSource="wfp" />);
+    await screen.findByText('Draft Report');
+
+    // Open the Status filter popover, select only "parsed", and apply.
+    fireEvent.click(screen.getByLabelText('Filter status'));
+    const popover = screen.getByText('Filter status').closest('.filter-popover') as HTMLElement;
+    fireEvent.click(within(popover).getByText('parsed'));
+    fireEvent.click(within(popover).getByRole('button', { name: /^Apply/ }));
+
+    expect(screen.getByText('Draft Report')).toBeInTheDocument();
+    expect(screen.queryByText('Zambia Country Programme')).not.toBeInTheDocument();
+  });
+
   test('opens the metadata modal from the row link', async () => {
     render(<TocValidatorManager dataSource="wfp" />);
     const row = (await screen.findByText('Zambia Country Programme')).closest('tr') as HTMLElement;

--- a/ui/frontend/src/types/api.ts
+++ b/ui/frontend/src/types/api.ts
@@ -257,3 +257,29 @@ export interface DrilldownNode {
 export interface SearchFilters {
   [coreField: string]: string | undefined;
 }
+
+/** One classified-TOC section flagged by the TOC validator */
+export interface TocValidationSection {
+  title: string;
+  label: string;
+  page: number | null;
+}
+
+/**
+ * Result of the admin TOC validator check for a single document: whether every
+ * section inside the human-set main-body page range uses a section type that
+ * Search includes by default.
+ */
+export interface TocValidationResult {
+  doc_id: string;
+  status: 'pass' | 'fail' | 'skipped';
+  range_start: number | null;
+  range_end: number | null;
+  sections_in_range: number;
+  num_excluded: number;
+  excluded_section_types: string[];
+  excluded_sections: TocValidationSection[];
+  reasons: string[];
+  validated_at: string;
+  validated_by: string | null;
+}


### PR DESCRIPTION
## Summary

Adds an admin **TOC Validator** screen (ticket 339595) that surfaces documents whose body content is at risk of being hidden from Search because of how its sections are tagged.

Search's default **content type** filter only returns chunks whose section type is one of the "real content" types (`executive_summary, context, methodology, findings, conclusions, recommendations, other`). Everything else — `front_matter, acronyms, annexes, appendix, bibliography, introduction` — is excluded by default. Tagging is automatic at upload, so a body section mis-tagged as e.g. `annexes` silently disappears from default search results.

Each document carries a human-set body page range in its source metadata (`Introduction - before beginning of Annexes`). This feature checks that every section falling inside that range uses a default-included type, and lets an admin verify/fix the classification.

## Screenshots

<img width="1372" height="771" alt="image" src="https://github.com/user-attachments/assets/c025fab0-2abd-4435-ba96-b05392f479e7" />

## What it does

- Lists documents (reusing the Documents Library `/documents` endpoint), with an indication of any prior validation result.
- Select some or all documents → **Run validation** → each verdict is shown and persisted; rows that were added/changed by the run are highlighted.
- **Metadata** and **Contents** links open the same modals as the Documents Library, so a flagged result can be checked — and edited — against the real document. Editing a classification re-validates that document.

Verdicts: **pass** (all in-range sections included), **fail** (an excluded type inside the body range), **skipped** (no range / no classified contents).

> The check inspects the **current** classification only; it never re-tags.

## How it's built

**Shared logic** — extracted into `pipeline/validation/section_inclusion.py` so the backend service and the existing offline eval script (`tests/evaluation/section_inclusion/`) share one implementation (the script now imports it; no behaviour change).

**Backend** (superuser-only, rate-limited) in `ui/backend/routes/toc_validator.py` + `services/toc_validator.py`:
- `POST /toc-validator/run` — validate selected docs, persist, return results
- `GET /toc-validator/results` — stored results for the screen on load

**Frontend** — new admin tab: `TocValidatorManager` + `TocValidatorTable` + `TocValidationResultCell` + `useTocValidator`, reusing `MetadataModal`/`TocModal` and the app's design tokens + shared badge/table/button classes.

## Persistence — note for reviewers

Results are stored per document under a `sys_toc_validation` field via `merge_doc_sys_fields` (the same mechanism `sys_toc_approved` uses). **No Alembic migration**: the per-data-source `docs_<source>` tables are created/altered dynamically at runtime by the `ensure_*` helpers — they are not Alembic-managed except for `uneg`, so a migration would only (wrongly) touch that one source. This matches the existing per-doc-field precedent.

## A finding worth a decision

Across the WFP corpus the dominant failure is sections tagged `introduction` inside the body range. That is systemic, not per-document mis-tagging: the body range starts at the introduction, and `introduction` is not in the default-included set (and has no checkbox in Search settings). The genuinely actionable mis-tags are `annexes`/`acronyms`/`bibliography`/`front_matter` appearing mid-body (e.g. a report whose Findings/Recommendations chapters were labelled `annexes` because headings contained "(EQs 1-5, Annex 8)"). Whether to add `introduction` to the defaults is a product decision this tool now makes visible.

## Testing

- Backend: unit tests for the shared logic (`test_section_inclusion.py`) and service (`test_toc_validator_service.py`); service round-tripped against real WFP data (persist + read-back).
- Frontend: `tocValidator.test.tsx` (manager/table/result cell); full suite **518 passing**, `tsc` clean, eslint zero warnings.
- Verified the two endpoints register on the running API and are superuser-gated.

Docs: `docs/admin/toc-validator.md` (added to the sidebar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
