### PR TITLE
feat(brief): AI Edit + Update actions, per-section research log, and change diff

### DIFF
--- a/prompts/brief_revise_system.j2
+++ b/prompts/brief_revise_system.j2
@@ -1,0 +1,19 @@
+You are a precise copy-editor revising ONE section of an evidence brief.
+
+You are given the section's current markdown. It contains inline citation
+markers like [1], [2], [3] that refer to numbered sources. Revise the section to
+satisfy the user's instruction while changing as LITTLE as possible.
+
+Rules:
+- Make the SMALLEST edits that satisfy the instruction. Keep every sentence,
+  phrase and word the instruction does not require changing EXACTLY as-is.
+- PRESERVE the existing [n] citation markers on the claims they support. Do NOT
+  renumber, add or remove citations — you have no access to the source library,
+  so never invent a citation or a source.
+- Do NOT rewrite or replace the whole section. Do NOT add a preamble, apology,
+  explanation, heading or code fence — output ONLY the revised section markdown.
+- If the instruction cannot be fully satisfied by editing the existing text
+  alone (e.g. it would need new evidence), make the closest safe edit and leave
+  everything else unchanged.
+
+Return ONLY the revised section as markdown — nothing before or after it.

--- a/prompts/brief_revise_system.j2
+++ b/prompts/brief_revise_system.j2
@@ -1,19 +1,26 @@
-You are a precise copy-editor revising ONE section of an evidence brief.
+You are an editor revising ONE section of an evidence brief to satisfy the
+user's instruction.
 
 You are given the section's current markdown. It contains inline citation
-markers like [1], [2], [3] that refer to numbered sources. Revise the section to
-satisfy the user's instruction while changing as LITTLE as possible.
+markers like [1], [2], [3] that refer to numbered sources.
+
+Your FIRST priority is to FULLY carry out the instruction — even when doing so
+requires substantial change: removing, condensing, reordering or rewriting parts
+of the section (for example, "just focus on impacts" means cut everything that
+is not about impacts). Do not water the instruction down or leave it half-done.
+
+Your SECOND priority, subordinate to the first, is continuity: keep the wording
+and citations of the material the instruction does NOT touch as close to the
+original as possible. Do not gratuitously reword unaffected sentences.
 
 Rules:
-- Make the SMALLEST edits that satisfy the instruction. Keep every sentence,
-  phrase and word the instruction does not require changing EXACTLY as-is.
-- PRESERVE the existing [n] citation markers on the claims they support. Do NOT
-  renumber, add or remove citations — you have no access to the source library,
-  so never invent a citation or a source.
-- Do NOT rewrite or replace the whole section. Do NOT add a preamble, apology,
-  explanation, heading or code fence — output ONLY the revised section markdown.
-- If the instruction cannot be fully satisfied by editing the existing text
-  alone (e.g. it would need new evidence), make the closest safe edit and leave
-  everything else unchanged.
+- Actually apply the instruction. If it calls for a big change, make it.
+- Keep the [n] citation markers on the claims they support, and keep them on
+  material you retain. Do NOT renumber, invent, or add citations — you have no
+  access to the source library, so never fabricate a citation or source. You may
+  drop a citation only when you remove the claim it supported.
+- Output ONLY the revised section markdown — no preamble, apology, explanation,
+  heading, or code fence.
+- Use straight quotes (") and apostrophes ('); never HTML entities.
 
 Return ONLY the revised section as markdown — nothing before or after it.

--- a/prompts/brief_revise_user.j2
+++ b/prompts/brief_revise_user.j2
@@ -1,0 +1,6 @@
+Instruction: {{ instruction }}
+
+Current section markdown:
+"""
+{{ content }}
+"""

--- a/prompts/brief_revise_user.j2
+++ b/prompts/brief_revise_user.j2
@@ -1,6 +1,11 @@
+{#- This is a plain-text LLM prompt, not HTML: disable autoescape so quotes and
+    ampersands in the instruction/content are not turned into entities (&#34;)
+    that the model would echo back into the revised section. -#}
+{% autoescape false -%}
 Instruction: {{ instruction }}
 
 Current section markdown:
 """
 {{ content }}
 """
+{%- endautoescape %}

--- a/tests/unit/test_brief_revise.py
+++ b/tests/unit/test_brief_revise.py
@@ -1,0 +1,71 @@
+"""Unit tests for Brief section AI Edit — the surgical single-LLM revise
+(``ui.backend.services.llm_service.revise_brief_section`` + ``_strip_section_wrapper``)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ui.backend.services.llm_service import _strip_section_wrapper, revise_brief_section
+
+pytestmark = pytest.mark.unit
+
+
+class TestStripSectionWrapper:
+    def test_strips_language_code_fence(self):
+        assert _strip_section_wrapper("```markdown\n# Title\n\nBody.\n```") == "# Title\n\nBody."
+
+    def test_strips_bare_code_fence(self):
+        assert _strip_section_wrapper("```\nBody.\n```") == "Body."
+
+    def test_strips_triple_quote_wrapper(self):
+        assert _strip_section_wrapper('"""\nBody.\n"""') == "Body."
+
+    def test_leaves_plain_markdown_untouched(self):
+        md = "## Heading\n\nA claim [1]."
+        assert _strip_section_wrapper(md) == md
+
+
+class TestReviseBriefSection:
+    @staticmethod
+    def _mock_llm(content: str):
+        fake_response = MagicMock()
+        fake_response.content = content
+        fake_llm = MagicMock()
+        fake_llm.ainvoke = AsyncMock(return_value=fake_response)
+        return fake_llm
+
+    @pytest.mark.asyncio
+    async def test_sends_instruction_and_content_without_html_escaping(self):
+        # The model HTML-escapes a quote in its output; the stored section must be
+        # cleaned (entities decoded), and the PROMPT must not escape the content.
+        fake_llm = self._mock_llm('The report says &#34;free and compulsory&#34; [1].')
+        with patch(
+            "ui.backend.services.llm_service.get_llm", return_value=fake_llm
+        ) as mock_get_llm:
+            result = await revise_brief_section(
+                content='Article 53 declares basic education "free and compulsory" [1].',
+                instruction="Make it more concise",
+                model_key="some-model",
+            )
+
+        mock_get_llm.assert_called_once()
+        assert mock_get_llm.call_args.kwargs["model"] == "some-model"
+        sent = fake_llm.ainvoke.call_args.args[0]
+        joined = " ".join(str(m.content) for m in sent)
+        # Instruction + content both reach the LLM.
+        assert "Make it more concise" in joined
+        assert "free and compulsory" in joined
+        # Autoescape is neutralised (Markup/unescape) so quotes are NOT sent as
+        # entities that the model would echo back.
+        assert "&#34;" not in joined
+        # Output entities are decoded so the stored markdown is clean.
+        assert result == 'The report says "free and compulsory" [1].'
+
+    @pytest.mark.asyncio
+    async def test_strips_code_fence_from_output(self):
+        fake_llm = self._mock_llm("```markdown\nRevised body [1].\n```")
+        with patch("ui.backend.services.llm_service.get_llm", return_value=fake_llm):
+            result = await revise_brief_section(
+                content="Body [1].", instruction="tighten", model_key="m"
+            )
+        assert result == "Revised body [1]."

--- a/tests/unit/test_brief_revise.py
+++ b/tests/unit/test_brief_revise.py
@@ -12,7 +12,10 @@ pytestmark = pytest.mark.unit
 
 class TestStripSectionWrapper:
     def test_strips_language_code_fence(self):
-        assert _strip_section_wrapper("```markdown\n# Title\n\nBody.\n```") == "# Title\n\nBody."
+        assert (
+            _strip_section_wrapper("```markdown\n# Title\n\nBody.\n```")
+            == "# Title\n\nBody."
+        )
 
     def test_strips_bare_code_fence(self):
         assert _strip_section_wrapper("```\nBody.\n```") == "Body."
@@ -38,7 +41,7 @@ class TestReviseBriefSection:
     async def test_sends_instruction_and_content_without_html_escaping(self):
         # The model HTML-escapes a quote in its output; the stored section must be
         # cleaned (entities decoded), and the PROMPT must not escape the content.
-        fake_llm = self._mock_llm('The report says &#34;free and compulsory&#34; [1].')
+        fake_llm = self._mock_llm("The report says &#34;free and compulsory&#34; [1].")
         with patch(
             "ui.backend.services.llm_service.get_llm", return_value=fake_llm
         ) as mock_get_llm:

--- a/ui/backend/routes/brief.py
+++ b/ui/backend/routes/brief.py
@@ -16,7 +16,13 @@ from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Request
 
-from ui.backend.schemas import BriefHeading, BriefOutlineRequest, BriefOutlineResponse
+from ui.backend.schemas import (
+    BriefHeading,
+    BriefOutlineRequest,
+    BriefOutlineResponse,
+    BriefReviseRequest,
+    BriefReviseResponse,
+)
 from ui.backend.services import llm_service as llm_service_module
 from ui.backend.utils.app_limits import get_rate_limits, limiter
 
@@ -115,3 +121,44 @@ async def generate_outline(
     except Exception:
         logger.error("Brief outline generation failed", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to generate outline")
+
+
+@router.post("/brief/revise", response_model=BriefReviseResponse)
+@limiter.limit(RATE_LIMIT_AI)
+async def revise_section(
+    request: Request, body: BriefReviseRequest
+) -> BriefReviseResponse:
+    """Surgically revise a section's markdown per an instruction (Brief "Edit").
+
+    A single LLM copy-edit — NOT deep research — so the section keeps its wording
+    and inline [n] citations and only the smallest necessary changes are made.
+    """
+    content = body.content or ""
+    instruction = (body.instruction or "").strip()
+    if not content.strip():
+        raise HTTPException(status_code=400, detail="content is required")
+    if not instruction:
+        raise HTTPException(status_code=400, detail="instruction is required")
+    if len(instruction) > _MAX_QUESTION_CHARS:
+        raise HTTPException(status_code=400, detail="instruction is too long")
+    _validate_data_source(body.data_source)
+
+    model_key = (body.model or "").strip() or _resolve_configured_model(
+        body.data_source
+    )
+    if not model_key:
+        raise HTTPException(
+            status_code=503, detail="No chat/deep-research model is configured"
+        )
+
+    try:
+        llm_service = _get_llm_service()
+        revised = await llm_service.revise_brief_section(
+            content=content,
+            instruction=instruction,
+            model_key=model_key,
+        )
+        return BriefReviseResponse(content=revised)
+    except Exception:
+        logger.error("Brief section revise failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to revise section")

--- a/ui/backend/schemas/__init__.py
+++ b/ui/backend/schemas/__init__.py
@@ -200,3 +200,16 @@ class BriefOutlineRequest(BaseModel):
 class BriefOutlineResponse(BaseModel):
     title: str
     headings: List[BriefHeading]
+
+
+class BriefReviseRequest(BaseModel):
+    # The section's current markdown (with its inline [n] citation markers).
+    content: str
+    # The user's edit instruction (what to change).
+    instruction: str
+    data_source: str
+    model: Optional[str] = None
+
+
+class BriefReviseResponse(BaseModel):
+    content: str

--- a/ui/backend/services/llm_service.py
+++ b/ui/backend/services/llm_service.py
@@ -530,7 +530,10 @@ async def revise_brief_section(
         HumanMessage(content=user_prompt),
     ]
     response = await llm.ainvoke(messages)  # type: ignore[arg-type]
-    return _strip_section_wrapper(str(response.content))
+    # Some models HTML-escape quotes/ampersands in their output (e.g. &#34;),
+    # which would render literally in the section. Decode entities back to plain
+    # text so the stored markdown is clean.
+    return html.unescape(_strip_section_wrapper(str(response.content)))
 
 
 async def translate_text(

--- a/ui/backend/services/llm_service.py
+++ b/ui/backend/services/llm_service.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 
 from deep_translator import GoogleTranslator
 from jinja2 import Environment, FileSystemLoader
-from markupsafe import Markup
 from langchain_core.callbacks import UsageMetadataCallbackHandler
 from langchain_core.messages import HumanMessage, SystemMessage
 
@@ -509,16 +508,16 @@ async def revise_brief_section(
     changes are made. Returns the revised section markdown (wrappers stripped).
     Prompts live in ``prompts/brief_revise_*.j2``.
     """
-    # The prompt Jinja env autoescapes (it is shared and Bandit requires it),
-    # but these templates emit a plain-text LLM prompt, not HTML — escaping
-    # would turn quotes into entities (&#34;) that the model then echoes back
-    # into the revised section verbatim. Interpolate the values unmodified,
-    # and unescape entities already baked into stored content by renders that
-    # predate this fix.
+    # The shared prompt Jinja env autoescapes (Bandit requires it), but these
+    # templates emit a plain-text LLM prompt, not HTML — escaping would turn
+    # quotes into entities (&#34;) that the model then echoes back into the
+    # revised section verbatim. The user template disables autoescape in-place
+    # ({% autoescape false %}), so pass the values as plain strings; unescape
+    # entities already baked into stored content by renders predating this fix.
     system_prompt = _brief_revise_system_template.render()
     user_prompt = _brief_revise_user_template.render(
-        instruction=Markup(html.unescape(instruction.strip())),
-        content=Markup(html.unescape(content)),
+        instruction=html.unescape(instruction.strip()),
+        content=html.unescape(content),
     )
     llm = get_llm(
         model=model_key,

--- a/ui/backend/services/llm_service.py
+++ b/ui/backend/services/llm_service.py
@@ -2,6 +2,7 @@
 LLM Service for generating AI summaries using LangChain
 """
 
+import html
 import json
 import logging
 import os
@@ -13,6 +14,7 @@ from typing import Any, Dict, List, Optional
 
 from deep_translator import GoogleTranslator
 from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
 from langchain_core.callbacks import UsageMetadataCallbackHandler
 from langchain_core.messages import HumanMessage, SystemMessage
 
@@ -120,6 +122,8 @@ _system_template = jinja_env.get_template("ai_summary_system.j2")
 _user_template = jinja_env.get_template("ai_summary_user.j2")
 _brief_outline_system_template = jinja_env.get_template("brief_outline_system.j2")
 _brief_outline_user_template = jinja_env.get_template("brief_outline_user.j2")
+_brief_revise_system_template = jinja_env.get_template("brief_revise_system.j2")
+_brief_revise_user_template = jinja_env.get_template("brief_revise_user.j2")
 
 
 def render_prompt(
@@ -472,6 +476,61 @@ async def generate_brief_outline(
     raw = str(response.content).strip()
     logger.info("Brief outline raw response (%d chars): %s", len(raw), raw[:500])
     return parse_brief_outline(raw, fallback_title=question.strip())
+
+
+def _strip_section_wrapper(text: str) -> str:
+    """Drop an accidental ```markdown fence or matching triple-quote wrapper the
+    model sometimes adds around the returned section."""
+    t = text.strip()
+    if t.startswith("```"):
+        # Remove leading ```lang line and a trailing ``` if present.
+        lines = t.splitlines()
+        if lines:
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        t = "\n".join(lines).strip()
+    if t.startswith('"""') and t.endswith('"""') and len(t) >= 6:
+        t = t[3:-3].strip()
+    return t
+
+
+async def revise_brief_section(
+    content: str,
+    instruction: str,
+    model_key: str | None = None,
+    temperature: float | None = None,
+    max_tokens: int | None = None,
+) -> str:
+    """Surgically revise one brief section's markdown per an instruction.
+
+    A single LLM call — NOT deep research — so the existing wording and inline
+    ``[n]`` citation markers are preserved and only the smallest necessary
+    changes are made. Returns the revised section markdown (wrappers stripped).
+    Prompts live in ``prompts/brief_revise_*.j2``.
+    """
+    # The prompt Jinja env autoescapes (it is shared and Bandit requires it),
+    # but these templates emit a plain-text LLM prompt, not HTML — escaping
+    # would turn quotes into entities (&#34;) that the model then echoes back
+    # into the revised section verbatim. Interpolate the values unmodified,
+    # and unescape entities already baked into stored content by renders that
+    # predate this fix.
+    system_prompt = _brief_revise_system_template.render()
+    user_prompt = _brief_revise_user_template.render(
+        instruction=Markup(html.unescape(instruction.strip())),
+        content=Markup(html.unescape(content)),
+    )
+    llm = get_llm(
+        model=model_key,
+        temperature=temperature if temperature is not None else 0.2,
+        max_tokens=max_tokens or 3000,
+    )
+    messages = [
+        SystemMessage(content=system_prompt),
+        HumanMessage(content=user_prompt),
+    ]
+    response = await llm.ainvoke(messages)  # type: ignore[arg-type]
+    return _strip_section_wrapper(str(response.content))
 
 
 async def translate_text(

--- a/ui/frontend/src/components/brief/BriefDiff.tsx
+++ b/ui/frontend/src/components/brief/BriefDiff.tsx
@@ -198,7 +198,7 @@ const BLOCK_CLASS: Record<DiffBlockType, string> = {
 // straight vs curly) — e.g. an older draft has `&#34;`/`"` while a fresh revise
 // has `"`. They render identically, so treat them as equal to avoid a diff full
 // of meaningless quote-only "changes".
-const normalizeQuotes = (s: string): string =>
+export const normalizeQuotes = (s: string): string =>
   s
     .replace(/&#34;|&quot;/g, '"')
     .replace(/&#39;|&apos;|&#8217;|&#8216;/g, "'")

--- a/ui/frontend/src/components/brief/BriefDiff.tsx
+++ b/ui/frontend/src/components/brief/BriefDiff.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
-// Word-level diff of two markdown strings (old → new) for the Brief "show
-// changes" view after an Edit/Update. Self-contained LCS so no new dependency.
+// Rendered diff of two markdown strings (old → new) for the Brief "show
+// changes" view after an Edit/Update. Lines are diffed first (LCS) so whole
+// added/removed blocks render as tinted markdown; a removed-then-added run is
+// word-diffed and the add/del runs are tagged with private-use sentinel
+// characters that survive markdown parsing, then wrapped in <ins>/<del> at
+// render time. Self-contained so no new dependency.
 
 type SegType = 'same' | 'add' | 'del';
 interface Seg {
@@ -9,12 +15,15 @@ interface Seg {
   text: string;
 }
 
-// Split into word + whitespace tokens so re-joined output preserves spacing.
-const tokenize = (s: string): string[] => s.split(/(\s+)/).filter((t) => t.length > 0);
+// Sentinels marking add/del runs inside a changed block's markdown. Private-use
+// codepoints never occur in real content and pass through remark as plain text.
+export const MARK_ADD_OPEN = '\uE000';
+export const MARK_ADD_CLOSE = '\uE001';
+export const MARK_DEL_OPEN = '\uE002';
+export const MARK_DEL_CLOSE = '\uE003';
 
-export const diffWords = (oldText: string, newText: string): Seg[] => {
-  const a = tokenize(oldText);
-  const b = tokenize(newText);
+// Core LCS diff over token arrays; emits one op per token (unmerged).
+const lcsOps = (a: string[], b: string[]): Seg[] => {
   const n = a.length;
   const m = b.length;
   // LCS length table (row-major, n+1 x m+1).
@@ -24,56 +33,195 @@ export const diffWords = (oldText: string, newText: string): Seg[] => {
       dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
     }
   }
-  const segs: Seg[] = [];
-  const push = (type: SegType, text: string) => {
-    const last = segs[segs.length - 1];
-    if (last && last.type === type) last.text += text;
-    else segs.push({ type, text });
-  };
+  const ops: Seg[] = [];
   let i = 0;
   let j = 0;
   while (i < n && j < m) {
     if (a[i] === b[j]) {
-      push('same', a[i]);
+      ops.push({ type: 'same', text: a[i] });
       i += 1;
       j += 1;
     } else if (dp[i + 1][j] >= dp[i][j + 1]) {
-      push('del', a[i]);
+      ops.push({ type: 'del', text: a[i] });
       i += 1;
     } else {
-      push('add', b[j]);
+      ops.push({ type: 'add', text: b[j] });
       j += 1;
     }
   }
-  while (i < n) {
-    push('del', a[i]);
-    i += 1;
-  }
-  while (j < m) {
-    push('add', b[j]);
-    j += 1;
-  }
+  while (i < n) ops.push({ type: 'del', text: a[i++] });
+  while (j < m) ops.push({ type: 'add', text: b[j++] });
+  return ops;
+};
+
+// Merge adjacent ops of the same type into contiguous segments.
+const mergeOps = (ops: Seg[]): Seg[] => {
+  const segs: Seg[] = [];
+  ops.forEach((op) => {
+    const last = segs[segs.length - 1];
+    if (last && last.type === op.type) last.text += op.text;
+    else segs.push({ ...op });
+  });
   return segs;
 };
 
+// Split into word + whitespace tokens so re-joined output preserves spacing.
+const tokenize = (s: string): string[] => s.split(/(\s+)/).filter((t) => t.length > 0);
+
+export const diffWords = (oldText: string, newText: string): Seg[] =>
+  mergeOps(lcsOps(tokenize(oldText), tokenize(newText)));
+
+// Wrap an add/del segment in sentinels, re-opening after every newline so a
+// marker pair never spans a markdown block boundary.
+const markSegment = (text: string, open: string, close: string): string =>
+  text
+    .split('\n')
+    .map((piece) => (piece.trim() ? `${open}${piece}${close}` : piece))
+    .join('\n');
+
+// Word-diff a changed old→new block into one markdown string with sentinels.
+const mergeChanged = (oldText: string, newText: string): string =>
+  diffWords(oldText, newText)
+    .map((s) => {
+      if (s.type === 'same') return s.text;
+      return s.type === 'add'
+        ? markSegment(s.text, MARK_ADD_OPEN, MARK_ADD_CLOSE)
+        : markSegment(s.text, MARK_DEL_OPEN, MARK_DEL_CLOSE);
+    })
+    .join('');
+
+export type DiffBlockType = 'same' | 'add' | 'del' | 'changed';
+export interface DiffBlock {
+  type: DiffBlockType;
+  markdown: string;
+}
+
+/** Line-level diff grouped into renderable markdown blocks. */
+export const diffBlocks = (oldText: string, newText: string): DiffBlock[] => {
+  const ops = lcsOps(oldText.split('\n'), newText.split('\n'));
+  const blocks: DiffBlock[] = [];
+  let i = 0;
+  const takeRun = (type: SegType): string[] => {
+    const run: string[] = [];
+    while (i < ops.length && ops[i].type === type) run.push(ops[i++].text);
+    return run;
+  };
+  while (i < ops.length) {
+    const type = ops[i].type;
+    const run = takeRun(type);
+    if (type === 'del') {
+      // A removal immediately followed by an addition is one changed block.
+      const addRun = takeRun('add');
+      if (addRun.length) {
+        blocks.push({ type: 'changed', markdown: mergeChanged(run.join('\n'), addRun.join('\n')) });
+      } else {
+        blocks.push({ type: 'del', markdown: run.join('\n') });
+      }
+    } else {
+      blocks.push({ type, markdown: run.join('\n') });
+    }
+  }
+  return blocks;
+};
+
+// ---- rendering ----
+
+const MARKER_SPLIT = /([\uE000-\uE003])/;
+type Mode = 'same' | 'add' | 'del';
+
+const wrapNode = (node: React.ReactNode, mode: Mode, key: React.Key): React.ReactNode => {
+  if (mode === 'add') {
+    return (
+      <ins key={key} className="brief-diff-add">
+        {node}
+      </ins>
+    );
+  }
+  if (mode === 'del') {
+    return (
+      <del key={key} className="brief-diff-del">
+        {node}
+      </del>
+    );
+  }
+  return <React.Fragment key={key}>{node}</React.Fragment>;
+};
+
+// Walk a node's children in order, toggling add/del mode on sentinel characters
+// and wrapping the runs in <ins>/<del>. Non-string children (e.g. <strong>)
+// inherit the mode active where they appear.
+const renderWithMarkers = (children: React.ReactNode): React.ReactNode => {
+  let mode: Mode = 'same';
+  const out: React.ReactNode[] = [];
+  let k = 0;
+  React.Children.forEach(children, (child) => {
+    if (typeof child !== 'string') {
+      out.push(wrapNode(child, mode, `n${k++}`));
+      return;
+    }
+    child.split(MARKER_SPLIT).forEach((part) => {
+      if (part === MARK_ADD_OPEN) mode = 'add';
+      else if (part === MARK_DEL_OPEN) mode = 'del';
+      else if (part === MARK_ADD_CLOSE || part === MARK_DEL_CLOSE) mode = 'same';
+      else if (part) out.push(wrapNode(part, mode, `t${k++}`));
+    });
+  });
+  return <>{out}</>;
+};
+
+const marked =
+  (Tag: string) =>
+  ({ children, ...props }: any) =>
+    React.createElement(Tag, props, renderWithMarkers(children));
+
+const DIFF_COMPONENTS = {
+  p: marked('p'),
+  li: marked('li'),
+  em: marked('em'),
+  strong: marked('strong'),
+  h1: marked('h1'),
+  h2: marked('h2'),
+  h3: marked('h3'),
+  h4: marked('h4'),
+  h5: marked('h5'),
+  h6: marked('h6'),
+};
+
+const BLOCK_CLASS: Record<DiffBlockType, string> = {
+  same: '',
+  changed: '',
+  add: ' brief-diff-block-add',
+  del: ' brief-diff-block-del',
+};
+
+// Old and new drafts can encode the same quote differently (HTML entity vs
+// straight vs curly) — e.g. an older draft has `&#34;`/`"` while a fresh revise
+// has `"`. They render identically, so treat them as equal to avoid a diff full
+// of meaningless quote-only "changes".
+const normalizeQuotes = (s: string): string =>
+  s
+    .replace(/&#34;|&quot;/g, '"')
+    .replace(/&#39;|&apos;|&#8217;|&#8216;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/[‘’‚‛]/g, "'")
+    .replace(/[“”„‟]/g, '"');
+
 export const BriefDiff: React.FC<{ oldText: string; newText: string }> = ({ oldText, newText }) => {
-  const segs = diffWords(oldText || '', newText || '');
+  const blocks = useMemo(
+    () => diffBlocks(normalizeQuotes(oldText || ''), normalizeQuotes(newText || '')),
+    [oldText, newText],
+  );
   return (
     <div className="brief-diff">
-      {segs.map((s, idx) => {
-        if (s.type === 'same') return <span key={idx}>{s.text}</span>;
-        if (s.type === 'add')
-          return (
-            <ins key={idx} className="brief-diff-add">
-              {s.text}
-            </ins>
-          );
-        return (
-          <del key={idx} className="brief-diff-del">
-            {s.text}
-          </del>
-        );
-      })}
+      {blocks.map((b, idx) =>
+        b.markdown.trim() ? (
+          <div key={idx} className={`brief-diff-block${BLOCK_CLASS[b.type]}`}>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={DIFF_COMPONENTS}>
+              {b.markdown}
+            </ReactMarkdown>
+          </div>
+        ) : null,
+      )}
     </div>
   );
 };

--- a/ui/frontend/src/components/brief/BriefDiff.tsx
+++ b/ui/frontend/src/components/brief/BriefDiff.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+
+// Word-level diff of two markdown strings (old → new) for the Brief "show
+// changes" view after an Edit/Update. Self-contained LCS so no new dependency.
+
+type SegType = 'same' | 'add' | 'del';
+interface Seg {
+  type: SegType;
+  text: string;
+}
+
+// Split into word + whitespace tokens so re-joined output preserves spacing.
+const tokenize = (s: string): string[] => s.split(/(\s+)/).filter((t) => t.length > 0);
+
+export const diffWords = (oldText: string, newText: string): Seg[] => {
+  const a = tokenize(oldText);
+  const b = tokenize(newText);
+  const n = a.length;
+  const m = b.length;
+  // LCS length table (row-major, n+1 x m+1).
+  const dp: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  const segs: Seg[] = [];
+  const push = (type: SegType, text: string) => {
+    const last = segs[segs.length - 1];
+    if (last && last.type === type) last.text += text;
+    else segs.push({ type, text });
+  };
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      push('same', a[i]);
+      i += 1;
+      j += 1;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      push('del', a[i]);
+      i += 1;
+    } else {
+      push('add', b[j]);
+      j += 1;
+    }
+  }
+  while (i < n) {
+    push('del', a[i]);
+    i += 1;
+  }
+  while (j < m) {
+    push('add', b[j]);
+    j += 1;
+  }
+  return segs;
+};
+
+export const BriefDiff: React.FC<{ oldText: string; newText: string }> = ({ oldText, newText }) => {
+  const segs = diffWords(oldText || '', newText || '');
+  return (
+    <div className="brief-diff">
+      {segs.map((s, idx) => {
+        if (s.type === 'same') return <span key={idx}>{s.text}</span>;
+        if (s.type === 'add')
+          return (
+            <ins key={idx} className="brief-diff-add">
+              {s.text}
+            </ins>
+          );
+        return (
+          <del key={idx} className="brief-diff-del">
+            {s.text}
+          </del>
+        );
+      })}
+    </div>
+  );
+};

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -6,6 +6,8 @@ import { IconDownload, IconEdit, IconRefresh, IconSparkle } from './BriefIcons';
 import { BriefToc } from './BriefToc';
 import { BriefSection } from './briefTypes';
 import { UseBriefReturn } from './useBrief';
+import { BriefDiff } from './BriefDiff';
+import { BriefSectionAudit } from './BriefSectionAudit';
 
 const tagClass = (tag: string): string => `brief-tag brief-tag-${tag.toLowerCase()}`;
 
@@ -59,9 +61,29 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   display,
 }) => {
   const [editing, setEditing] = useState(false);
+  // AI Edit/Update instruction panel + audit modal + changes toggle.
+  const [aiPanel, setAiPanel] = useState<null | 'edit' | 'update'>(null);
+  const [aiText, setAiText] = useState('');
+  const [logOpen, setLogOpen] = useState(false);
+  const [showDiff, setShowDiff] = useState(false);
   const panelOpen = brief.regenFor === section.id;
   const isDone = section.status === 'done';
   const anyResearching = brief.sections.some((s) => s.status === 'researching');
+  const auditCount = section.audit?.length ?? 0;
+  const hasChanges = !!section.prevContent;
+  // Surface the diff automatically once an edit/update completes, so the user
+  // sees what changed (struck-out removals + highlighted additions) right away.
+  useEffect(() => {
+    if (section.prevContent) setShowDiff(true);
+  }, [section.prevContent]);
+  const submitAi = () => {
+    const panel = aiPanel;
+    if (!panel) return;
+    setAiPanel(null);
+    setShowDiff(false);
+    brief.reviseSection(section.id, panel, aiText.trim() || null);
+    setAiText('');
+  };
   // View/evidence use the globally-renumbered content; editing uses the raw text.
   const viewContent = display?.content ?? section.content;
   const viewSources = display?.sources ?? section.sources;
@@ -89,7 +111,88 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
           <button className="brief-regen-btn" onClick={() => brief.openRegen(section.id)}>
             <IconRefresh /> Regenerate
           </button>
+          <button
+            className="brief-regen-btn"
+            onClick={() => {
+              setAiText('');
+              setAiPanel((p) => (p === 'edit' ? null : 'edit'));
+            }}
+            title="Revise this section with an AI instruction, keeping the current content"
+          >
+            <IconSparkle /> Edit
+          </button>
+          <button
+            className="brief-regen-btn"
+            onClick={() => {
+              setAiText('');
+              setAiPanel((p) => (p === 'update' ? null : 'update'));
+            }}
+            title="Search for sources published since this section was last run and fold them in"
+          >
+            <IconRefresh /> Update
+          </button>
+          {hasChanges && (
+            <button
+              className="brief-regen-btn brief-changes-btn"
+              onClick={() => setShowDiff((v) => !v)}
+              title="Show what changed in the last edit/update"
+            >
+              {showDiff ? 'Hide changes' : 'Show changes'}
+            </button>
+          )}
+          <button className="brief-section-log-link" onClick={() => setLogOpen(true)}>
+            Log{auditCount ? ` (${auditCount})` : ''}
+          </button>
         </div>
+      )}
+
+      {aiPanel && (
+        <div className="brief-regen-panel brief-ai-panel">
+          <div className="brief-regen-title">
+            {aiPanel === 'edit' ? `Edit “${section.title}”` : `Update “${section.title}”`}
+          </div>
+          <div className="brief-ai-panel-hint">
+            {aiPanel === 'edit'
+              ? 'Keeps the current text and revises it to your instruction (does not replace it unless you ask). May search for supporting evidence.'
+              : 'Searches the library for sources published since this section was last run and folds any new findings in. Add an optional focus below.'}
+          </div>
+          <textarea
+            value={aiText}
+            onChange={(e) => setAiText(e.target.value)}
+            rows={2}
+            placeholder={
+              aiPanel === 'edit'
+                ? 'e.g. “Adjust so the viewpoint relates more to domestic policy”'
+                : 'Optional focus for the update — e.g. “prioritise enforcement actions”'
+            }
+          />
+          <div className="brief-regen-actions">
+            <button
+              className="brief-btn brief-btn-primary"
+              onClick={submitAi}
+              disabled={aiPanel === 'edit' && !aiText.trim()}
+            >
+              {aiPanel === 'edit' ? 'Apply edit' : 'Run update'}
+            </button>
+            <button
+              className="brief-btn brief-btn-secondary"
+              onClick={() => {
+                setAiPanel(null);
+                setAiText('');
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      {logOpen && (
+        <BriefSectionAudit
+          title={section.title}
+          audit={section.audit ?? []}
+          onClose={() => setLogOpen(false)}
+        />
       )}
 
       {panelOpen && <GuidancePanel section={section} brief={brief} />}
@@ -135,6 +238,25 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
               onBlur={brief.commitEdits}
               rows={Math.min(28, Math.max(8, section.content.split('\n').length + 2))}
             />
+          ) : showDiff && hasChanges ? (
+            <div className="brief-doc-content">
+              <div className="brief-diff-head">
+                <span>
+                  Changes from the last{' '}
+                  {section.lastChangeKind === 'update' ? 'update' : 'edit'}
+                </span>
+                <button
+                  className="brief-diff-dismiss"
+                  onClick={() => {
+                    setShowDiff(false);
+                    brief.dismissChanges(section.id);
+                  }}
+                >
+                  Keep &amp; dismiss
+                </button>
+              </div>
+              <BriefDiff oldText={section.prevContent || ''} newText={section.content} />
+            </div>
           ) : (
             <div className="brief-doc-content">
               <CitedMarkdown

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -131,6 +131,168 @@ const GuidancePanel: React.FC<{ section: BriefSection; brief: UseBriefReturn }> 
   );
 };
 
+// Content + sources for the done/stale views: the globally-renumbered display
+// variant when available, else the section's own.
+const sectionView = (section: BriefSection, display?: SectionDisplay) => ({
+  content: display?.content ?? section.content,
+  sources: display?.sources ?? section.sources,
+});
+
+// The AI action toolbar shown on a completed section.
+const SectionTools: React.FC<{
+  editing: boolean;
+  auditCount: number;
+  onToggleEdit: () => void;
+  onRegenerate: () => void;
+  onAiEdit: () => void;
+  onAiUpdate: () => void;
+  onOpenLog: () => void;
+}> = ({ editing, auditCount, onToggleEdit, onRegenerate, onAiEdit, onAiUpdate, onOpenLog }) => (
+  <div className="brief-doc-section-tools">
+    <button className="brief-regen-btn" onClick={onToggleEdit}>
+      <IconEdit /> {editing ? 'Done' : 'Manually Edit'}
+    </button>
+    <button className="brief-regen-btn" onClick={onRegenerate}>
+      <IconRefresh /> AI Regenerate
+    </button>
+    <button
+      className="brief-regen-btn"
+      onClick={onAiEdit}
+      title="Revise this section with an AI instruction, keeping the current content"
+    >
+      <IconSparkle /> AI Edit
+    </button>
+    <button
+      className="brief-regen-btn"
+      onClick={onAiUpdate}
+      title="Search for sources published since this section was last run and fold them in"
+    >
+      <IconClock /> AI Get Updates
+    </button>
+    <button className="brief-section-log-link" onClick={onOpenLog}>
+      Log{auditCount ? ` (${auditCount})` : ''}
+    </button>
+  </div>
+);
+
+// The "research this section" prompt shown for a pending section.
+const SectionPending: React.FC<{ sample?: boolean; onResearch: () => void }> = ({
+  sample,
+  onResearch,
+}) => (
+  <div className="brief-pending">
+    <button
+      className="brief-btn brief-btn-secondary brief-research-one-btn"
+      onClick={onResearch}
+      disabled={sample}
+      title={sample ? 'Edit this heading before researching it' : undefined}
+    >
+      <IconSparkle /> Research this section
+    </button>
+  </div>
+);
+
+// The live "researching…"/"revising…" panel; keeps the current text greyed out
+// in place while a revise (Edit/Update) runs.
+const SectionResearching: React.FC<{
+  section: BriefSection;
+  display?: SectionDisplay;
+  onSourceClick: (source: SourceReference) => void;
+}> = ({ section, display, onSourceClick }) => {
+  const { content, sources } = sectionView(section, display);
+  return (
+    <>
+      <div className="brief-researching">
+        <div className="brief-researching-head">
+          <span className="brief-spinner" />
+          <span className="brief-researching-label">
+            {section.revising ? 'Revising this section' : 'Researching this section'}
+          </span>
+          <span className="brief-researching-pct">{section.progress}%</span>
+        </div>
+        <div className="brief-activity">
+          {section.activity.map((ev, idx) => (
+            <div className="brief-activity-row" key={`${ev.tag}-${idx}`}>
+              <span className={tagClass(ev.tag)}>{ev.tag}</span>
+              <span>{ev.text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      {section.revising && !!section.content && (
+        // The current text stays in place, greyed out, until the revised version
+        // arrives and swaps in atomically.
+        <div className="brief-doc-content brief-doc-content-stale" aria-busy="true">
+          <CitedMarkdown content={content} sources={sources} onSourceClick={onSourceClick} />
+        </div>
+      )}
+    </>
+  );
+};
+
+// The completed-section body: raw-edit textarea, a change diff, or the rendered
+// content — plus the collapsible evidence list.
+const SectionDoneBody: React.FC<{
+  section: BriefSection;
+  brief: UseBriefReturn;
+  display?: SectionDisplay;
+  editing: boolean;
+  diffEntry: SectionAuditEntry | null;
+  viewingPending: boolean;
+  onSourceClick: (source: SourceReference) => void;
+  onCloseDiff: () => void;
+}> = ({
+  section,
+  brief,
+  display,
+  editing,
+  diffEntry,
+  viewingPending,
+  onSourceClick,
+  onCloseDiff,
+}) => {
+  const { content, sources } = sectionView(section, display);
+  return (
+    <>
+      {editing ? (
+        <textarea
+          className="brief-edit-textarea"
+          value={section.content}
+          onChange={(e) => brief.editContent(section.id, e.target.value)}
+          onBlur={brief.commitEdits}
+          rows={Math.min(28, Math.max(8, section.content.split('\n').length + 2))}
+        />
+      ) : diffEntry && diffEntry.before != null ? (
+        <SectionChangesView
+          entry={diffEntry}
+          viewingPending={viewingPending}
+          onHide={onCloseDiff}
+          onKeep={() => {
+            onCloseDiff();
+            brief.dismissChanges(section.id);
+          }}
+          onReject={() => {
+            onCloseDiff();
+            brief.rejectChanges(section.id);
+          }}
+        />
+      ) : (
+        <div className="brief-doc-content">
+          <CitedMarkdown content={content} sources={sources} onSourceClick={onSourceClick} />
+        </div>
+      )}
+      <CitedReferences
+        content={content}
+        sources={sources}
+        onSourceClick={onSourceClick}
+        collapsible
+        labelPrefix="Evidence"
+        className="brief-evidence"
+      />
+    </>
+  );
+};
+
 const BriefSectionView: React.FC<SectionViewProps> = ({
   section,
   num,
@@ -171,9 +333,6 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
     brief.reviseSection(section.id, panel, aiText.trim() || null);
     setAiText('');
   };
-  // View/evidence use the globally-renumbered content; editing uses the raw text.
-  const viewContent = display?.content ?? section.content;
-  const viewSources = display?.sources ?? section.sources;
 
   return (
     <section
@@ -191,37 +350,21 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
       </div>
 
       {isDone && (
-        <div className="brief-doc-section-tools">
-          <button className="brief-regen-btn" onClick={() => setEditing((v) => !v)}>
-            <IconEdit /> {editing ? 'Done' : 'Manually Edit'}
-          </button>
-          <button className="brief-regen-btn" onClick={() => brief.openRegen(section.id)}>
-            <IconRefresh /> AI Regenerate
-          </button>
-          <button
-            className="brief-regen-btn"
-            onClick={() => {
-              setAiText('');
-              setAiPanel((p) => (p === 'edit' ? null : 'edit'));
-            }}
-            title="Revise this section with an AI instruction, keeping the current content"
-          >
-            <IconSparkle /> AI Edit
-          </button>
-          <button
-            className="brief-regen-btn"
-            onClick={() => {
-              setAiText('');
-              setAiPanel((p) => (p === 'update' ? null : 'update'));
-            }}
-            title="Search for sources published since this section was last run and fold them in"
-          >
-            <IconClock /> AI Get Updates
-          </button>
-          <button className="brief-section-log-link" onClick={() => setLogOpen(true)}>
-            Log{auditCount ? ` (${auditCount})` : ''}
-          </button>
-        </div>
+        <SectionTools
+          editing={editing}
+          auditCount={auditCount}
+          onToggleEdit={() => setEditing((v) => !v)}
+          onRegenerate={() => brief.openRegen(section.id)}
+          onAiEdit={() => {
+            setAiText('');
+            setAiPanel((p) => (p === 'edit' ? null : 'edit'));
+          }}
+          onAiUpdate={() => {
+            setAiText('');
+            setAiPanel((p) => (p === 'update' ? null : 'update'));
+          }}
+          onOpenLog={() => setLogOpen(true)}
+        />
       )}
 
       {aiPanel && (
@@ -256,93 +399,24 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
       {panelOpen && <GuidancePanel section={section} brief={brief} />}
 
       {section.status === 'pending' && !panelOpen && !anyResearching && (
-        <div className="brief-pending">
-          <button
-            className="brief-btn brief-btn-secondary brief-research-one-btn"
-            onClick={() => brief.openRegen(section.id)}
-            disabled={section.sample}
-            title={section.sample ? 'Edit this heading before researching it' : undefined}
-          >
-            <IconSparkle /> Research this section
-          </button>
-        </div>
+        <SectionPending sample={section.sample} onResearch={() => brief.openRegen(section.id)} />
       )}
 
       {section.status === 'researching' && (
-        <>
-          <div className="brief-researching">
-            <div className="brief-researching-head">
-              <span className="brief-spinner" />
-              <span className="brief-researching-label">
-                {section.revising ? 'Revising this section' : 'Researching this section'}
-              </span>
-              <span className="brief-researching-pct">{section.progress}%</span>
-            </div>
-            <div className="brief-activity">
-              {section.activity.map((ev, idx) => (
-                <div className="brief-activity-row" key={`${ev.tag}-${idx}`}>
-                  <span className={tagClass(ev.tag)}>{ev.tag}</span>
-                  <span>{ev.text}</span>
-                </div>
-              ))}
-            </div>
-          </div>
-          {section.revising && !!section.content && (
-            // The current text stays in place, greyed out, until the revised
-            // version arrives and swaps in atomically.
-            <div className="brief-doc-content brief-doc-content-stale" aria-busy="true">
-              <CitedMarkdown
-                content={viewContent}
-                sources={viewSources}
-                onSourceClick={onSourceClick}
-              />
-            </div>
-          )}
-        </>
+        <SectionResearching section={section} display={display} onSourceClick={onSourceClick} />
       )}
 
       {isDone && (
-        <>
-          {editing ? (
-            <textarea
-              className="brief-edit-textarea"
-              value={section.content}
-              onChange={(e) => brief.editContent(section.id, e.target.value)}
-              onBlur={brief.commitEdits}
-              rows={Math.min(28, Math.max(8, section.content.split('\n').length + 2))}
-            />
-          ) : diffEntry && diffEntry.before != null ? (
-            <SectionChangesView
-              entry={diffEntry}
-              viewingPending={viewingPending}
-              onHide={() => setDiffEntryId(null)}
-              onKeep={() => {
-                setDiffEntryId(null);
-                brief.dismissChanges(section.id);
-              }}
-              onReject={() => {
-                setDiffEntryId(null);
-                brief.rejectChanges(section.id);
-              }}
-            />
-          ) : (
-            <div className="brief-doc-content">
-              <CitedMarkdown
-                content={viewContent}
-                sources={viewSources}
-                onSourceClick={onSourceClick}
-              />
-            </div>
-          )}
-          <CitedReferences
-            content={viewContent}
-            sources={viewSources}
-            onSourceClick={onSourceClick}
-            collapsible
-            labelPrefix="Evidence"
-            className="brief-evidence"
-          />
-        </>
+        <SectionDoneBody
+          section={section}
+          brief={brief}
+          display={display}
+          editing={editing}
+          diffEntry={diffEntry}
+          viewingPending={viewingPending}
+          onSourceClick={onSourceClick}
+          onCloseDiff={() => setDiffEntryId(null)}
+        />
       )}
     </section>
   );

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -408,7 +408,7 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
                 disabled={!canEditStructure}
                 title="Re-research every section from scratch"
               >
-                <IconRefresh /> Regenerate all
+                <IconRefresh /> AI Regenerate All
               </button>
             )}
             {onExportWord && (

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -4,12 +4,90 @@ import { CitedMarkdown, CitedReferences } from '../citations/CitedContent';
 import { buildGlobalCitations, SectionDisplay } from './briefCitations';
 import { IconDownload, IconEdit, IconRefresh, IconSparkle } from './BriefIcons';
 import { BriefToc } from './BriefToc';
-import { BriefSection } from './briefTypes';
+import { BriefSection, SectionAuditEntry } from './briefTypes';
 import { UseBriefReturn } from './useBrief';
 import { BriefDiff } from './BriefDiff';
 import { BriefSectionAudit } from './BriefSectionAudit';
 
 const tagClass = (tag: string): string => `brief-tag brief-tag-${tag.toLowerCase()}`;
+
+// The changes view for one audit entry: a diff header (Hide, plus Keep/Reject
+// for the still-pending change) over the rendered before→after diff.
+const SectionChangesView: React.FC<{
+  entry: SectionAuditEntry;
+  viewingPending: boolean;
+  onHide: () => void;
+  onKeep: () => void;
+  onReject: () => void;
+}> = ({ entry, viewingPending, onHide, onKeep, onReject }) => (
+  <div className="brief-doc-content">
+    <div className="brief-diff-head">
+      <span>
+        Changes from the {entry.kind === 'update' ? 'update' : 'edit'}
+        {viewingPending ? '' : ` on ${new Date(entry.at).toLocaleDateString()}`}
+      </span>
+      <span className="brief-diff-actions">
+        <button className="brief-diff-dismiss brief-diff-hide" onClick={onHide} title="Hide the diff">
+          Hide changes
+        </button>
+        {viewingPending && (
+          <>
+            <button className="brief-diff-dismiss brief-diff-keep" onClick={onKeep}>
+              Keep Edits
+            </button>
+            <button className="brief-diff-dismiss brief-diff-reject" onClick={onReject}>
+              Reject Edits
+            </button>
+          </>
+        )}
+      </span>
+    </div>
+    <BriefDiff oldText={entry.before || ''} newText={entry.after || ''} />
+  </div>
+);
+
+// The Edit/Update instruction panel (keeps the current text; runs a revise).
+const AiInstructionPanel: React.FC<{
+  mode: 'edit' | 'update';
+  title: string;
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}> = ({ mode, title, value, onChange, onSubmit, onCancel }) => (
+  <div className="brief-regen-panel brief-ai-panel">
+    <div className="brief-regen-title">
+      {mode === 'edit' ? `Edit “${title}”` : `Update “${title}”`}
+    </div>
+    <div className="brief-ai-panel-hint">
+      {mode === 'edit'
+        ? 'Keeps the current text and revises it to your instruction (does not replace it unless you ask).'
+        : 'Searches the library for sources published since this section was last run and folds any new findings in. Add an optional focus below.'}
+    </div>
+    <textarea
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      rows={2}
+      placeholder={
+        mode === 'edit'
+          ? 'e.g. “Adjust so the viewpoint relates more to domestic policy”'
+          : 'Optional focus for the update — e.g. “prioritise enforcement actions”'
+      }
+    />
+    <div className="brief-regen-actions">
+      <button
+        className="brief-btn brief-btn-primary"
+        onClick={onSubmit}
+        disabled={mode === 'edit' && !value.trim()}
+      >
+        {mode === 'edit' ? 'Apply edit' : 'Run update'}
+      </button>
+      <button className="brief-btn brief-btn-secondary" onClick={onCancel}>
+        Cancel
+      </button>
+    </div>
+  </div>
+);
 
 interface SectionViewProps {
   section: BriefSection;
@@ -65,22 +143,31 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   const [aiPanel, setAiPanel] = useState<null | 'edit' | 'update'>(null);
   const [aiText, setAiText] = useState('');
   const [logOpen, setLogOpen] = useState(false);
-  const [showDiff, setShowDiff] = useState(false);
+  // Which audit entry's diff is on screen (by id), or null. Any edit/update
+  // entry with a stored before/after can be viewed — including on a reloaded
+  // brief — not just the latest pending change.
+  const [diffEntryId, setDiffEntryId] = useState<string | null>(null);
   const panelOpen = brief.regenFor === section.id;
   const isDone = section.status === 'done';
   const anyResearching = brief.sections.some((s) => s.status === 'researching');
-  const auditCount = section.audit?.length ?? 0;
+  const audit = section.audit ?? [];
+  const auditCount = audit.length;
   const hasChanges = !!section.prevContent;
-  // Surface the diff automatically once an edit/update completes, so the user
-  // sees what changed (struck-out removals + highlighted additions) right away.
+  // The still-pending change (un-kept) is the latest audit entry; only it offers
+  // Keep/Reject. Everything else is view-only.
+  const pendingEntryId = hasChanges && audit.length ? audit[audit.length - 1].id : null;
+  const diffEntry = diffEntryId ? audit.find((e) => e.id === diffEntryId) ?? null : null;
+  const viewingPending = !!diffEntryId && diffEntryId === pendingEntryId;
+  // Surface the pending diff automatically once an edit/update completes (a new
+  // pending entry appears).
   useEffect(() => {
-    if (section.prevContent) setShowDiff(true);
-  }, [section.prevContent]);
+    if (pendingEntryId) setDiffEntryId(pendingEntryId);
+  }, [pendingEntryId]);
   const submitAi = () => {
     const panel = aiPanel;
     if (!panel) return;
     setAiPanel(null);
-    setShowDiff(false);
+    setDiffEntryId(null);
     brief.reviseSection(section.id, panel, aiText.trim() || null);
     setAiText('');
   };
@@ -131,15 +218,6 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
           >
             <IconRefresh /> Update
           </button>
-          {hasChanges && (
-            <button
-              className="brief-regen-btn brief-changes-btn"
-              onClick={() => setShowDiff((v) => !v)}
-              title="Show what changed in the last edit/update"
-            >
-              {showDiff ? 'Hide changes' : 'Show changes'}
-            </button>
-          )}
           <button className="brief-section-log-link" onClick={() => setLogOpen(true)}>
             Log{auditCount ? ` (${auditCount})` : ''}
           </button>
@@ -147,50 +225,30 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
       )}
 
       {aiPanel && (
-        <div className="brief-regen-panel brief-ai-panel">
-          <div className="brief-regen-title">
-            {aiPanel === 'edit' ? `Edit “${section.title}”` : `Update “${section.title}”`}
-          </div>
-          <div className="brief-ai-panel-hint">
-            {aiPanel === 'edit'
-              ? 'Keeps the current text and revises it to your instruction (does not replace it unless you ask). May search for supporting evidence.'
-              : 'Searches the library for sources published since this section was last run and folds any new findings in. Add an optional focus below.'}
-          </div>
-          <textarea
-            value={aiText}
-            onChange={(e) => setAiText(e.target.value)}
-            rows={2}
-            placeholder={
-              aiPanel === 'edit'
-                ? 'e.g. “Adjust so the viewpoint relates more to domestic policy”'
-                : 'Optional focus for the update — e.g. “prioritise enforcement actions”'
-            }
-          />
-          <div className="brief-regen-actions">
-            <button
-              className="brief-btn brief-btn-primary"
-              onClick={submitAi}
-              disabled={aiPanel === 'edit' && !aiText.trim()}
-            >
-              {aiPanel === 'edit' ? 'Apply edit' : 'Run update'}
-            </button>
-            <button
-              className="brief-btn brief-btn-secondary"
-              onClick={() => {
-                setAiPanel(null);
-                setAiText('');
-              }}
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <AiInstructionPanel
+          mode={aiPanel}
+          title={section.title}
+          value={aiText}
+          onChange={setAiText}
+          onSubmit={submitAi}
+          onCancel={() => {
+            setAiPanel(null);
+            setAiText('');
+          }}
+        />
       )}
 
       {logOpen && (
         <BriefSectionAudit
           title={section.title}
-          audit={section.audit ?? []}
+          audit={audit}
+          pendingEntryId={pendingEntryId}
+          // Any edit/update entry with a stored before/after can be re-viewed —
+          // clicking its row opens that change's diff.
+          onShowChanges={(entryId) => {
+            setLogOpen(false);
+            setDiffEntryId(entryId);
+          }}
           onClose={() => setLogOpen(false)}
         />
       )}
@@ -211,21 +269,36 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
       )}
 
       {section.status === 'researching' && (
-        <div className="brief-researching">
-          <div className="brief-researching-head">
-            <span className="brief-spinner" />
-            <span className="brief-researching-label">Researching this section</span>
-            <span className="brief-researching-pct">{section.progress}%</span>
+        <>
+          <div className="brief-researching">
+            <div className="brief-researching-head">
+              <span className="brief-spinner" />
+              <span className="brief-researching-label">
+                {section.revising ? 'Revising this section' : 'Researching this section'}
+              </span>
+              <span className="brief-researching-pct">{section.progress}%</span>
+            </div>
+            <div className="brief-activity">
+              {section.activity.map((ev, idx) => (
+                <div className="brief-activity-row" key={`${ev.tag}-${idx}`}>
+                  <span className={tagClass(ev.tag)}>{ev.tag}</span>
+                  <span>{ev.text}</span>
+                </div>
+              ))}
+            </div>
           </div>
-          <div className="brief-activity">
-            {section.activity.map((ev, idx) => (
-              <div className="brief-activity-row" key={`${ev.tag}-${idx}`}>
-                <span className={tagClass(ev.tag)}>{ev.tag}</span>
-                <span>{ev.text}</span>
-              </div>
-            ))}
-          </div>
-        </div>
+          {section.revising && !!section.content && (
+            // The current text stays in place, greyed out, until the revised
+            // version arrives and swaps in atomically.
+            <div className="brief-doc-content brief-doc-content-stale" aria-busy="true">
+              <CitedMarkdown
+                content={viewContent}
+                sources={viewSources}
+                onSourceClick={onSourceClick}
+              />
+            </div>
+          )}
+        </>
       )}
 
       {isDone && (
@@ -238,25 +311,20 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
               onBlur={brief.commitEdits}
               rows={Math.min(28, Math.max(8, section.content.split('\n').length + 2))}
             />
-          ) : showDiff && hasChanges ? (
-            <div className="brief-doc-content">
-              <div className="brief-diff-head">
-                <span>
-                  Changes from the last{' '}
-                  {section.lastChangeKind === 'update' ? 'update' : 'edit'}
-                </span>
-                <button
-                  className="brief-diff-dismiss"
-                  onClick={() => {
-                    setShowDiff(false);
-                    brief.dismissChanges(section.id);
-                  }}
-                >
-                  Keep &amp; dismiss
-                </button>
-              </div>
-              <BriefDiff oldText={section.prevContent || ''} newText={section.content} />
-            </div>
+          ) : diffEntry && diffEntry.before != null ? (
+            <SectionChangesView
+              entry={diffEntry}
+              viewingPending={viewingPending}
+              onHide={() => setDiffEntryId(null)}
+              onKeep={() => {
+                setDiffEntryId(null);
+                brief.dismissChanges(section.id);
+              }}
+              onReject={() => {
+                setDiffEntryId(null);
+                brief.rejectChanges(section.id);
+              }}
+            />
           ) : (
             <div className="brief-doc-content">
               <CitedMarkdown

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -193,10 +193,10 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
       {isDone && (
         <div className="brief-doc-section-tools">
           <button className="brief-regen-btn" onClick={() => setEditing((v) => !v)}>
-            <IconEdit /> {editing ? 'Done' : 'Edit text'}
+            <IconEdit /> {editing ? 'Done' : 'Manually Edit'}
           </button>
           <button className="brief-regen-btn" onClick={() => brief.openRegen(section.id)}>
-            <IconRefresh /> Regenerate
+            <IconRefresh /> AI Regenerate
           </button>
           <button
             className="brief-regen-btn"
@@ -206,7 +206,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
             }}
             title="Revise this section with an AI instruction, keeping the current content"
           >
-            <IconSparkle /> Edit
+            <IconSparkle /> AI Edit
           </button>
           <button
             className="brief-regen-btn"
@@ -216,7 +216,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
             }}
             title="Search for sources published since this section was last run and fold them in"
           >
-            <IconRefresh /> Update
+            <IconRefresh /> AI Get Updates
           </button>
           <button className="brief-section-log-link" onClick={() => setLogOpen(true)}>
             Log{auditCount ? ` (${auditCount})` : ''}

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { SearchResult, SourceReference } from '../../types/api';
 import { CitedMarkdown, CitedReferences } from '../citations/CitedContent';
 import { buildGlobalCitations, SectionDisplay } from './briefCitations';
-import { IconDownload, IconEdit, IconRefresh, IconSparkle } from './BriefIcons';
+import { IconClock, IconDownload, IconEdit, IconRefresh, IconSparkle } from './BriefIcons';
 import { BriefToc } from './BriefToc';
 import { BriefSection, SectionAuditEntry } from './briefTypes';
 import { UseBriefReturn } from './useBrief';
@@ -216,7 +216,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
             }}
             title="Search for sources published since this section was last run and fold them in"
           >
-            <IconRefresh /> AI Get Updates
+            <IconClock /> AI Get Updates
           </button>
           <button className="brief-section-log-link" onClick={() => setLogOpen(true)}>
             Log{auditCount ? ` (${auditCount})` : ''}
@@ -409,6 +409,16 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
                 title="Re-research every section from scratch"
               >
                 <IconRefresh /> AI Regenerate All
+              </button>
+            )}
+            {sections.some((s) => s.status === 'done') && (
+              <button
+                className="brief-regen-all"
+                onClick={brief.updateAll}
+                disabled={!canEditStructure}
+                title="Fold sources published since each section was last run into every section"
+              >
+                <IconClock /> AI Get All Recent Updates
               </button>
             )}
             {onExportWord && (

--- a/ui/frontend/src/components/brief/BriefIcons.tsx
+++ b/ui/frontend/src/components/brief/BriefIcons.tsx
@@ -41,6 +41,13 @@ export const IconRefresh: React.FC<IconProps> = ({ size = 14 }) => (
   </svg>
 );
 
+export const IconClock: React.FC<IconProps> = ({ size = 14 }) => (
+  <svg {...svgProps(size)}>
+    <circle cx="12" cy="12" r="9" />
+    <polyline points="12 7 12 12 16 14" />
+  </svg>
+);
+
 export const IconEdit: React.FC<IconProps> = ({ size = 14 }) => (
   <svg {...svgProps(size)}>
     <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />

--- a/ui/frontend/src/components/brief/BriefSectionAudit.tsx
+++ b/ui/frontend/src/components/brief/BriefSectionAudit.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { SectionAuditEntry, SectionAuditKind } from './briefTypes';
+
+// Per-section research/audit log modal — the full provenance of a section:
+// every generate/edit/update, its question/instruction, and what it drew in.
+// Mirrors BriefHistoryModal's structure/classes so it reads as the same modal.
+
+const KIND_LABEL: Record<SectionAuditKind, string> = {
+  generate: 'Generated',
+  edit: 'Edited',
+  update: 'Updated',
+};
+
+const formatWhen = (ts: number): string => {
+  try {
+    const d = new Date(ts);
+    return `${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} · ${d.toLocaleTimeString(
+      undefined,
+      { hour: 'numeric', minute: '2-digit' },
+    )}`;
+  } catch {
+    return '';
+  }
+};
+
+interface Props {
+  title: string;
+  audit: SectionAuditEntry[];
+  onClose: () => void;
+}
+
+export const BriefSectionAudit: React.FC<Props> = ({ title, audit, onClose }) => (
+  <div className="brief-modal-overlay" onClick={onClose}>
+    <div className="brief-modal" onClick={(e) => e.stopPropagation()}>
+      <div className="brief-modal-head">
+        <div>
+          <div className="brief-modal-title">Research log</div>
+          <div className="brief-modal-sub">{title}</div>
+        </div>
+        <button className="brief-modal-close" onClick={onClose} aria-label="Close">
+          ×
+        </button>
+      </div>
+
+      {audit.length === 0 ? (
+        <div className="brief-modal-empty">No research activity recorded for this section yet.</div>
+      ) : (
+        <div className="brief-modal-list">
+          {[...audit]
+            .slice()
+            .reverse()
+            .map((e) => (
+              <div key={e.id} className="brief-modal-row">
+                <div className="brief-modal-row-main">
+                  <div className="brief-modal-row-title">
+                    <span className={`brief-audit-kind brief-audit-kind-${e.kind}`}>
+                      {KIND_LABEL[e.kind]}
+                    </span>
+                  </div>
+                  {e.question && (
+                    <div className="brief-modal-row-query">
+                      <span className="brief-audit-label">Question</span> {e.question}
+                    </div>
+                  )}
+                  {e.instruction && (
+                    <div className="brief-modal-row-query">
+                      <span className="brief-audit-label">Instruction</span> {e.instruction}
+                    </div>
+                  )}
+                  <div className="brief-modal-row-meta">
+                    {formatWhen(e.at)}
+                    {e.sourceCount != null
+                      ? ` · ${e.sourceCount} source${e.sourceCount === 1 ? '' : 's'}`
+                      : ''}
+                    {e.addedSourceCount ? ` · ${e.addedSourceCount} new` : ''}
+                  </div>
+                </div>
+              </div>
+            ))}
+        </div>
+      )}
+    </div>
+  </div>
+);

--- a/ui/frontend/src/components/brief/BriefSectionAudit.tsx
+++ b/ui/frontend/src/components/brief/BriefSectionAudit.tsx
@@ -26,10 +26,22 @@ const formatWhen = (ts: number): string => {
 interface Props {
   title: string;
   audit: SectionAuditEntry[];
+  // The entry whose change is still pending (not yet kept/rejected) — labelled
+  // as such; its diff also offers Keep/Reject.
+  pendingEntryId?: string | null;
+  // Open a given entry's diff. Any edit/update entry with a stored before/after
+  // is viewable (including on a reloaded brief).
+  onShowChanges?: (entryId: string) => void;
   onClose: () => void;
 }
 
-export const BriefSectionAudit: React.FC<Props> = ({ title, audit, onClose }) => (
+export const BriefSectionAudit: React.FC<Props> = ({
+  title,
+  audit,
+  pendingEntryId,
+  onShowChanges,
+  onClose,
+}) => (
   <div className="brief-modal-overlay" onClick={onClose}>
     <div className="brief-modal" onClick={(e) => e.stopPropagation()}>
       <div className="brief-modal-head">
@@ -49,13 +61,17 @@ export const BriefSectionAudit: React.FC<Props> = ({ title, audit, onClose }) =>
           {[...audit]
             .slice()
             .reverse()
-            .map((e) => (
-              <div key={e.id} className="brief-modal-row">
+            .map((e) => {
+              const pending = !!pendingEntryId && e.id === pendingEntryId;
+              const viewable = e.before != null && !!onShowChanges;
+              const body = (
                 <div className="brief-modal-row-main">
                   <div className="brief-modal-row-title">
                     <span className={`brief-audit-kind brief-audit-kind-${e.kind}`}>
                       {KIND_LABEL[e.kind]}
                     </span>
+                    {pending && <span className="brief-audit-pending">· pending</span>}
+                    {viewable && <span className="brief-audit-view">· view changes</span>}
                   </div>
                   {e.question && (
                     <div className="brief-modal-row-query">
@@ -75,8 +91,30 @@ export const BriefSectionAudit: React.FC<Props> = ({ title, audit, onClose }) =>
                     {e.addedSourceCount ? ` · ${e.addedSourceCount} new` : ''}
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+              return viewable ? (
+                <div
+                  key={e.id}
+                  className="brief-modal-row brief-audit-row-clickable"
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => onShowChanges?.(e.id)}
+                  onKeyDown={(ev) => {
+                    if (ev.key === 'Enter' || ev.key === ' ') {
+                      ev.preventDefault();
+                      onShowChanges?.(e.id);
+                    }
+                  }}
+                  title="View the changes from this edit"
+                >
+                  {body}
+                </div>
+              ) : (
+                <div key={e.id} className="brief-modal-row">
+                  {body}
+                </div>
+              );
+            })}
         </div>
       )}
     </div>

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -1495,3 +1495,96 @@
   color: var(--brand-primary);
   background: #f7f9fa;
 }
+
+/* ---------- AI Edit / Update, changes diff, and per-section audit log ---------- */
+.brief-section-log-link {
+  margin-left: auto;
+  background: none;
+  border: none;
+  padding: 2px 6px;
+  font-size: 12px;
+  color: var(--brand-text-tertiary);
+  text-decoration: underline;
+  cursor: pointer;
+}
+.brief-section-log-link:hover {
+  color: var(--brand-primary);
+}
+.brief-changes-btn {
+  color: var(--brand-primary);
+  border-color: var(--brand-primary);
+}
+
+.brief-ai-panel .brief-ai-panel-hint {
+  font-size: 12px;
+  color: var(--brand-text-secondary);
+  margin: 2px 0 8px;
+  line-height: 1.4;
+}
+
+/* Word-diff of the last edit/update. */
+.brief-diff-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--brand-text-secondary);
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--brand-border-light);
+}
+.brief-diff-dismiss {
+  background: none;
+  border: 1px solid var(--brand-border);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-size: 12px;
+  color: var(--brand-text-secondary);
+  cursor: pointer;
+}
+.brief-diff-dismiss:hover {
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
+}
+.brief-diff {
+  white-space: pre-wrap;
+  line-height: 1.6;
+  font-family: var(--font-body);
+  color: var(--brand-text-primary);
+}
+.brief-diff-add {
+  background: rgba(16, 156, 145, 0.16);
+  color: var(--brand-primary-dark);
+  text-decoration: none;
+  border-radius: 2px;
+}
+.brief-diff-del {
+  background: rgba(220, 38, 38, 0.12);
+  color: var(--brand-error);
+  text-decoration: line-through;
+  border-radius: 2px;
+}
+
+/* Per-section audit modal reuses the .brief-modal-* row chrome; only the kind
+   badge + inline label prefixes are audit-specific. */
+.brief-audit-kind {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 12px;
+}
+.brief-audit-kind-generate {
+  color: var(--brand-text-secondary);
+}
+.brief-audit-kind-edit {
+  color: var(--brand-primary);
+}
+.brief-audit-kind-update {
+  color: var(--brand-warning);
+}
+.brief-audit-label {
+  font-weight: 600;
+  color: var(--brand-text-secondary);
+}

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -775,6 +775,27 @@
   flex-direction: column;
   gap: 5px;
 }
+/* The per-section status box shows ~5 events, then scrolls. */
+.brief-researching .brief-activity {
+  max-height: 112px;
+  overflow-y: auto;
+  padding-right: 6px;
+  scrollbar-width: thin;
+}
+.brief-researching .brief-activity::-webkit-scrollbar {
+  width: 6px;
+}
+.brief-researching .brief-activity::-webkit-scrollbar-thumb {
+  background: var(--brand-border);
+  border-radius: 3px;
+}
+/* The section's current text stays in place, greyed, while a revise runs. */
+.brief-doc-content-stale {
+  opacity: 0.45;
+  pointer-events: none;
+  user-select: none;
+  margin-top: 12px;
+}
 .brief-activity-row {
   display: flex;
   align-items: center;
@@ -1535,6 +1556,10 @@
   padding-bottom: 6px;
   border-bottom: 1px solid var(--brand-border-light);
 }
+.brief-diff-actions {
+  display: inline-flex;
+  gap: 8px;
+}
 .brief-diff-dismiss {
   background: none;
   border: 1px solid var(--brand-border);
@@ -1544,15 +1569,40 @@
   color: var(--brand-text-secondary);
   cursor: pointer;
 }
-.brief-diff-dismiss:hover {
+.brief-diff-keep:hover {
   border-color: var(--brand-primary);
   color: var(--brand-primary);
 }
+.brief-diff-reject:hover {
+  border-color: var(--brand-error);
+  color: var(--brand-error);
+}
+/* Rendered-markdown diff: blocks flow like the document itself. */
 .brief-diff {
-  white-space: pre-wrap;
   line-height: 1.6;
   font-family: var(--font-body);
   color: var(--brand-text-primary);
+}
+.brief-diff-block > :first-child {
+  margin-top: 0;
+}
+.brief-diff-block > :last-child {
+  margin-bottom: 0;
+}
+.brief-diff-block {
+  margin: 0 0 10px;
+}
+.brief-diff-block-add {
+  background: rgba(16, 156, 145, 0.08);
+  border-left: 3px solid rgba(16, 156, 145, 0.5);
+  padding: 6px 10px;
+}
+.brief-diff-block-del {
+  background: rgba(220, 38, 38, 0.06);
+  border-left: 3px solid rgba(220, 38, 38, 0.4);
+  padding: 6px 10px;
+  text-decoration: line-through;
+  color: var(--brand-text-tertiary);
 }
 .brief-diff-add {
   background: rgba(16, 156, 145, 0.16);
@@ -1587,4 +1637,23 @@
 .brief-audit-label {
   font-weight: 600;
   color: var(--brand-text-secondary);
+}
+/* The pending (un-kept) edit row in the log opens its changes view. */
+.brief-audit-row-clickable {
+  cursor: pointer;
+}
+.brief-audit-row-clickable:hover {
+  background: var(--brand-border-light);
+}
+.brief-audit-pending {
+  margin-left: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--brand-warning);
+}
+.brief-audit-view {
+  margin-left: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--brand-primary);
 }

--- a/ui/frontend/src/components/brief/briefCitations.ts
+++ b/ui/frontend/src/components/brief/briefCitations.ts
@@ -59,9 +59,13 @@ export const buildGlobalCitations = (
 ): { refs: GlobalRef[]; display: Map<string, SectionDisplay> } => {
   const docToGlobal = new Map<string, number>();
   const refs: GlobalRef[] = [];
-  // Assign global numbers in order of first citation across done sections.
+  // A section mid-Edit/Update (revising) keeps its old content on screen, so
+  // it stays in the numbering — otherwise citations would jump twice per run.
+  const isVisible = (s: BriefSection): boolean =>
+    (s.status === 'done' || !!s.revising) && !!s.content;
+  // Assign global numbers in order of first citation across visible sections.
   sections.forEach((s) => {
-    if (s.status !== 'done' || !s.content) return;
+    if (!isVisible(s)) return;
     extractCitedNumbers(s.content).forEach((localN) => {
       const src = s.sources.find((x) => x.index === localN);
       if (!src || docToGlobal.has(src.docId)) return;
@@ -73,7 +77,7 @@ export const buildGlobalCitations = (
   // Build per-section display content + sources keyed by the global number.
   const display = new Map<string, SectionDisplay>();
   sections.forEach((s) => {
-    if (s.status !== 'done' || !s.content) return;
+    if (!isVisible(s)) return;
     const localToGlobal = new Map<number, number>();
     const sources: SourceReference[] = [];
     const seen = new Set<number>();

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -4,6 +4,26 @@ import { BriefActivityEvent } from '../../utils/briefStream';
 export type BriefStage = 'seed' | 'outline' | 'research' | 'done';
 export type SectionStatus = 'pending' | 'researching' | 'done';
 
+// What kind of AI operation produced a version of a section. `generate` is the
+// initial (re-)research; `edit` revises the existing draft per an instruction;
+// `update` folds in new sources published since the last run.
+export type SectionAuditKind = 'generate' | 'edit' | 'update';
+
+// One row in a section's research/audit log — surfaced in the per-section Log
+// modal so the full provenance of a section (every generate/edit/update, its
+// question/instruction, and what it drew in) is auditable.
+export interface SectionAuditEntry {
+  id: string;
+  kind: SectionAuditKind;
+  at: number; // epoch ms
+  // The research question (generate) and/or the user's edit/update instruction.
+  question?: string;
+  instruction?: string;
+  // Sources cited after this operation, and how many were newly added by it.
+  sourceCount?: number;
+  addedSourceCount?: number;
+}
+
 export interface BriefSection {
   id: string;
   title: string;
@@ -16,6 +36,22 @@ export interface BriefSection {
   // True for unedited placeholder headings from "write my own headings"; the
   // per-section research action stays disabled until the user edits them.
   sample?: boolean;
+  // Provenance for the Log modal — every generate/edit/update on this section.
+  audit?: SectionAuditEntry[];
+  // Epoch ms the section was last (re-)researched; drives Update's "sources
+  // published since" date filter.
+  lastResearchedAt?: number;
+  // True while an Edit/Update (revise) is running: the section is researching
+  // but its current content stays in place (rendered greyed-out) and keeps its
+  // slot in the global citation numbering.
+  revising?: boolean;
+  // The content/sources immediately before the most recent edit/update, kept so
+  // the user can view the diff and Keep or Reject the edits. Cleared on Keep;
+  // restored on Reject.
+  prevContent?: string;
+  prevSources?: SourceReference[];
+  // The kind of the most recent AI op that changed content, for the changes UI.
+  lastChangeKind?: SectionAuditKind;
 }
 
 export interface BriefReference {
@@ -32,6 +68,8 @@ export interface SavedBriefSection {
   status: SectionStatus;
   content: string;
   sources: SourceReference[];
+  audit?: SectionAuditEntry[];
+  lastResearchedAt?: number;
 }
 
 export interface SavedBrief {

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -22,6 +22,11 @@ export interface SectionAuditEntry {
   // Sources cited after this operation, and how many were newly added by it.
   sourceCount?: number;
   addedSourceCount?: number;
+  // For edit/update: the section content immediately before and after this
+  // operation, so its diff stays viewable from the Log even after it's kept and
+  // even on a reloaded (saved) brief. Absent for generate.
+  before?: string;
+  after?: string;
 }
 
 export interface BriefSection {

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -143,7 +143,9 @@ const computeReferences = (sections: BriefSection[]): BriefReference[] => {
   const seen = new Set<string>();
   const refs: BriefReference[] = [];
   sections.forEach((s) => {
-    if (s.status !== 'done') return;
+    // Sections mid-Edit/Update keep their (old) content on screen, so they
+    // keep their footnotes too — no renumbering while a revise runs.
+    if (s.status !== 'done' && !s.revising) return;
     const cited = new Set(extractCitedNumbers(s.content));
     s.sources.forEach((src: SourceReference) => {
       if (src.index == null || !cited.has(src.index)) return;
@@ -265,7 +267,9 @@ export const useBrief = ({
       // un-researched reverts to its last stable (pending) state on reload —
       // never a stuck "Researching…".
       sections: snap.map((s) => {
-        const done = s.status === 'done';
+        // A mid-revise section still holds its last good content — persist it
+        // as done so an interrupted Edit/Update never loses the section.
+        const done = s.status === 'done' || !!s.revising;
         return {
           title: s.title,
           level: s.level,
@@ -538,6 +542,9 @@ export const useBrief = ({
                 mode === 'generate' ? context || undefined : instruction || undefined,
               sourceCount: sources.length,
               addedSourceCount: added,
+              // Keep the before/after for a revise so its diff stays viewable.
+              before: isRevise ? priorContent : undefined,
+              after: isRevise ? content : undefined,
             };
             const cur = sectionsRef.current.find((s) => s.id === id);
             updateSection(id, {
@@ -667,6 +674,8 @@ export const useBrief = ({
           instruction: instruction.trim(),
           sourceCount: section.sources.length,
           addedSourceCount: 0,
+          before: priorContent,
+          after: revised,
         };
         updateSection(id, {
           status: 'done',
@@ -723,7 +732,8 @@ export const useBrief = ({
     [updateSection],
   );
 
-  // Reject Edits: restore the pre-op content and sources, dropping the revision.
+  // Reject Edits: restore the pre-op content and sources, drop the revision, and
+  // remove its (now-undone) audit row so the log only shows applied changes.
   const rejectChanges = useCallback(
     (id: string) =>
       setSections((prev) =>
@@ -736,6 +746,7 @@ export const useBrief = ({
                 prevContent: undefined,
                 prevSources: undefined,
                 lastChangeKind: undefined,
+                audit: s.audit ? s.audit.slice(0, -1) : s.audit,
               }
             : s,
         ),

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -600,6 +600,28 @@ export const useBrief = ({
     }
   }, [researchOne, saveCurrent]);
 
+  // Run "Get Updates" (fold in sources newer than each section's last run) on
+  // every already-researched section, sequentially — the doc-wide counterpart to
+  // the per-section AI Get Updates.
+  const updateAll = useCallback(async () => {
+    const ids = sectionsRef.current
+      .filter((s) => s.status === 'done' && !!s.content)
+      .map((s) => s.id);
+    if (!ids.length) return;
+    setError(null);
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setStage('research');
+    for (const id of ids) {
+      if (controller.signal.aborted) return;
+      await researchOne(id, null, controller.signal, { mode: 'update' });
+    }
+    if (!controller.signal.aborted) {
+      setStage('done');
+      saveCurrent();
+    }
+  }, [researchOne, saveCurrent]);
+
   // Abort all in-flight research and return to a stable, editable state: any
   // section mid-research reverts to pending; completed sections are kept.
   const stopResearch = useCallback(() => {
@@ -867,6 +889,7 @@ export const useBrief = ({
     editTitle,
     editContent,
     startResearch,
+    updateAll,
     stopResearch,
     regenerate,
     reviseSection,

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -7,8 +7,10 @@ import {
   BriefActivityEvent,
   BriefSourceSample,
   requestBriefOutline,
+  requestBriefRevise,
   researchBriefSection,
   runDeepResearch,
+  SectionResearchMode,
 } from '../../utils/briefStream';
 import {
   BRIEF_HISTORY_KEY,
@@ -16,6 +18,7 @@ import {
   BriefSection,
   BriefStage,
   SavedBrief,
+  SectionAuditEntry,
 } from './briefTypes';
 
 let _uid = 0;
@@ -222,9 +225,10 @@ export const useBrief = ({
   }, []);
 
   const pushActivity = useCallback((id: string, ev: BriefActivityEvent) => {
+    // Retain a deep log; the status box shows ~5 rows and scrolls for the rest.
     setSections((prev) =>
       prev.map((s) =>
-        s.id === id ? { ...s, activity: [ev, ...s.activity].slice(0, 4) } : s,
+        s.id === id ? { ...s, activity: [ev, ...s.activity].slice(0, 40) } : s,
       ),
     );
   }, []);
@@ -268,6 +272,8 @@ export const useBrief = ({
           status: done ? 'done' : 'pending',
           content: done ? s.content : '',
           sources: done ? s.sources : [],
+          audit: s.audit && s.audit.length ? s.audit : undefined,
+          lastResearchedAt: s.lastResearchedAt,
         };
       }),
       outlineLog: outlineLogRef.current,
@@ -452,11 +458,27 @@ export const useBrief = ({
 
   // ---- research engine ----
   const researchOne = useCallback(
-    (id: string, context: string | null, signal: AbortSignal): Promise<void> => {
+    (
+      id: string,
+      context: string | null,
+      signal: AbortSignal,
+      opts?: { mode?: SectionResearchMode; instruction?: string | null },
+    ): Promise<void> => {
       const list = sectionsRef.current;
       const idx = list.findIndex((s) => s.id === id);
       const section = list[idx];
       if (!section) return Promise.resolve();
+      const mode: SectionResearchMode = opts?.mode ?? 'generate';
+      const isRevise = mode === 'edit' || mode === 'update';
+      const instruction = (opts?.instruction || '').trim() || null;
+      // Snapshot the pre-op state for the audit row + the "show changes" diff.
+      const priorContent = section.content;
+      const priorSources = section.sources;
+      // Update: only surface sources newer than the last time this section ran.
+      const publishedAfterIso =
+        mode === 'update' && section.lastResearchedAt
+          ? new Date(section.lastResearchedAt).toISOString()
+          : null;
       // For a sub-section (level 2), find the nearest preceding level-1 heading
       // so its research stays scoped to the right parent.
       let parentTitle: string | null = null;
@@ -468,13 +490,15 @@ export const useBrief = ({
           }
         }
       }
-      updateSection(id, {
-        status: 'researching',
-        progress: 4,
-        content: '',
-        sources: [],
-        activity: [],
-      });
+      // Generate clears the section; Edit/Update keep the current draft in place
+      // (rendered greyed-out, still in the citation numbering) and swap
+      // atomically on completion.
+      updateSection(
+        id,
+        isRevise
+          ? { status: 'researching', progress: 4, activity: [], revising: true }
+          : { status: 'researching', progress: 4, content: '', sources: [], activity: [] },
+      );
       const briefTopic = queryRef.current.trim() || briefTitleRef.current;
       return researchBriefSection({
         apiBaseUrl,
@@ -487,20 +511,67 @@ export const useBrief = ({
         assistantModelConfig,
         rerankerModel: rerankerModelRef.current,
         searchSettings: searchSettingsRef.current,
+        mode,
+        existingContent: isRevise ? priorContent : null,
+        instruction,
+        publishedAfterIso,
         signal,
         handlers: {
           onActivity: (ev) => pushActivity(id, ev),
           onProgress: (p) => updateSection(id, { progress: p }),
-          onToken: (t) => updateSection(id, { content: t }),
-          onSources: (s) => updateSection(id, { sources: s }),
-          onDone: ({ content, sources }) =>
-            updateSection(id, { status: 'done', progress: 100, content, sources }),
+          // Keep the old draft visible during a revise; swap only at onDone.
+          onToken: (t) => {
+            if (!isRevise) updateSection(id, { content: t });
+          },
+          onSources: (s) => {
+            if (!isRevise) updateSection(id, { sources: s });
+          },
+          onDone: ({ content, sources }) => {
+            const priorKeys = new Set(priorSources.map((s) => s.docId));
+            const added = sources.filter((s) => !priorKeys.has(s.docId)).length;
+            const entry: SectionAuditEntry = {
+              id: uid(),
+              kind: mode,
+              at: Date.now(),
+              question: mode === 'generate' ? section.title : undefined,
+              instruction:
+                mode === 'generate' ? context || undefined : instruction || undefined,
+              sourceCount: sources.length,
+              addedSourceCount: added,
+            };
+            const cur = sectionsRef.current.find((s) => s.id === id);
+            updateSection(id, {
+              status: 'done',
+              progress: 100,
+              content,
+              sources,
+              audit: [...(cur?.audit || []), entry],
+              lastResearchedAt: Date.now(),
+              revising: undefined,
+              prevContent: isRevise ? priorContent : undefined,
+              prevSources: isRevise ? priorSources : undefined,
+              lastChangeKind: isRevise ? mode : undefined,
+            });
+          },
           onError: (m) => {
-            updateSection(id, { status: 'pending', progress: 0 });
+            // A revise keeps its previous good content; a fresh research reverts.
+            updateSection(
+              id,
+              isRevise
+                ? { status: 'done', progress: 100, revising: undefined }
+                : { status: 'pending', progress: 0 },
+            );
             setError(m);
           },
         },
-      }).catch(() => updateSection(id, { status: 'pending', progress: 0 }));
+      }).catch(() =>
+        updateSection(
+          id,
+          isRevise
+            ? { status: 'done', progress: 100, revising: undefined }
+            : { status: 'pending', progress: 0 },
+        ),
+      );
     },
     [apiBaseUrl, dataSource, assistantModelConfig, updateSection, pushActivity],
   );
@@ -561,6 +632,117 @@ export const useBrief = ({
     [stage, researchOne, finishIfComplete],
   );
 
+  // Edit (surgical): a single backend LLM copy-edit of the CURRENT draft — no
+  // deep research — so the section keeps its wording + inline [n] citations
+  // (sources unchanged) and only the smallest necessary changes are made. The
+  // pre-op content is retained so the user can view the diff.
+  const editSectionAI = useCallback(
+    async (id: string, instruction: string) => {
+      const section = sectionsRef.current.find((s) => s.id === id);
+      if (!section || !instruction.trim()) return;
+      const priorContent = section.content;
+      setError(null);
+      const controller = new AbortController();
+      abortRef.current = controller;
+      updateSection(id, {
+        status: 'researching',
+        progress: 35,
+        activity: [{ tag: 'DRAFT', text: 'Editing this section…' }],
+        revising: true,
+      });
+      try {
+        const revised = await requestBriefRevise({
+          apiBaseUrl,
+          dataSource,
+          content: priorContent,
+          instruction: instruction.trim(),
+          signal: controller.signal,
+        });
+        if (controller.signal.aborted) return;
+        const cur = sectionsRef.current.find((s) => s.id === id);
+        const entry: SectionAuditEntry = {
+          id: uid(),
+          kind: 'edit',
+          at: Date.now(),
+          instruction: instruction.trim(),
+          sourceCount: section.sources.length,
+          addedSourceCount: 0,
+        };
+        updateSection(id, {
+          status: 'done',
+          progress: 100,
+          content: revised,
+          // Sources unchanged — a surgical edit preserves the [n] markers.
+          audit: [...(cur?.audit || []), entry],
+          lastResearchedAt: Date.now(),
+          revising: undefined,
+          prevContent: priorContent,
+          prevSources: section.sources,
+          lastChangeKind: 'edit',
+        });
+      } catch (e) {
+        if (!controller.signal.aborted) {
+          updateSection(id, { status: 'done', progress: 100, revising: undefined });
+          setError(e instanceof Error ? e.message : 'Edit failed');
+        }
+      }
+    },
+    [apiBaseUrl, dataSource, updateSection],
+  );
+
+  // Dispatch the two AI actions on a DONE section: Edit → surgical revise;
+  // Update → deep research constrained to sources newer than the last run.
+  const reviseSection = useCallback(
+    async (id: string, mode: 'edit' | 'update', instruction: string | null) => {
+      setRegenFor(null);
+      setRegenText('');
+      setError(null);
+      if (stage === 'outline') setStage('research');
+      if (mode === 'edit') {
+        await editSectionAI(id, (instruction || '').trim());
+        finishIfComplete();
+        return;
+      }
+      let controller = abortRef.current;
+      if (!controller || controller.signal.aborted) controller = new AbortController();
+      abortRef.current = controller;
+      await researchOne(id, null, controller.signal, { mode, instruction });
+      finishIfComplete();
+    },
+    [stage, editSectionAI, researchOne, finishIfComplete],
+  );
+
+  // Keep Edits: accept the revised content and drop the retained pre-op state.
+  const dismissChanges = useCallback(
+    (id: string) =>
+      updateSection(id, {
+        prevContent: undefined,
+        prevSources: undefined,
+        lastChangeKind: undefined,
+      }),
+    [updateSection],
+  );
+
+  // Reject Edits: restore the pre-op content and sources, dropping the revision.
+  const rejectChanges = useCallback(
+    (id: string) =>
+      setSections((prev) =>
+        prev.map((s) =>
+          s.id === id && s.prevContent != null
+            ? {
+                ...s,
+                content: s.prevContent,
+                sources: s.prevSources ?? s.sources,
+                prevContent: undefined,
+                prevSources: undefined,
+                lastChangeKind: undefined,
+              }
+            : s,
+        ),
+      ),
+    [],
+  );
+
   // ---- history ----
   const loadBrief = useCallback((entry: SavedBrief) => {
     abortRef.current?.abort();
@@ -575,6 +757,8 @@ export const useBrief = ({
         progress: h.status === 'done' ? 100 : 0,
         content: h.status === 'done' ? h.content : '',
         sources: h.status === 'done' ? h.sources || [] : [],
+        audit: h.audit || [],
+        lastResearchedAt: h.lastResearchedAt,
       })),
     );
     setGeneratingActivity(entry.outlineLog || []);
@@ -674,6 +858,9 @@ export const useBrief = ({
     startResearch,
     stopResearch,
     regenerate,
+    reviseSection,
+    dismissChanges,
+    rejectChanges,
     openRegen: (id: string) => {
       setRegenFor(id);
       setRegenText('');

--- a/ui/frontend/src/tests/briefCitations.test.ts
+++ b/ui/frontend/src/tests/briefCitations.test.ts
@@ -120,3 +120,45 @@ describe('stripLeadingTitle', () => {
     );
   });
 });
+
+describe('footnotes react to citation changes', () => {
+  test('removing an inline citation drops its footnote and renumbers the rest', () => {
+    const sources = [
+      src({ index: 1, docId: 'd1', title: 'Doc One', page: 1 }),
+      src({ index: 2, docId: 'd2', title: 'Doc Two', page: 2 }),
+    ];
+    const before: BriefSection[] = [
+      section({ id: 'a', content: 'First [1] and second [2].', sources }),
+    ];
+    const after: BriefSection[] = [
+      // An AI edit removed the sentence citing [1]; sources are unchanged.
+      section({ id: 'a', content: 'Only the second remains [2].', sources }),
+    ];
+
+    expect(buildGlobalCitations(before).refs.map((r) => r.title)).toEqual([
+      'Doc One',
+      'Doc Two',
+    ]);
+
+    const { refs, display } = buildGlobalCitations(after);
+    expect(refs.map((r) => r.title)).toEqual(['Doc Two']);
+    expect(refs[0].n).toBe(1);
+    // The surviving citation is renumbered to the new global sequence.
+    expect(display.get('a')?.content).toBe('Only the second remains [1].');
+  });
+
+  test('a section mid-revise keeps its citations in the numbering', () => {
+    const sections: BriefSection[] = [
+      section({
+        id: 'a',
+        status: 'researching',
+        revising: true,
+        content: 'Still on screen [1].',
+        sources: [src({ index: 1, docId: 'd1', title: 'Doc One', page: 1 })],
+      }),
+    ];
+    const { refs, display } = buildGlobalCitations(sections);
+    expect(refs.map((r) => r.title)).toEqual(['Doc One']);
+    expect(display.get('a')?.content).toBe('Still on screen [1].');
+  });
+});

--- a/ui/frontend/src/tests/briefDiff.test.tsx
+++ b/ui/frontend/src/tests/briefDiff.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import {
+  BriefDiff,
+  diffBlocks,
+  diffWords,
+  MARK_ADD_OPEN,
+  MARK_DEL_OPEN,
+} from '../components/brief/BriefDiff';
+
+describe('diffWords', () => {
+  test('marks added and removed words, keeping shared text', () => {
+    const segs = diffWords('the quick fox', 'the quick brown fox');
+    expect(segs.map((s) => s.type)).toContain('add');
+    expect(segs.find((s) => s.type === 'add')?.text).toContain('brown');
+    expect(segs.filter((s) => s.type === 'del')).toHaveLength(0);
+  });
+});
+
+describe('diffBlocks', () => {
+  test('classifies unchanged, changed, added and removed blocks', () => {
+    const oldText = 'Same paragraph.\n\nOld wording here.\n\nDropped paragraph.';
+    const newText = 'Same paragraph.\n\nNew wording here.\n\nAppended paragraph.';
+    const blocks = diffBlocks(oldText, newText);
+    const types = blocks.map((b) => b.type);
+    expect(types).toContain('same');
+    expect(types).toContain('changed');
+    const changed = blocks.find((b) => b.type === 'changed');
+    expect(changed?.markdown).toContain(MARK_ADD_OPEN);
+    expect(changed?.markdown).toContain(MARK_DEL_OPEN);
+  });
+
+  test('a paragraph removed with no replacement becomes a del block', () => {
+    const blocks = diffBlocks('Kept.\n\nRemoved paragraph.', 'Kept.');
+    expect(blocks.some((b) => b.type === 'del' && b.markdown.includes('Removed'))).toBe(true);
+  });
+});
+
+describe('BriefDiff rendering', () => {
+  test('renders markdown (not raw markers) with ins/del wrapping', () => {
+    const oldText = 'Intro text.\n\nThe **quick** fox jumped.';
+    const newText = 'Intro text.\n\nThe **quick** brown fox jumped.\n\nA new paragraph.';
+    const { container } = render(<BriefDiff oldText={oldText} newText={newText} />);
+
+    // Markdown is rendered: bold becomes <strong>, no literal ** remains.
+    expect(container.querySelector('strong')?.textContent).toBe('quick');
+    expect(container.textContent).not.toContain('**');
+
+    // The inserted word is wrapped as an addition.
+    const ins = Array.from(container.querySelectorAll('ins.brief-diff-add'));
+    expect(ins.map((el) => el.textContent).join(' ')).toContain('brown');
+
+    // The whole-new paragraph renders inside an added block.
+    const addBlock = container.querySelector('.brief-diff-block-add');
+    expect(addBlock?.textContent).toContain('A new paragraph.');
+
+    // No sentinel characters leak into the visible text.
+    expect(container.textContent).not.toMatch(/[\uE000-\uE003]/);
+  });
+
+  test('renders removed paragraphs as struck-through del blocks', () => {
+    const { container } = render(
+      <BriefDiff oldText={'Kept.\n\nRemoved paragraph.'} newText={'Kept.'} />,
+    );
+    const delBlock = container.querySelector('.brief-diff-block-del');
+    expect(delBlock?.textContent).toContain('Removed paragraph.');
+  });
+
+  test('renders a changed markdown heading as a heading', () => {
+    const { container } = render(
+      <BriefDiff oldText={'## Old title\n\nBody.'} newText={'## New title\n\nBody.'} />,
+    );
+    const h2 = container.querySelector('h2');
+    expect(h2).not.toBeNull();
+    expect(h2?.textContent).toContain('New title');
+    expect(h2?.querySelector('ins.brief-diff-add')?.textContent).toContain('New');
+    expect(h2?.querySelector('del.brief-diff-del')?.textContent).toContain('Old');
+  });
+});

--- a/ui/frontend/src/tests/briefDiff.test.tsx
+++ b/ui/frontend/src/tests/briefDiff.test.tsx
@@ -4,6 +4,7 @@ import {
   BriefDiff,
   diffBlocks,
   diffWords,
+  normalizeQuotes,
   MARK_ADD_OPEN,
   MARK_DEL_OPEN,
 } from '../components/brief/BriefDiff';
@@ -46,13 +47,12 @@ describe('BriefDiff rendering', () => {
     expect(container.querySelector('strong')?.textContent).toBe('quick');
     expect(container.textContent).not.toContain('**');
 
-    // The inserted word is wrapped as an addition.
+    // The inserted word and the whole-new paragraph are both marked as additions.
     const ins = Array.from(container.querySelectorAll('ins.brief-diff-add'));
-    expect(ins.map((el) => el.textContent).join(' ')).toContain('brown');
-
-    // The whole-new paragraph renders inside an added block.
-    const addBlock = container.querySelector('.brief-diff-block-add');
-    expect(addBlock?.textContent).toContain('A new paragraph.');
+    const addedText = ins.map((el) => el.textContent).join(' ');
+    expect(addedText).toContain('brown');
+    expect(container.textContent).toContain('A new paragraph.');
+    expect(addedText).toContain('A new paragraph.');
 
     // No sentinel characters leak into the visible text.
     expect(container.textContent).not.toMatch(/[\uE000-\uE003]/);
@@ -75,5 +75,27 @@ describe('BriefDiff rendering', () => {
     expect(h2?.textContent).toContain('New title');
     expect(h2?.querySelector('ins.brief-diff-add')?.textContent).toContain('New');
     expect(h2?.querySelector('del.brief-diff-del')?.textContent).toContain('Old');
+  });
+});
+
+describe('normalizeQuotes', () => {
+  test('collapses entity, curly, and straight quotes to one form', () => {
+    expect(normalizeQuotes('&#34;free&#34;')).toBe('"free"');
+    expect(normalizeQuotes('&quot;a&quot;')).toBe('"a"');
+    expect(normalizeQuotes('the government&#39;s plan')).toBe("the government's plan");
+    expect(normalizeQuotes('“curly” and ‘curly’')).toBe('"curly" and \'curly\'');
+    expect(normalizeQuotes('a &amp; b')).toBe('a & b');
+  });
+
+  test('quote-encoding-only differences produce no diff', () => {
+    // Old draft has entities, new draft has straight quotes — same text.
+    const { container } = render(
+      <BriefDiff
+        oldText={'The Act declares it &#34;free&#34; [1].'}
+        newText={'The Act declares it "free" [1].'}
+      />,
+    );
+    expect(container.querySelector('ins.brief-diff-add')).toBeNull();
+    expect(container.querySelector('del.brief-diff-del')).toBeNull();
   });
 });

--- a/ui/frontend/src/tests/briefSectionQuery.test.ts
+++ b/ui/frontend/src/tests/briefSectionQuery.test.ts
@@ -38,4 +38,29 @@ describe('buildSectionQuery', () => {
         'and cite a source for every claim.',
     );
   });
+
+  test('update mode preserves the draft, date-filters, and keeps citations', () => {
+    const q = buildSectionQuery({
+      heading: 'Impacts',
+      briefTopic: 'girls education',
+      mode: 'update',
+      existingContent: 'Enrolment rose sharply [1].',
+      instruction: 'prioritise enforcement',
+      publishedAfterIso: '2023-05-01T00:00:00.000Z',
+    });
+    // Keeps/embeds the current draft.
+    expect(q).toContain('Enrolment rose sharply [1].');
+    expect(q).toContain('Preserve its wording, structure and citations');
+    // Constrains the search to newer sources (date only).
+    expect(q).toContain('PUBLISHED AFTER 2023-05-01');
+    // Threads the optional instruction + demands sequential citations back.
+    expect(q).toContain('prioritise enforcement');
+    expect(q).toContain('sequential [n] citation markers');
+  });
+
+  test('update mode without a draft falls back to a normal generate query', () => {
+    const q = buildSectionQuery({ heading: 'Impacts', mode: 'update' });
+    expect(q).toContain('Write the "Impacts" section');
+    expect(q).not.toContain('Preserve its wording');
+  });
 });

--- a/ui/frontend/src/utils/assistantStream.ts
+++ b/ui/frontend/src/utils/assistantStream.ts
@@ -43,6 +43,9 @@ interface AssistantStreamOptions {
   searchSettings?: Partial<SearchSettings> | null;
   deepResearch?: boolean;
   conversationHistory?: ConversationMessage[];
+  // ISO date; constrains the library search to documents published on/after it
+  // (Brief "Update" action). Sent inside search_settings.published_after.
+  publishedAfter?: string | null;
   handlers: AssistantStreamHandlers;
   signal?: AbortSignal;
 }
@@ -217,9 +220,16 @@ export const streamAssistantChat = async ({
   searchSettings,
   deepResearch,
   conversationHistory,
+  publishedAfter,
   handlers,
   signal,
 }: AssistantStreamOptions): Promise<void> => {
+  // Fold the per-request publish-date cutoff into the search_settings payload
+  // (backend allows extra keys and applies it as a Qdrant range filter).
+  const settingsPayload = buildSearchSettingsPayload(searchSettings);
+  const searchSettingsBody = publishedAfter
+    ? { ...(settingsPayload || {}), published_after: publishedAfter }
+    : settingsPayload;
   const response = await fetch(`${apiBaseUrl}/assistant/chat/stream`, {
     method: 'POST',
     headers: buildHeaders(),
@@ -230,7 +240,7 @@ export const streamAssistantChat = async ({
       data_source: dataSource || undefined,
       assistant_model_config: assistantModelConfig || undefined,
       reranker_model: rerankerModel || undefined,
-      search_settings: buildSearchSettingsPayload(searchSettings),
+      search_settings: searchSettingsBody,
       deep_research: deepResearch || undefined,
       conversation_history: conversationHistory?.length ? conversationHistory : undefined,
     }),

--- a/ui/frontend/src/utils/briefStream.ts
+++ b/ui/frontend/src/utils/briefStream.ts
@@ -99,6 +99,52 @@ export const requestBriefOutline = async ({
   };
 };
 
+/**
+ * Surgically revise one section's markdown per an instruction (Brief "Edit").
+ * A single backend LLM copy-edit — NOT deep research — so the section keeps its
+ * wording + inline [n] citations. Returns the revised markdown.
+ */
+export const requestBriefRevise = async ({
+  apiBaseUrl,
+  dataSource,
+  content,
+  instruction,
+  model,
+  signal,
+}: {
+  apiBaseUrl: string;
+  dataSource: string;
+  content: string;
+  instruction: string;
+  model?: string | null;
+  signal?: AbortSignal;
+}): Promise<string> => {
+  const response = await fetch(`${apiBaseUrl}/brief/revise`, {
+    method: 'POST',
+    headers: buildHeaders(),
+    credentials: 'include',
+    body: JSON.stringify({
+      content,
+      instruction,
+      data_source: dataSource,
+      model: model ?? null,
+    }),
+    signal,
+  });
+  if (!response.ok) {
+    let detail = `Edit request failed (${response.status})`;
+    try {
+      const body = await response.json();
+      if (body?.detail) detail = String(body.detail);
+    } catch {
+      /* keep generic message */
+    }
+    throw new Error(detail);
+  }
+  const data = await response.json();
+  return typeof data.content === 'string' ? data.content : content;
+};
+
 export type BriefActivityTag = 'SCAN' | 'READ' | 'EXTRACT' | 'DRAFT' | 'DONE';
 
 export interface BriefActivityEvent {
@@ -136,6 +182,7 @@ export interface RunDeepResearchOptions {
   // the default CPU cross-encoder is too slow for multi-query research).
   rerankerModel?: string | null;
   searchSettings?: Partial<SearchSettings> | null;
+  publishedAfter?: string | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -152,6 +199,7 @@ export const runDeepResearch = async ({
   assistantModelConfig,
   rerankerModel = null,
   searchSettings = null,
+  publishedAfter = null,
   handlers,
   signal,
 }: RunDeepResearchOptions): Promise<void> => {
@@ -166,6 +214,7 @@ export const runDeepResearch = async ({
     assistantModelConfig: assistantModelConfig ?? null,
     rerankerModel: rerankerModel ?? null,
     searchSettings: searchSettings ?? null,
+    publishedAfter: publishedAfter ?? null,
     handlers: {
       onPhase: (phase) => {
         const pct = PHASE_PROGRESS[phase];
@@ -222,15 +271,72 @@ export interface ResearchSectionOptions {
   assistantModelConfig?: SummaryModelConfig | null;
   rerankerModel?: string | null;
   searchSettings?: Partial<SearchSettings> | null;
+  // Edit/Update: the mode, the current draft, the user's instruction, and (for
+  // Update) the ISO date after which the library search is constrained.
+  mode?: SectionResearchMode;
+  existingContent?: string | null;
+  instruction?: string | null;
+  publishedAfterIso?: string | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
 
+// 'edit' revises the existing draft per an instruction; 'update' folds in
+// sources published since `publishedAfterIso`. Both keep the current draft.
+export type SectionResearchMode = 'generate' | 'edit' | 'update';
+
+const updateInstruction = (instr: string, publishedAfterIso?: string | null): string => {
+  const after = (publishedAfterIso || '').slice(0, 10);
+  const base = after
+    ? `Search the document library for relevant sources PUBLISHED AFTER ${after} and fold any new findings into the draft, citing them. Keep the existing content; add or refresh only where newer evidence warrants. If no newer sources are found, return the draft unchanged and note that no newer sources were available.`
+    : 'Search the document library for the most recent relevant sources and fold any new findings into the draft, citing them.';
+  return instr ? `${base} Additional instruction: ${instr}` : base;
+};
+
+// Update: preserve the existing draft; the model folds in newer sources rather
+// than rewriting, returning the FULL section with a coherent sequential [n]
+// citation set. (Edit uses the backend /brief/revise .j2 prompt, not this.)
+const buildReviseQuery = (args: {
+  scope: string;
+  draft: string;
+  instr: string;
+  guidance: string;
+  publishedAfterIso?: string | null;
+}): string => {
+  const parts = [
+    `You are revising ${args.scope}.`,
+    `Here is the current draft of the section. Preserve its wording, structure and citations except where the instruction below requires a change:\n\n"""\n${args.draft}\n"""`,
+    updateInstruction(args.instr, args.publishedAfterIso),
+    'Return the FULL revised section as markdown with sequential [n] citation markers and cite a source for every claim.',
+  ];
+  if (args.guidance) parts.push(`Overall brief guidance: ${args.guidance}`);
+  return parts.join(' ');
+};
+
+const buildGenerateQuery = (args: {
+  scope: string;
+  parent: string;
+  guidance: string;
+  focus: string;
+}): string => {
+  const parts = [`Write ${args.scope}.`];
+  if (args.parent) {
+    parts.push(
+      `This section sits under the parent section "${args.parent}" — keep it specifically about that aspect of the brief and avoid repeating material that belongs in sibling sections.`,
+    );
+  }
+  parts.push(
+    'Search the document library for evidence relevant to this specific section and cite a source for every claim.',
+  );
+  if (args.guidance) parts.push(`Overall brief guidance: ${args.guidance}`);
+  if (args.focus) parts.push(`Focus for this section: ${args.focus}`);
+  return parts.join(' ');
+};
+
 /**
- * Build the deep-research instruction for one brief section. The brief topic,
- * the parent section (for sub-sections) and the author's brief-level guidance
- * are all woven in so the assistant's generated search queries — and the prose
- * it writes — stay relevant to where this section sits in the document.
+ * Build the deep-research instruction for one brief section. For generate it
+ * weaves in the brief topic, parent section and author guidance; for edit/update
+ * it embeds the current draft with revise-don't-replace semantics.
  */
 export const buildSectionQuery = ({
   heading,
@@ -238,34 +344,43 @@ export const buildSectionQuery = ({
   briefInstructions,
   parentTitle,
   context,
+  mode = 'generate',
+  existingContent,
+  instruction,
+  publishedAfterIso,
 }: {
   heading: string;
   briefTopic?: string | null;
   briefInstructions?: string | null;
   parentTitle?: string | null;
   context?: string | null;
+  mode?: SectionResearchMode;
+  existingContent?: string | null;
+  instruction?: string | null;
+  publishedAfterIso?: string | null;
 }): string => {
   const topic = (briefTopic || '').trim();
-  const parent = (parentTitle || '').trim();
   const guidance = (briefInstructions || '').trim();
-  const focus = (context || '').trim();
-  const parts: string[] = [];
-  parts.push(
-    topic
-      ? `Write the "${heading}" section of an evidence brief on "${topic}".`
-      : `Write the "${heading}" section of an evidence brief.`,
-  );
-  if (parent) {
-    parts.push(
-      `This section sits under the parent section "${parent}" — keep it specifically about that aspect of the brief and avoid repeating material that belongs in sibling sections.`,
-    );
+  const draft = (existingContent || '').trim();
+  const scope = topic
+    ? `the "${heading}" section of an evidence brief on "${topic}"`
+    : `the "${heading}" section of an evidence brief`;
+
+  if (mode === 'update' && draft) {
+    return buildReviseQuery({
+      scope,
+      draft,
+      instr: (instruction || '').trim(),
+      guidance,
+      publishedAfterIso,
+    });
   }
-  parts.push(
-    'Search the document library for evidence relevant to this specific section and cite a source for every claim.',
-  );
-  if (guidance) parts.push(`Overall brief guidance: ${guidance}`);
-  if (focus) parts.push(`Focus for this section: ${focus}`);
-  return parts.join(' ');
+  return buildGenerateQuery({
+    scope,
+    parent: (parentTitle || '').trim(),
+    guidance,
+    focus: (context || '').trim(),
+  });
 };
 
 /**
@@ -285,10 +400,24 @@ export const researchBriefSection = ({
   assistantModelConfig,
   rerankerModel,
   searchSettings,
+  mode = 'generate',
+  existingContent,
+  instruction,
+  publishedAfterIso,
   handlers,
   signal,
 }: ResearchSectionOptions): Promise<void> => {
-  const query = buildSectionQuery({ heading, briefTopic, briefInstructions, parentTitle, context });
+  const query = buildSectionQuery({
+    heading,
+    briefTopic,
+    briefInstructions,
+    parentTitle,
+    context,
+    mode,
+    existingContent,
+    instruction,
+    publishedAfterIso,
+  });
   return runDeepResearch({
     apiBaseUrl,
     dataSource,
@@ -296,6 +425,10 @@ export const researchBriefSection = ({
     assistantModelConfig,
     rerankerModel,
     searchSettings,
+    // Update also constrains the *search* to newer documents via a publish-date
+    // filter the backend applies to the Qdrant query (belt-and-braces with the
+    // prompt instruction above).
+    publishedAfter: mode === 'update' ? publishedAfterIso : null,
     handlers,
     signal,
   });


### PR DESCRIPTION
## What

Adds AI **Edit** and **Update** actions to each generated brief section, a per-section **research/audit log**, and an inline **change diff** so the user can see exactly what changed.

### Per-section actions
- **Manually Edit** — hand-edit the section text (unchanged).
- **AI Regenerate** — re-run deep research for the section from scratch (unchanged).
- **AI Edit** (✨) — surgically revises the section's *current* draft to a user instruction (e.g. "just focus on impacts") via a new `POST /brief/revise`: a **single LLM copy-edit** (prompts in `prompts/brief_revise_system.j2` / `brief_revise_user.j2`) that **preserves existing wording and inline `[n]` citations** and fully carries out the instruction without re-researching. Emphasis is edit-not-replace.
- **AI Get Updates** (🕐) — re-researches the section constrained to sources **published after it was last generated/updated**, folding new evidence into the existing draft.
- **Log** — opens a modal (styled like the history modal) with the original research question + instruction, plus a row for every Edit and Update with its instruction and source counts.

### Toolbar
- **AI Regenerate All** — regenerate every section.
- **AI Get All Recent Updates** (🕐) — run "Get Updates" across all completed sections in one click.

### Seeing the changes
- After an Edit/Update the section shows a **word-level diff** (struck-out removals + highlighted additions), rendered markdown (not raw), with **Keep Edits / Reject Edits**. Original text stays in place, greyed, while the AI runs.
- Each audit entry stores a `before`/`after` snapshot, so **clicking a Log row re-opens that change's diff** — including on previously-saved reports.
- Quote encodings (`&#34;` / `"` / curly) are normalized before diffing so quote-only noise doesn't appear as a change.

## Backend
- `POST /brief/revise` (`ui/backend/routes/brief.py`) → `revise_brief_section` (`llm_service.py`): renders the `.j2` prompts, neutralises Jinja autoescape on the input, strips any code-fence/`"""` wrapper and decodes HTML entities on the output.
- Schemas: `BriefReviseRequest` / `BriefReviseResponse`.

## Tests
- `tests/unit/test_brief_revise.py` — `_strip_section_wrapper` + `revise_brief_section` (instruction/content reach the LLM unescaped, output entities decoded, code-fence stripping), `get_llm` mocked. **6 tests, passing.**
- `briefSectionQuery.test.ts` — update-mode preserves the draft, date-filters, keeps citations; falls back to a generate query with no draft.
- `briefDiff.test.tsx` — `normalizeQuotes` collapses entity/curly/straight quotes; quote-only differences yield no diff.
- All 7 brief frontend suites pass (41 tests).

## Notes
- Edit's prompts are externalised in `prompts/*.j2` like every other prompt. **Update's instruction is still assembled in the frontend query builder** (same pattern as the pre-existing `generate` section query); a follow-up should move Update onto the same backend `.j2` flow as Edit.
- Verified locally against the data-loaded WFP stack: UI compiles, API boots clean, `/brief/revise` registered. Full in-browser LLM output is best confirmed manually (local auth is MS-OAuth only).
