### PR TITLE
fix(auth): sign-out always works, even without a valid session

### DIFF
--- a/tests/unit/test_auth_logout.py
+++ b/tests/unit/test_auth_logout.py
@@ -1,15 +1,15 @@
-"""Unit tests for the OAuth-only cookie logout route.
+"""Unit tests for the unconditional cookie logout route.
 
-In OAuth-only deployments (``DISABLE_EMAIL_LOGIN=true``) the email/password
-auth router — which normally carries ``/cookie-login/logout`` — is not mounted,
-so a standalone logout is registered instead. These tests verify that route
-exists, clears the auth cookie, and still requires a valid session. The route
-is registered at import time from the env var, so the module is reloaded per
-mode.
+Signing out must never depend on being signed in: a user whose session cookie
+is stale (expired mid-session, network/VPN transition) still needs the cookie
+cleared, otherwise they are stuck with a broken session they can neither use
+nor discard. The logout route is therefore registered before the built-in
+fastapi-users auth routers (first-registered route wins) and requires no
+authentication, in both email-login and OAuth-only deployments. Routes are
+registered at import time from the env var, so the module is reloaded per mode.
 """
 
 import importlib
-from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -19,61 +19,60 @@ COOKIE_NAME = "evidencelab_auth"
 LOGOUT_PATH = "/auth/cookie-login/logout"
 
 
-@pytest.fixture
-def oauth_only_auth_routes(monkeypatch):
-    """Reload the auth routes module in OAuth-only mode, then restore it.
+def _reload_auth_routes(monkeypatch, *, disable_email_login: bool):
+    """Reload the auth routes module under the given login mode.
 
     Args:
         monkeypatch: pytest fixture used to set ``DISABLE_EMAIL_LOGIN``.
+        disable_email_login: When True, reload in OAuth-only mode.
 
-    Yields:
+    Returns:
         module: The reloaded ``ui.backend.routes.auth`` module.
     """
-    monkeypatch.setenv("DISABLE_EMAIL_LOGIN", "true")
+    monkeypatch.setenv(
+        "DISABLE_EMAIL_LOGIN", "true" if disable_email_login else "false"
+    )
     from ui.backend.routes import auth as auth_routes
 
-    yield importlib.reload(auth_routes)
+    return importlib.reload(auth_routes)
 
-    # Restore the module to its env-default state so other tests are unaffected.
+
+@pytest.fixture
+def oauth_only_auth_routes(monkeypatch):
+    """Auth routes module reloaded in OAuth-only mode, restored afterwards."""
+    yield _reload_auth_routes(monkeypatch, disable_email_login=True)
     monkeypatch.undo()
+    from ui.backend.routes import auth as auth_routes
+
     importlib.reload(auth_routes)
 
 
-def _build_app(auth_routes, *, authenticated: bool) -> FastAPI:
-    """Mount the auth router, optionally overriding auth to authenticated.
+@pytest.fixture
+def email_login_auth_routes(monkeypatch):
+    """Auth routes module reloaded with email login enabled, restored after."""
+    yield _reload_auth_routes(monkeypatch, disable_email_login=False)
+    monkeypatch.undo()
+    from ui.backend.routes import auth as auth_routes
+
+    importlib.reload(auth_routes)
+
+
+def _build_app(auth_routes) -> FastAPI:
+    """Mount the auth router on a bare app (no auth overrides).
 
     Args:
         auth_routes: The (reloaded) auth routes module.
-        authenticated: When True, treat requests as an authenticated user.
 
     Returns:
         FastAPI: The configured application.
     """
-    from ui.backend.auth.users import current_active_user
-
     app = FastAPI()
     app.include_router(auth_routes.router, prefix="/auth")
-    if authenticated:
-        app.dependency_overrides[current_active_user] = lambda: SimpleNamespace(
-            id="user-1"
-        )
     return app
 
 
-@pytest.mark.unit
-def test_cookie_logout_route_registered_in_oauth_only_mode(oauth_only_auth_routes):
-    """The standalone logout route exists when email login is disabled."""
-    paths = {route.path for route in oauth_only_auth_routes.router.routes}
-    assert "/cookie-login/logout" in paths
-
-
-@pytest.mark.unit
-def test_cookie_logout_when_authenticated_clears_cookie(oauth_only_auth_routes):
-    """An authenticated logout returns 204 and expires the auth cookie."""
-    client = TestClient(_build_app(oauth_only_auth_routes, authenticated=True))
-
-    resp = client.post(LOGOUT_PATH)
-
+def _assert_logout_clears_cookie(resp) -> None:
+    """Assert a logout response expires the auth cookie."""
     assert resp.status_code == 204
     set_cookie = resp.headers.get("set-cookie", "").lower()
     assert f"{COOKIE_NAME}=" in set_cookie
@@ -81,10 +80,50 @@ def test_cookie_logout_when_authenticated_clears_cookie(oauth_only_auth_routes):
 
 
 @pytest.mark.unit
-def test_cookie_logout_requires_authentication(oauth_only_auth_routes):
-    """Logout without a valid session is rejected (nothing to clear)."""
-    client = TestClient(_build_app(oauth_only_auth_routes, authenticated=False))
+def test_cookie_logout_route_registered_in_oauth_only_mode(oauth_only_auth_routes):
+    """The logout route exists when email login is disabled."""
+    paths = {route.path for route in oauth_only_auth_routes.router.routes}
+    assert "/cookie-login/logout" in paths
+
+
+@pytest.mark.unit
+def test_cookie_logout_without_session_clears_cookie_oauth_only(
+    oauth_only_auth_routes,
+):
+    """Logout with no session cookie still succeeds and expires the cookie.
+
+    A user with a stale or missing session must always be able to sign out —
+    logout must not require being logged in.
+    """
+    client = TestClient(_build_app(oauth_only_auth_routes))
 
     resp = client.post(LOGOUT_PATH)
 
-    assert resp.status_code == 401
+    _assert_logout_clears_cookie(resp)
+
+
+@pytest.mark.unit
+def test_cookie_logout_without_session_clears_cookie_email_mode(
+    email_login_auth_routes,
+):
+    """With email login enabled, the unconditional logout shadows the built-in.
+
+    fastapi-users' own /cookie-login/logout returns 401 without a valid
+    session; the unconditional route is registered first so it wins.
+    """
+    client = TestClient(_build_app(email_login_auth_routes))
+
+    resp = client.post(LOGOUT_PATH)
+
+    _assert_logout_clears_cookie(resp)
+
+
+@pytest.mark.unit
+def test_cookie_logout_with_stale_cookie_clears_cookie(oauth_only_auth_routes):
+    """Logout with an invalid (expired/garbage) cookie still clears it."""
+    client = TestClient(_build_app(oauth_only_auth_routes))
+    client.cookies.set(COOKIE_NAME, "not-a-valid-jwt")
+
+    resp = client.post(LOGOUT_PATH)
+
+    _assert_logout_clears_cookie(resp)

--- a/ui/backend/routes/auth.py
+++ b/ui/backend/routes/auth.py
@@ -78,6 +78,33 @@ DISABLE_EMAIL_LOGIN = os.environ.get("DISABLE_EMAIL_LOGIN", "false").lower() in 
 
 router = APIRouter()
 
+
+# ---------------------------------------------------------------------------
+# Logout — registered BEFORE the built-in auth routers so it takes precedence
+# over fastapi-users' logout (first-registered route wins), which returns 401
+# when the session cookie is missing, expired, or invalid.
+#
+# Signing out must never depend on being signed in: a user whose cookie is
+# stale (expired mid-session, network/VPN transition, clock skew) still needs
+# the cookie cleared, otherwise they are stuck with a broken session they can
+# neither use nor discard. The stateless JWT needs no server-side revocation,
+# so unconditionally returning the cookie-clearing response is sufficient —
+# and harmless when no cookie was present.
+# ---------------------------------------------------------------------------
+
+
+@router.post("/cookie-login/logout", tags=["auth"])
+async def cookie_logout():
+    """Clear the auth cookie for the current browser, session or not.
+
+    Deliberately requires no authentication (see block comment above).
+
+    Returns:
+        Response: A 204 response carrying a cookie-clearing ``Set-Cookie``.
+    """
+    return await cookie_backend.transport.get_logout_response()
+
+
 # ---------------------------------------------------------------------------
 # Email/password auth — mounted only when DISABLE_EMAIL_LOGIN is not set.
 # Verify and reset-password routers remain available so OAuth users who also
@@ -108,37 +135,6 @@ router.include_router(
     fastapi_users.get_reset_password_router(),
     tags=["auth"],
 )
-
-
-# ---------------------------------------------------------------------------
-# Logout
-#
-# The email/password auth router mounted above carries the cookie logout
-# endpoint (/cookie-login/logout) — but only when email login is enabled. In
-# OAuth-only deployments (DISABLE_EMAIL_LOGIN=true) that router is absent, yet
-# the frontend still needs to clear the auth cookie on sign-out and on idle
-# logout. Register a standalone logout that works for any cookie session, but
-# only when the built-in one is not mounted, to avoid a duplicate route.
-# ---------------------------------------------------------------------------
-
-if DISABLE_EMAIL_LOGIN:
-
-    @router.post("/cookie-login/logout", tags=["auth"])
-    async def cookie_logout(user: User = Depends(current_active_user)):
-        """Clear the auth cookie for the current cookie session.
-
-        Mirrors the built-in cookie logout for OAuth-only deployments where the
-        email/password auth router that normally provides it is not mounted.
-        Requires a valid session cookie; the stateless JWT needs no server-side
-        revocation, so clearing the cookie is sufficient.
-
-        Args:
-            user: The authenticated user, resolved from the existing auth cookie.
-
-        Returns:
-            Response: A 204 response carrying a cookie-clearing ``Set-Cookie``.
-        """
-        return await cookie_backend.transport.get_logout_response()
 
 
 # ---------------------------------------------------------------------------

--- a/ui/frontend/src/hooks/useAuth.ts
+++ b/ui/frontend/src/hooks/useAuth.ts
@@ -175,12 +175,8 @@ export function useAuthState(): AuthContextValue {
     let timeoutId: ReturnType<typeof setTimeout>;
 
     const handleTimeout = async () => {
-      // Clear the server-side cookie (best-effort — may already be expired)
-      try {
-        await axios.post(`${API_BASE_URL}/auth/cookie-login/logout`);
-      } catch {
-        // Ignore — cookie may have already expired or CSRF may be stale
-      }
+      // End the client session first — expiring the UI must not wait on (or
+      // be blocked by) the network.
       setSessionExpired(true);
       setState({
         user: null,
@@ -188,6 +184,14 @@ export function useAuthState(): AuthContextValue {
         isLoading: false,
         isAuthenticated: false,
       });
+      // Clear the server-side cookie (best-effort — may already be expired)
+      try {
+        await axios.post(`${API_BASE_URL}/auth/cookie-login/logout`, undefined, {
+          timeout: 10000,
+        });
+      } catch {
+        // Ignore — cookie may have already expired or the network may be down
+      }
     };
 
     const resetTimer = () => {
@@ -382,12 +386,10 @@ export function useAuthState(): AuthContextValue {
   }, []);
 
   const logout = useCallback(async () => {
-    try {
-      // Ask the backend to clear the auth cookie
-      await axios.post(`${API_BASE_URL}/auth/cookie-login/logout`);
-    } catch {
-      // Logout endpoint might fail if already expired — that's fine
-    }
+    // Sign the user out of the UI immediately — logout must never depend on
+    // the network or on the session still being valid. A hung request (e.g.
+    // after a VPN drop, where axios has no timeout) previously left the click
+    // doing nothing at all.
     setState({ user: null, token: null, isLoading: false, isAuthenticated: false });
     setSessionExpired(false);
 
@@ -395,6 +397,18 @@ export function useAuthState(): AuthContextValue {
     if (authPromiseRef.current) {
       authPromiseRef.current.resolve(false);
       authPromiseRef.current = null;
+    }
+
+    try {
+      // Best-effort: ask the backend to clear the httpOnly auth cookie. The
+      // endpoint requires no authentication, so this also clears stale or
+      // invalid cookies. Time-boxed so a dead connection can't hang the call.
+      await axios.post(`${API_BASE_URL}/auth/cookie-login/logout`, undefined, {
+        timeout: 10000,
+      });
+    } catch {
+      // Network failure or timeout — the client is already signed out; the
+      // cookie (if any) lapses on its own at token expiry.
     }
   }, []);
 

--- a/ui/frontend/src/tests/useAuthSession.test.tsx
+++ b/ui/frontend/src/tests/useAuthSession.test.tsx
@@ -309,7 +309,27 @@ describe('useAuthState — inactivity timeout', () => {
 
     expect(axios.post).toHaveBeenCalledWith(
       expect.stringContaining('/auth/cookie-login/logout'),
+      undefined,
+      expect.objectContaining({ timeout: expect.any(Number) }),
     );
+    jest.useRealTimers();
+  });
+
+  it('expires the session immediately even when the logout request hangs', async () => {
+    jest.useFakeTimers();
+    render(<AuthTestHarness />);
+    await flushPromises();
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+
+    // Simulate a dead connection (e.g. after a VPN drop): the logout POST
+    // never settles. The session must still end.
+    (axios.post as jest.Mock).mockImplementation(() => new Promise(() => {}));
+
+    await act(async () => { jest.advanceTimersByTime(60 * 60 * 1000 + 100); });
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+    expect(screen.getByTestId('session-expired').textContent).toBe('true');
     jest.useRealTimers();
   });
 });
@@ -434,5 +454,42 @@ describe('useAuthState — login/logout session state', () => {
 
     expect(screen.getByTestId('session-expired').textContent).toBe('false');
     expect(screen.getByTestId('authenticated').textContent).toBe('false');
+  });
+
+  it('signs out immediately even when the logout request hangs', async () => {
+    render(<AuthTestHarness />);
+    await flushPromises();
+
+    await act(async () => {
+      await latestAuth.login({ username: 'test@test.com', password: 'pass1234' }); // pragma: allowlist secret
+    });
+    expect(screen.getByTestId('authenticated').textContent).toBe('true');
+
+    // Simulate a dead connection (e.g. after a VPN drop): the logout POST
+    // never settles. Clicking Sign Out must still sign the user out.
+    (axios.post as jest.Mock).mockImplementation(() => new Promise(() => {}));
+
+    act(() => {
+      latestAuth.logout();
+    });
+
+    expect(screen.getByTestId('authenticated').textContent).toBe('false');
+    expect(screen.getByTestId('session-expired').textContent).toBe('false');
+  });
+
+  it('sends the logout request with a timeout so it cannot hang forever', async () => {
+    render(<AuthTestHarness />);
+    await flushPromises();
+
+    (axios.post as jest.Mock).mockClear();
+    await act(async () => {
+      await latestAuth.logout();
+    });
+
+    expect(axios.post).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/cookie-login/logout'),
+      undefined,
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
   });
 });


### PR DESCRIPTION
## What

Makes **Sign Out unconditional** — clicking it always logs the user out, regardless of session validity or network state. Previously it depended on being logged in, twice over:

### Backend
Both logout variants required `current_active_user` and returned **401 when the session cookie was stale** — so a user with a broken session could never clear their cookie (httpOnly cookies can only be cleared by a server `Set-Cookie`):
- fastapi-users' built-in `/cookie-login/logout` (email-login mode)
- the standalone OAuth-only logout (`DISABLE_EMAIL_LOGIN=true`)

Fix: register an unconditional `POST /auth/cookie-login/logout` **before** the built-in routers (first-registered route wins), returning the cookie-clearing 204 in both modes with no auth dependency. The JWT is stateless, so no server-side revocation is needed.

### Frontend
`logout()` cleared UI state only **after** awaiting the logout POST — and no axios call in the app has a timeout. On a dead connection (e.g. after a VPN transition, where requests hang rather than fail) the Sign Out click **did nothing, with no console error**.

Fix: clear the client session immediately, then send the cookie-clearing request best-effort with a 10s timeout. The idle-logout handler had the same ordering flaw and gets the same fix.

## Tests
- `tests/unit/test_auth_logout.py` (rewritten — it previously *asserted* logout requires auth): logout with no session and with a garbage cookie returns 204 + expires the cookie, in **both** email-login and OAuth-only modes (verifies route shadowing). All 98 auth unit tests pass.
- `useAuthSession.test.tsx`: sign-out and idle-expiry complete even when the logout request never settles; logout request carries a timeout. All 544 frontend tests pass.

## Context
Motivated by a user whose user menu intermittently "does nothing" (no console errors), likely tied to VPN on/off transitions — a hung, timeout-less logout request exactly reproduces "click Sign Out, nothing happens, nothing in console".
