### PR TITLE
fix(translate): chunk long texts under GoogleTranslator's 5000-char cap

### DIFF
--- a/tests/integration/test_translation_integration.py
+++ b/tests/integration/test_translation_integration.py
@@ -1,0 +1,58 @@
+"""Integration tests for translation against the real translation service.
+
+The unit tests in ``tests/unit/test_translation.py`` mock GoogleTranslator, so
+they cannot catch real-service constraints — most importantly its hard
+5000-character per-request cap, which silently broke AI-summary translation
+(the bare except in ``translate_text`` returned the original English with a
+200). These tests exercise the real service end-to-end, including an
+AI-summary-sized text, so a regression in the chunked-translation path or a
+service behaviour change is caught in CI rather than by users.
+
+Requires outbound network access (runs in the integration job / Docker stack).
+"""
+
+import pytest
+
+from ui.backend.services.llm_service import translate_text
+
+pytestmark = pytest.mark.integration
+
+_PARAGRAPH = (
+    "The evaluation of the programme found significant improvements in school "
+    "enrolment and retention, particularly for girls in rural districts [1]. "
+    "Funding constraints nevertheless limited the scale-up of feeding "
+    "programmes in the northern region [2].\n\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_search_chunk_sized_text_translates():
+    """A typical search-result chunk translates to real French."""
+    out = await translate_text(_PARAGRAPH.strip(), "fr", "en")
+
+    assert out != _PARAGRAPH.strip()
+    assert "évaluation" in out.lower() or "programme" in out.lower()
+    assert "[1]" in out and "[2]" in out
+
+
+@pytest.mark.asyncio
+async def test_ai_summary_sized_text_translates_beyond_5000_chars():
+    """An AI-summary-sized text (over the 5000-char cap) fully translates.
+
+    This is the exact case that used to fail: GoogleTranslator rejects
+    requests of 5000+ characters, and the failure was silently swallowed,
+    returning the original English text.
+    """
+    long_text = "## Key findings\n\n" + _PARAGRAPH * 26
+    assert len(long_text) > 5000  # sanity: must exercise the chunked path
+
+    out = await translate_text(long_text, "fr", "en")
+
+    # Actually translated — not the silently-returned original.
+    assert out != long_text
+    assert "évaluation" in out.lower() or "scolarisation" in out.lower()
+    # Citations and paragraph structure survive chunking and restore.
+    assert "[1]" in out and "[2]" in out
+    assert out.count("\n\n") >= 20
+    # No protection markers leak into the visible text.
+    assert "__" not in out

--- a/tests/unit/test_translation.py
+++ b/tests/unit/test_translation.py
@@ -2,7 +2,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ui.backend.services.llm_service import translate_text
+from ui.backend.services.llm_service import (
+    _TRANSLATE_CHAR_LIMIT,
+    _pack_units,
+    translate_text,
+)
 
 
 @pytest.mark.asyncio
@@ -99,3 +103,91 @@ async def test_language_mapping():
         # Test unknown -> "en" default
         await translate_text("text", "klingon")
         mock_translator_class.assert_called_with(source="auto", target="en")
+
+
+def test_pack_units_respects_limit_and_order():
+    """Units are greedily packed under the limit, order preserved."""
+    chunks = _pack_units(["aa", "bb", "cc", "dd"], limit=7, joiner="|")
+    assert chunks == ["aa|bb", "cc|dd"]
+
+
+def test_pack_units_oversized_unit_becomes_own_chunk():
+    """A unit longer than the limit is emitted alone for further splitting."""
+    chunks = _pack_units(["x" * 20, "yy"], limit=10, joiner=" ")
+    assert chunks == ["x" * 20, "yy"]
+
+
+@pytest.mark.asyncio
+async def test_long_text_is_translated_in_chunks_under_the_cap():
+    """AI-summary-sized text is split so every request stays under the cap.
+
+    A single oversized request is rejected by GoogleTranslator with
+    NotValidLength (>= 5000 chars), which previously made AI-summary
+    translation silently return the original English text.
+    """
+    with patch(
+        "ui.backend.services.llm_service.GoogleTranslator"
+    ) as mock_translator_class:
+        mock_instance = MagicMock()
+        # Echo the input so restore logic and reassembly can be verified.
+        mock_instance.translate.side_effect = lambda chunk: chunk
+        mock_translator_class.return_value = mock_instance
+
+        paragraph = (
+            "The evaluation found significant improvements in enrolment "
+            "and retention for girls in rural districts [1]. Funding "
+            "constraints limited scale-up in the northern region [2]."
+        )
+        long_text = "## Key findings\n\n" + "\n\n".join([paragraph] * 40)
+        assert len(long_text) > 5000  # sanity: the failing case
+
+        result = await translate_text(long_text, "french", "en")
+
+        # Multiple requests were made, and every one is under the hard cap.
+        calls = [c.args[0] for c in mock_instance.translate.call_args_list]
+        assert len(calls) > 1
+        assert all(len(c) < 5000 for c in calls)
+        # Round-trip through an identity translator preserves the content:
+        # references and paragraph structure are restored intact.
+        assert result == long_text
+
+
+@pytest.mark.asyncio
+async def test_short_text_still_translated_in_a_single_request():
+    """Texts under the cap keep the original single-request behavior."""
+    with patch(
+        "ui.backend.services.llm_service.GoogleTranslator"
+    ) as mock_translator_class:
+        mock_instance = MagicMock()
+        mock_instance.translate.side_effect = lambda chunk: chunk
+        mock_translator_class.return_value = mock_instance
+
+        text = "A short chunk-sized text [1].\n\nSecond paragraph."
+        result = await translate_text(text, "french", "en")
+
+        assert mock_instance.translate.call_count == 1
+        assert result == text
+
+
+@pytest.mark.asyncio
+async def test_single_oversized_paragraph_is_split_on_sentences():
+    """One paragraph above the cap is packed on sentence boundaries."""
+    with patch(
+        "ui.backend.services.llm_service.GoogleTranslator"
+    ) as mock_translator_class:
+        mock_instance = MagicMock()
+        mock_instance.translate.side_effect = lambda chunk: chunk
+        mock_translator_class.return_value = mock_instance
+
+        sentence = "This is a fairly long sentence about programme outcomes. "
+        one_paragraph = (
+            sentence * ((_TRANSLATE_CHAR_LIMIT // len(sentence)) + 5)
+        ).strip()
+        assert len(one_paragraph) > _TRANSLATE_CHAR_LIMIT
+
+        result = await translate_text(one_paragraph, "french", "en")
+
+        calls = [c.args[0] for c in mock_instance.translate.call_args_list]
+        assert len(calls) > 1
+        assert all(len(c) < 5000 for c in calls)
+        assert result == one_paragraph

--- a/ui/backend/services/llm_service.py
+++ b/ui/backend/services/llm_service.py
@@ -535,6 +535,99 @@ async def revise_brief_section(
     return html.unescape(_strip_section_wrapper(str(response.content)))
 
 
+# GoogleTranslator rejects requests of 5000+ characters outright, so long
+# texts (AI summaries easily exceed this; search-result chunks never do) must
+# be translated in pieces. The margin below 5000 absorbs marker inflation and
+# keeps every request safely inside the cap.
+_TRANSLATE_CHAR_LIMIT = 4500
+
+
+def _pack_units(units: List[str], limit: int, joiner: str) -> List[str]:
+    """Greedily pack string units into chunks of at most ``limit`` characters.
+
+    A single unit longer than ``limit`` becomes its own (oversized) chunk for
+    the caller to split further.
+
+    Args:
+        units: Ordered pieces of text to pack.
+        limit: Maximum chunk length in characters.
+        joiner: String placed between units within a chunk.
+
+    Returns:
+        List of packed chunks, in order.
+    """
+    chunks: List[str] = []
+    current = ""
+    for unit in units:
+        candidate = f"{current}{joiner}{unit}" if current else unit
+        if not current or len(candidate) <= limit:
+            current = candidate
+        else:
+            chunks.append(current)
+            current = unit
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _translate_oversized_paragraph(translator: GoogleTranslator, chunk: str) -> str:
+    """Translate a single paragraph that alone exceeds the request cap.
+
+    Splits on sentence ends first; a pathological single sentence is packed on
+    word boundaries as a last resort.
+
+    Args:
+        translator: Configured GoogleTranslator instance.
+        chunk: Protected paragraph text longer than the request cap.
+
+    Returns:
+        The translated paragraph.
+    """
+    out: List[str] = []
+    for sentence_chunk in _pack_units(
+        re.split(r"(?<=[.!?])\s+", chunk), _TRANSLATE_CHAR_LIMIT, " "
+    ):
+        if len(sentence_chunk) > _TRANSLATE_CHAR_LIMIT:
+            word_chunks = _pack_units(
+                sentence_chunk.split(" "), _TRANSLATE_CHAR_LIMIT, " "
+            )
+            out.extend(translator.translate(w) or w for w in word_chunks)
+        else:
+            out.append(translator.translate(sentence_chunk) or sentence_chunk)
+    return " ".join(out)
+
+
+def _translate_protected(translator: GoogleTranslator, protected: str) -> str:
+    """Translate protected text, keeping every request under the service cap.
+
+    Short texts go through in one request (the common search-result case).
+    Longer texts (AI summaries) are split at paragraph markers — natural
+    translation units — and each piece is translated separately, then
+    re-joined with the paragraph marker so the restore step behaves exactly
+    as in the single-request case.
+
+    Args:
+        translator: Configured GoogleTranslator instance.
+        protected: Text with references and newlines already marker-protected.
+
+    Returns:
+        The translated text, markers preserved.
+    """
+    if len(protected) <= _TRANSLATE_CHAR_LIMIT:
+        return translator.translate(protected)
+    para_chunks = _pack_units(
+        protected.split(" __PARA__ "), _TRANSLATE_CHAR_LIMIT, " __PARA__ "
+    )
+    return " __PARA__ ".join(
+        (
+            _translate_oversized_paragraph(translator, chunk)
+            if len(chunk) > _TRANSLATE_CHAR_LIMIT
+            else translator.translate(chunk) or chunk
+        )
+        for chunk in para_chunks
+    )
+
+
 async def translate_text(
     text: str, target_language: str, source_language: str | None = None
 ) -> str:
@@ -616,8 +709,11 @@ async def translate_text(
 
         # 3. Perform translation
         # deep-translator is synchronous, suitable for direct call here.
+        # Long texts (e.g. AI summaries) are split into chunks below the
+        # service's per-request character cap — a single oversized request
+        # is rejected outright with NotValidLength.
         translator = GoogleTranslator(source=source_lang_code, target=target_lang_code)
-        translated_text = translator.translate(protected_text)
+        translated_text = _translate_protected(translator, protected_text)
 
         # 4. Restore references: __REF_64__ -> [64]
         if translated_text:


### PR DESCRIPTION
## What

Fixes AI-summary translation silently doing nothing.

**Root cause (measured, not guessed):** the whole summary was sent to Google Translate as a single request; `GoogleTranslator` rejects 5000+ characters with `NotValidLength`; and `translate_text`'s bare `except` swallowed the error and **returned the original English with HTTP 200** — so the UI showed "translated" text identical to the source, with no error anywhere. Search-result chunks are short, which is why they kept working. Gemini models (`max_tokens` up to 65536) produce the longest summaries, making them the most exposed.

Reproduced live before the fix: a 6,517-char summary → `Translation failed: ... Text length need to be between 0 and 5000 characters` → original English returned.

## Fix

`translate_text` now splits the marker-protected text into chunks under a 4,500-char margin:
- split at `__PARA__` paragraph markers (natural translation units), greedily packed;
- an oversized single paragraph falls back to sentence packing, then word packing;
- chunks re-join with the paragraph marker, so the existing `[n]`-reference and newline restore logic is untouched.

Short texts keep the exact original single-request path (existing mocked tests pass unchanged).

## Why tests didn't catch it

`tests/unit/test_translation.py` fully mocks `GoogleTranslator`, so the real service's 5000-char cap was invisible. Added:
- **Unit** (5 new): every request stays under the cap for AI-summary-sized input; identity round-trip preserves references and paragraph structure; short texts still use one request; oversized single paragraphs split on sentences.
- **Integration** (new file, `@pytest.mark.integration`): real-service translation of chunk-sized *and* AI-summary-sized texts — asserts actual French output, citations `[1]`/`[2]` preserved, paragraphs intact, no `__` markers leaked.

## Verification (local WFP stack, real services)

- 6.5k-char summary → `POST /translate` → full French/Spanish, citations + paragraph structure preserved.
- Real `gemini-2.5-flash` (Vertex) summary generated and translated end-to-end — translation is model-independent (`/translate` never touches an LLM), so this holds for all configured models.
- 24 parallel chunk-sized requests: all translated (search-result burst path).
- 9/9 translation unit tests, 2/2 integration tests, 61 adjacent unit tests pass.
