### PR TITLE
feat(ui): add nav-tab tooltips and search result-count context

### DIFF
--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -596,6 +596,51 @@ h6,
   background: none;
 }
 
+/* Nav tab tooltips — describe each main tab on hover/keyboard focus.
+   Reuses the app tooltip look (dark bubble + arrow) from .tooltip-text, but
+   wraps to a readable width instead of a single nowrap line. */
+.nav-tab-tooltip {
+  position: absolute;
+  top: calc(100% + 0.25rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(-4px);
+  width: max-content;
+  max-width: 240px;
+  padding: 0.625rem 0.875rem;
+  background: var(--gray-900);
+  color: var(--white);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.4;
+  text-align: center;
+  white-space: normal;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+  z-index: 1000;
+}
+
+.nav-tab-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-bottom-color: var(--gray-900);
+}
+
+.nav-tab:hover .nav-tab-tooltip,
+.nav-tab:focus-visible .nav-tab-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+}
+
 /* Search Container */
 .search-container {
   background: var(--white);
@@ -8541,6 +8586,73 @@ li.ai-fact-active::before {
   font-style: italic;
   color: var(--gray-400);
   white-space: nowrap;
+}
+
+/* Info affordance explaining what the org result counts mean.
+   Shares the dark-bubble tooltip look used elsewhere in the app. */
+.result-info {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.result-info-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: none;
+  border: none;
+  color: var(--gray-400);
+  cursor: help;
+  transition: color 0.15s ease;
+}
+
+.result-info-icon:hover,
+.result-info-icon:focus-visible {
+  color: var(--primary-blue);
+}
+
+.result-info-tooltip {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%) translateY(-4px);
+  width: max-content;
+  max-width: 280px;
+  padding: 0.625rem 0.875rem;
+  background: var(--gray-900);
+  color: var(--white);
+  border-radius: var(--radius-md);
+  font-family: var(--font-body);
+  font-size: 0.8125rem;
+  font-weight: 400;
+  line-height: 1.45;
+  text-align: left;
+  white-space: normal;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
+  z-index: 1000;
+}
+
+.result-info-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-bottom-color: var(--gray-900);
+}
+
+.result-info:hover .result-info-tooltip,
+.result-info:focus-within .result-info-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
 }
 
 .search-result-filters-org-label {

--- a/ui/frontend/src/components/app/SearchTabContent.tsx
+++ b/ui/frontend/src/components/app/SearchTabContent.tsx
@@ -11,6 +11,7 @@ import { useRatings } from '../../hooks/useRatings';
 import { useAuth } from '../../hooks/useAuth';
 import RatingModal from '../ratings/RatingModal';
 import { serializeDrilldownTree } from '../../utils/drilldownUtils';
+import { buildResultsCoverageText } from '../../utils/resultsCoverage';
 import { useDevFixtureSearch } from '../../__fixtures__/useDevFixtureSearch';
 
 interface SearchTabContentProps {
@@ -236,6 +237,7 @@ const WanderingSpinner: React.FC = () => {
 /** Extracted sub-component for the org buttons, document thumbnail carousel, and filter indicator */
 const SearchResultFilters: React.FC<{
   uniqueOrgs: Array<{ org: string; count: number }>;
+  coverageText: string;
   filteredOrgs: string[];
   onOrgToggle: (org: string) => void;
   filteredDocIds: string[];
@@ -251,6 +253,7 @@ const SearchResultFilters: React.FC<{
   onClearAll: () => void;
 }> = ({
   uniqueOrgs,
+  coverageText,
   filteredOrgs,
   onOrgToggle,
   filteredDocIds,
@@ -278,6 +281,19 @@ const SearchResultFilters: React.FC<{
             {org} ({count})
           </button>
         ))}
+        <span className="result-info">
+          <button
+            type="button"
+            className="result-info-icon"
+            aria-label="What do these result counts mean?"
+            aria-describedby="results-coverage-tip"
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10" /><line x1="12" y1="16" x2="12" y2="12" /><line x1="12" y1="8" x2="12.01" y2="8" /></svg>
+          </button>
+          <span className="result-info-tooltip" role="tooltip" id="results-coverage-tip">
+            {coverageText}
+          </span>
+        </span>
       </div>
     )}
     <div className="search-result-filters-thumbnails">
@@ -676,6 +692,19 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
       .map(([org, count]) => ({ org, count }));
   }, [uniqueDocuments]);
 
+  // Live explanation of what the org result counts represent (documents behind
+  // the most relevant excerpts). Derived from current search state, not
+  // hardcoded, so it stays accurate if the page size changes.
+  const coverageText = useMemo(
+    () =>
+      buildResultsCoverageText({
+        excerptCount: visibleResults.length,
+        documentCount: uniqueDocuments.length,
+        orgCount: uniqueOrgs.length,
+      }),
+    [visibleResults.length, uniqueDocuments.length, uniqueOrgs.length],
+  );
+
   // Documents filtered by selected orgs
   const filteredUniqueDocuments = useMemo(() =>
     filteredOrgs.length > 0
@@ -888,6 +917,7 @@ export const SearchTabContent: React.FC<SearchTabContentProps> = ({
           {showFilters && (
             <SearchResultFilters
               uniqueOrgs={uniqueOrgs}
+              coverageText={coverageText}
               filteredOrgs={filteredOrgs}
               onOrgToggle={handleOrgToggle}
               filteredDocIds={filteredDocIds}

--- a/ui/frontend/src/components/layout/NavTabs.tsx
+++ b/ui/frontend/src/components/layout/NavTabs.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ResolvedTab, TabKey, resolveTabs } from './tabConfig';
+import { ResolvedTab, TAB_TOOLTIPS, TabKey, resolveTabs } from './tabConfig';
 
 type TabName = 'search' | 'assistant' | 'brief' | 'heatmap' | 'documents' | 'pipeline' | 'processing' | 'info' | 'tech' | 'data' | 'privacy' | 'terms' | 'stats' | 'admin' | 'docs';
 
@@ -40,8 +40,13 @@ export const NavTabs = ({ activeTab, onTabChange, tabs }: NavTabsProps) => {
             key={key}
             className={`nav-tab ${activeTab === key ? ACTIVE_CLASS : ''}`}
             onClick={() => onTabChange(key)}
+            aria-label={resolved[key].label}
+            aria-describedby={`nav-tab-tip-${key}`}
           >
             {resolved[key].label}
+            <span className="nav-tab-tooltip" role="tooltip" id={`nav-tab-tip-${key}`}>
+              {TAB_TOOLTIPS[key]}
+            </span>
           </button>
         ) : null,
       )}

--- a/ui/frontend/src/components/layout/tabConfig.ts
+++ b/ui/frontend/src/components/layout/tabConfig.ts
@@ -14,6 +14,18 @@ export const DEFAULT_TAB_LABELS: Record<TabKey, string> = {
   heatmap: 'Map',
 };
 
+// Short descriptions shown as hover/focus tooltips on each main nav tab.
+// Keyed by the stable TabKey (not the label) so the copy stays correct even
+// when a group overrides a tab's display label.
+export const TAB_TOOLTIPS: Record<TabKey, string> = {
+  search:
+    'Find relevant evidence in evaluations and connect straight to the source document.',
+  assistant: 'Ask questions in plain language and get cited answers.',
+  brief: 'Turn any topic into a structured, fully cited brief.',
+  heatmap:
+    'Visualize evidence by theme, region, or year to quickly identify evidence coverage and gaps.',
+};
+
 export interface TabSetting {
   enabled?: boolean;
   label?: string | null;

--- a/ui/frontend/src/tests/navTabs.test.tsx
+++ b/ui/frontend/src/tests/navTabs.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+
+import { NavTabs } from '../components/layout/NavTabs';
+import { TAB_TOOLTIPS } from '../components/layout/tabConfig';
+
+describe('NavTabs tooltips', () => {
+  it('renders a tooltip with the correct copy on every main tab', () => {
+    render(<NavTabs activeTab="search" onTabChange={() => {}} />);
+
+    const tooltips = screen.getAllByRole('tooltip');
+    const texts = tooltips.map((el) => el.textContent);
+
+    expect(texts).toContain(TAB_TOOLTIPS.search);
+    expect(texts).toContain(TAB_TOOLTIPS.assistant);
+    expect(texts).toContain(TAB_TOOLTIPS.brief);
+    expect(texts).toContain(TAB_TOOLTIPS.heatmap);
+  });
+
+  it('nests each tooltip inside its tab button so it anchors to that tab', () => {
+    render(<NavTabs activeTab="search" onTabChange={() => {}} />);
+
+    const searchTab = screen.getByRole('button', { name: /Search/ });
+    expect(
+      within(searchTab).getByText(TAB_TOOLTIPS.search),
+    ).toBeInTheDocument();
+  });
+
+  it('omits tooltips for tabs a group has disabled', () => {
+    render(
+      <NavTabs
+        activeTab="search"
+        onTabChange={() => {}}
+        tabs={{
+          search: { enabled: true, label: 'Search' },
+          assistant: { enabled: false, label: 'Chat' },
+          brief: { enabled: true, label: 'Brief' },
+          heatmap: { enabled: true, label: 'Map' },
+        }}
+      />,
+    );
+
+    const texts = screen
+      .getAllByRole('tooltip')
+      .map((el) => el.textContent);
+    expect(texts).toContain(TAB_TOOLTIPS.search);
+    expect(texts).not.toContain(TAB_TOOLTIPS.assistant);
+  });
+});

--- a/ui/frontend/src/tests/resultsCoverage.test.ts
+++ b/ui/frontend/src/tests/resultsCoverage.test.ts
@@ -1,0 +1,46 @@
+import { buildResultsCoverageText } from '../utils/resultsCoverage';
+
+describe('buildResultsCoverageText', () => {
+  it('states excerpt and document counts for the single-organization case', () => {
+    const text = buildResultsCoverageText({
+      excerptCount: 50,
+      documentCount: 28,
+      orgCount: 1,
+    });
+    expect(text).toContain('50 most relevant text excerpts');
+    expect(text).toContain('28 documents');
+    // A single org reads awkwardly, so the org clause is omitted.
+    expect(text).not.toContain('organization');
+    expect(text).toContain('Refine your search query');
+  });
+
+  it('includes the organization clause when results span multiple orgs', () => {
+    const text = buildResultsCoverageText({
+      excerptCount: 42,
+      documentCount: 30,
+      orgCount: 4,
+    });
+    expect(text).toContain('30 documents across 4 organizations');
+  });
+
+  it('pluralizes correctly for singular counts', () => {
+    const text = buildResultsCoverageText({
+      excerptCount: 1,
+      documentCount: 1,
+      orgCount: 1,
+    });
+    expect(text).toContain('1 most relevant text excerpt ');
+    expect(text).toContain('1 document.');
+    expect(text).not.toContain('1 documents');
+  });
+
+  it('does not hardcode any page-size number', () => {
+    const text = buildResultsCoverageText({
+      excerptCount: 500,
+      documentCount: 120,
+      orgCount: 3,
+    });
+    expect(text).toContain('500 most relevant text excerpts');
+    expect(text).toContain('120 documents across 3 organizations');
+  });
+});

--- a/ui/frontend/src/tests/searchTabContent.test.tsx
+++ b/ui/frontend/src/tests/searchTabContent.test.tsx
@@ -291,6 +291,32 @@ describe('SearchTabContent result filters', () => {
     expect(titles[1].textContent).toBe('Popular Report');
   });
 
+  test('renders the coverage info tooltip after the org pills with live counts', () => {
+    const results = [
+      buildResult({ chunk_id: 'c1', doc_id: 'doc-1', title: 'Report A', organization: 'UNICEF' }),
+      buildResult({ chunk_id: 'c2', doc_id: 'doc-2', title: 'Report B', organization: 'WFP' }),
+      buildResult({ chunk_id: 'c3', doc_id: 'doc-3', title: 'Report C', organization: 'WFP' }),
+    ];
+
+    render(<SearchTabContent {...baseProps} results={results} />);
+
+    // The info affordance carries the live explanation: 3 excerpts, 3 docs, 2 orgs.
+    const tooltip = document.getElementById('results-coverage-tip');
+    expect(tooltip).not.toBeNull();
+    expect(tooltip?.textContent).toContain('3 most relevant text excerpts');
+    expect(tooltip?.textContent).toContain('3 documents across 2 organizations');
+
+    // The icon sits after the organization pills, not before them.
+    const orgsRow = document.querySelector('.search-result-filters-orgs');
+    const children = Array.from(orgsRow?.children ?? []);
+    const pillIndexes = children
+      .map((el, i) => (el.classList.contains('search-result-filters-org-label') ? i : -1))
+      .filter((i) => i >= 0);
+    const infoIndex = children.findIndex((el) => el.classList.contains('result-info'));
+    expect(pillIndexes.length).toBeGreaterThan(0);
+    expect(infoIndex).toBeGreaterThan(Math.max(...pillIndexes));
+  });
+
   test('semantic highlight updates do not reset active filter', () => {
     const results = [
       buildResult({ chunk_id: 'c1', doc_id: 'doc-1', title: 'Report A', organization: 'UNICEF' }),

--- a/ui/frontend/src/tests/tabConfig.test.ts
+++ b/ui/frontend/src/tests/tabConfig.test.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_TAB_LABELS,
   TAB_KEYS,
+  TAB_TOOLTIPS,
   resolveTabs,
 } from '../components/layout/tabConfig';
 
@@ -39,5 +40,14 @@ describe('resolveTabs', () => {
     const r = resolveTabs({ search: { enabled: true } });
     expect(r.search.enabled).toBe(true);
     expect(r.assistant.enabled).toBe(false);
+  });
+});
+
+describe('TAB_TOOLTIPS', () => {
+  it('provides a non-empty tooltip description for every tab key', () => {
+    TAB_KEYS.forEach((k) => {
+      expect(TAB_TOOLTIPS[k]).toBeTruthy();
+      expect(TAB_TOOLTIPS[k].trim().length).toBeGreaterThan(0);
+    });
   });
 });

--- a/ui/frontend/src/utils/resultsCoverage.ts
+++ b/ui/frontend/src/utils/resultsCoverage.ts
@@ -1,0 +1,41 @@
+// Builds the human-readable explanation of what the organization result
+// counts (e.g. "WFP (28)") actually represent: the distinct documents behind
+// the most relevant text excerpts returned for the query. The numbers are
+// derived from live search state (never hardcoded) so the sentence stays true
+// regardless of the configured page size.
+
+export interface ResultsCoverage {
+  /** Relevant text excerpts (chunks) currently backing the result chips. */
+  excerptCount: number;
+  /** Distinct source documents those excerpts come from. */
+  documentCount: number;
+  /** Distinct organizations across those documents. */
+  orgCount: number;
+}
+
+/** Pluralize a count with its noun: `plural(1, 'document') -> '1 document'`. */
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * Compose the coverage explanation shown in the results info tooltip.
+ *
+ * Example (28 docs, 1 org, 50 excerpts):
+ *   "The 50 most relevant text excerpts for your query come from 28
+ *    documents. Expecting broader or narrower coverage? Refine your search
+ *    query or adjust the filters on the left."
+ */
+export function buildResultsCoverageText({
+  excerptCount,
+  documentCount,
+  orgCount,
+}: ResultsCoverage): string {
+  const orgClause = orgCount > 1 ? ` across ${plural(orgCount, 'organization')}` : '';
+  return (
+    `The ${plural(excerptCount, 'most relevant text excerpt')} for your query ` +
+    `come from ${plural(documentCount, 'document')}${orgClause}. ` +
+    'Expecting broader or narrower coverage? Refine your search query or ' +
+    'adjust the filters on the left.'
+  );
+}


### PR DESCRIPTION
## Description

Two small, related UI clarity improvements.

**1. Navigation-tab tooltips.** Hover/focus tooltips on the main tabs (Search, Chat, Brief, Map) explaining what each does, using the app's existing dark-bubble tooltip styling. Copy is keyed by the stable `TabKey` (not the display label) so it stays correct when a group overrides a tab's label, and is exposed to assistive tech via `aria-describedby`.
<img width="1369" height="793" alt="image" src="https://github.com/user-attachments/assets/f66397a8-ce74-4590-9f9d-9a5ff5fae40f" />

**2. Search result-count context.** The organization pills on the results row (e.g. `WFP (28)`) show a bare number whose meaning isn't obvious. Investigation confirmed the count is the **distinct source documents** behind the most-relevant text excerpts returned for the query — and that the excerpt cap is config-driven (`config.application.search.page_size`, default **50**), not a fixed number. This PR adds an `ⓘ` affordance to the right of the pills whose tooltip explains this using **live** counts derived from search state (excerpts / documents / organizations), so it never goes stale if the page size changes. Example:

<img width="1369" height="793" alt="image" src="https://github.com/user-attachments/assets/fa42faeb-0c9c-4ea4-b17b-356dd8975500" />

The "across N organizations" clause only appears when results span more than one org, so the common single-org case reads cleanly.

## Type of Change
- [x] New feature

## Testing
- [x] Full frontend suite passes: **553 tests** (incl. new `resultsCoverage`, `navTabs`, and additions to `tabConfig` / `searchTabContent`)
- [x] `tsc --noEmit` clean
- [x] Complexity gate (`code_metrics.py --fail-on-bad`) passes — nothing rated bad
- [x] ESLint on changed files: 0 errors
- [x] DOM verified via React Testing Library (real `SearchResultFilters`): info icon renders after the org pills and carries the live sentence

> Note: this environment gates the whole UI behind login, so a live in-browser click-through was not performed; rendering was verified through the component tests instead. Screenshots to follow if desired.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] New tests added for new functionality
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)