### PR TITLE
feat(eval): filter eval cases by document title, country/region and year

### DIFF
--- a/docs/admin/evaluation.md
+++ b/docs/admin/evaluation.md
@@ -35,7 +35,7 @@ The CSV is the **same format as the dataset upload** (see [Add test cases](#add-
 | `expectation` | yes | Free text describing the expected answer. Becomes that row's **LLM‑judge rubric** (per‑case override). |
 | `tags` | no | Separated by `;` within the cell. |
 | `notes` | no | Free text. |
-| `filters` | no | JSON object, e.g. `{"country": "Kenya"}`. |
+| `filters` | no | JSON object — see [Filtering a case](#filtering-a-case). |
 
 In the **Create Dataset and Experiment** dialog you provide:
 
@@ -82,7 +82,32 @@ The CSV columns are:
 | `query` | yes | The search query / question. |
 | `tags` | no | Separated by `;` within the cell, e.g. `regression;baseline`. |
 | `notes` | no | Free text. |
-| `filters` | no | JSON object, e.g. `{"country": "Kenya"}`. |
+| `filters` | no | JSON object — see [Filtering a case](#filtering-a-case). |
+
+#### Filtering a case
+
+Filters restrict which documents a case searches, reproducing the app's search
+facets. With **+ Add case** you can set the common ones with UI controls — a
+**document picker** (type to search real document titles), **country** and
+**region** pickers (populated from the data source's values), and a
+**publication year** range — and use the collapsible **Advanced filters /
+params (JSON)** box for anything else. In a CSV `filters` cell (and in the
+Advanced box) you provide a JSON object:
+
+| Filter | Format | Example |
+|--------|--------|---------|
+| Specific documents | `doc_titles`: a list of **exact document titles as they appear in the UI** (matched case-insensitively) | `{"doc_titles": ["Evaluation of X", "Annual Report 2021"]}` |
+| Publication year | `published_year_min` / `published_year_max` (numbers) | `{"published_year_min": 2018, "published_year_max": 2022}` |
+| Country / region | `country` / `region`: lists of values | `{"country": ["Kenya"], "region": ["Asia and the Pacific"]}` |
+| Other fields | e.g. `organization`, `document_type` (strings) | `{"organization": "WFP"}` |
+
+`doc_titles` and `region` are resolved to the matching document IDs at run time,
+so you filter by the human-readable title/region rather than an internal ID
+(region also matches documents whose region field is not stamped on individual
+chunks). A `doc_titles` or `region` value that matches no document yields
+**zero** results for that case (it is never silently ignored), so prefer the
+pickers to avoid typos. Use a separate `params` key for search behaviour (e.g.
+`rerank`, `limit`), not for document filtering.
 
 ---
 

--- a/pipeline/db/postgres_client_docs.py
+++ b/pipeline/db/postgres_client_docs.py
@@ -565,6 +565,39 @@ class PostgresDocMixin:
                 rows = cur.fetchall()
         return [str(row[0]) for row in rows]
 
+    def fetch_doc_ids_by_exact_titles(
+        self, titles: List[str], limit: int = 5000
+    ) -> List[str]:
+        """Fetch doc_ids whose display title exactly matches any given title.
+
+        Matching is case-insensitive but otherwise exact (no substring), so a
+        supplied title resolves only to the document(s) shown under that exact
+        title in the UI. Titles are the raw ``map_title`` display values, not the
+        sanitized on-disk filename form.
+
+        Args:
+            titles: Exact display titles as they appear in the UI.
+            limit: Maximum number of doc_ids to return.
+
+        Returns:
+            List of matching doc_id strings (empty if none match).
+        """
+        normalized = [t.strip().lower() for t in titles if t and t.strip()]
+        if not normalized:
+            return []
+        query = f"""
+            SELECT doc_id
+            FROM {self.docs_table}
+            WHERE LOWER(map_title) = ANY(%s)
+            LIMIT %s
+        """
+        rows: List[tuple] = []
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(query, (normalized, limit))
+                rows = cur.fetchall()
+        return [str(row[0]) for row in rows]
+
     def fetch_indexed_doc_ids(self) -> List[str]:
         """Fetch all indexed document IDs."""
         query = f"""

--- a/tests/unit/test_harness_doc_filters.py
+++ b/tests/unit/test_harness_doc_filters.py
@@ -1,0 +1,157 @@
+"""Unit tests for the eval-harness document-level filter resolver.
+
+The evaluation harness lets a test case filter by exact document title (``doc_titles``)
+and by ``region`` — both document-level fields not stored on chunks. Because the
+harness calls chunk search directly (bypassing the ``/search`` route's own
+resolvers), these must be resolved to a ``doc_id`` filter at run time. These tests
+cover that resolution, its AND-intersection with a pre-existing ``doc_id`` filter,
+region OR-union, and the no-match sentinel behaviour.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ui.backend.utils.filter_helpers import NO_MATCH_DOC_ID, resolve_doc_level_filters
+
+pytestmark = pytest.mark.unit
+
+
+def _pg_titles(doc_ids):
+    pg = MagicMock()
+    pg.fetch_doc_ids_by_exact_titles.return_value = list(doc_ids)
+    return pg
+
+
+class TestResolveDocTitles:
+    def test_no_doc_level_keys_when_absent_then_filters_returned_unchanged(self):
+        filters = {"published_year_max": 2020, "country": "Kenya"}
+        pg = MagicMock()
+        assert resolve_doc_level_filters(filters, pg) == {
+            "published_year_max": 2020,
+            "country": "Kenya",
+        }
+        pg.fetch_doc_ids_by_exact_titles.assert_not_called()
+        pg.fetch_doc_ids_by_region.assert_not_called()
+
+    def test_single_title_when_set_then_replaced_by_doc_id_filter(self):
+        filters = {"doc_titles": ["Report A"]}
+        pg = _pg_titles(["d1"])
+        result = resolve_doc_level_filters(filters, pg)
+        assert "doc_titles" not in result
+        assert result["doc_id"] == ["d1"]
+        pg.fetch_doc_ids_by_exact_titles.assert_called_once_with(["Report A"])
+
+    def test_multiple_titles_when_set_then_all_doc_ids_returned(self):
+        filters = {"doc_titles": ["Report A", "Report B"]}
+        result = resolve_doc_level_filters(filters, _pg_titles(["d2", "d1"]))
+        assert result["doc_id"] == ["d1", "d2"]  # sorted, deterministic
+
+    def test_comma_string_when_given_then_split_into_titles(self):
+        filters = {"doc_titles": "Report A, Report B"}
+        pg = _pg_titles(["d1"])
+        resolve_doc_level_filters(filters, pg)
+        pg.fetch_doc_ids_by_exact_titles.assert_called_once_with(
+            ["Report A", "Report B"]
+        )
+
+    def test_blank_titles_when_only_whitespace_then_no_lookup_and_no_doc_id(self):
+        filters = {"doc_titles": ["  ", ""]}
+        pg = MagicMock()
+        result = resolve_doc_level_filters(filters, pg)
+        assert "doc_titles" not in result
+        assert "doc_id" not in result
+        pg.fetch_doc_ids_by_exact_titles.assert_not_called()
+
+    def test_titles_when_no_docs_match_then_sentinel_doc_id(self):
+        filters = {"doc_titles": ["Nonexistent"]}
+        result = resolve_doc_level_filters(filters, _pg_titles([]))
+        assert result["doc_id"] == [NO_MATCH_DOC_ID]
+
+    def test_existing_doc_id_when_titles_set_then_intersected(self):
+        filters = {"doc_titles": ["Report A"], "doc_id": "d1,d2,d3"}
+        result = resolve_doc_level_filters(filters, _pg_titles(["d2", "d3", "d4"]))
+        assert result["doc_id"] == ["d2", "d3"]
+
+    def test_existing_doc_id_when_disjoint_then_sentinel(self):
+        filters = {"doc_titles": ["Report A"], "doc_id": ["d1"]}
+        result = resolve_doc_level_filters(filters, _pg_titles(["d9"]))
+        assert result["doc_id"] == [NO_MATCH_DOC_ID]
+
+    def test_invalid_titles_when_not_list_or_string_then_value_error(self):
+        with pytest.raises(ValueError, match="doc_titles must be a list"):
+            resolve_doc_level_filters({"doc_titles": 123}, MagicMock())
+
+    def test_input_dict_when_resolved_then_not_mutated(self):
+        filters = {"doc_titles": ["Report A"], "country": "Kenya"}
+        resolve_doc_level_filters(filters, _pg_titles(["d1"]))
+        assert filters == {"doc_titles": ["Report A"], "country": "Kenya"}
+
+    def test_non_dict_when_passed_then_returned_unchanged(self):
+        assert resolve_doc_level_filters(None, MagicMock()) is None
+
+    def test_country_when_set_then_left_untouched(self):
+        # country is stamped on chunks and applied natively — never resolved here.
+        filters = {"country": ["Kenya"], "doc_titles": ["Report A"]}
+        result = resolve_doc_level_filters(filters, _pg_titles(["d1"]))
+        assert result["country"] == ["Kenya"]
+        assert result["doc_id"] == ["d1"]
+
+
+class TestResolveRegion:
+    def test_single_region_when_set_then_resolved_to_doc_ids(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_region.return_value = ["d1", "d2"]
+        result = resolve_doc_level_filters({"region": "Asia and the Pacific"}, pg)
+        assert "region" not in result
+        assert result["doc_id"] == ["d1", "d2"]
+        pg.fetch_doc_ids_by_region.assert_called_once_with("Asia and the Pacific")
+
+    def test_region_list_when_set_then_doc_ids_are_unioned(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_region.side_effect = [["d1", "d2"], ["d2", "d3"]]
+        result = resolve_doc_level_filters(
+            {"region": ["Asia and the Pacific", "Eastern Africa"]}, pg
+        )
+        assert result["doc_id"] == ["d1", "d2", "d3"]  # union, sorted
+        assert pg.fetch_doc_ids_by_region.call_count == 2
+
+    def test_region_name_with_comma_when_string_then_not_split(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_region.return_value = ["d1"]
+        resolve_doc_level_filters(
+            {"region": "Middle East, Northern Africa, and Eastern Europe"}, pg
+        )
+        pg.fetch_doc_ids_by_region.assert_called_once_with(
+            "Middle East, Northern Africa, and Eastern Europe"
+        )
+
+    def test_region_when_no_docs_match_then_sentinel_doc_id(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_region.return_value = []
+        result = resolve_doc_level_filters({"region": ["Nowhere"]}, pg)
+        assert result["doc_id"] == [NO_MATCH_DOC_ID]
+
+    def test_invalid_region_when_not_list_or_string_then_value_error(self):
+        with pytest.raises(ValueError, match="region must be a string or a list"):
+            resolve_doc_level_filters({"region": 5}, MagicMock())
+
+
+class TestResolveTitlesAndRegionCombined:
+    def test_titles_and_region_when_both_set_then_intersected(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_exact_titles.return_value = ["d1", "d2", "d3"]
+        pg.fetch_doc_ids_by_region.return_value = ["d2", "d3", "d4"]
+        result = resolve_doc_level_filters(
+            {"doc_titles": ["Report A"], "region": ["Asia and the Pacific"]}, pg
+        )
+        assert result["doc_id"] == ["d2", "d3"]
+
+    def test_titles_and_region_when_disjoint_then_sentinel(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_exact_titles.return_value = ["d1"]
+        pg.fetch_doc_ids_by_region.return_value = ["d9"]
+        result = resolve_doc_level_filters(
+            {"doc_titles": ["Report A"], "region": ["Asia and the Pacific"]}, pg
+        )
+        assert result["doc_id"] == [NO_MATCH_DOC_ID]

--- a/ui/backend/services/test_runner.py
+++ b/ui/backend/services/test_runner.py
@@ -41,6 +41,7 @@ from ui.backend.auth.testing_models import (
 )
 from ui.backend.services.evaluation_metrics import compute_summary_stats
 from ui.backend.services.test_evaluators import evaluate_assertions
+from ui.backend.utils.filter_helpers import resolve_doc_level_filters
 
 logger = logging.getLogger(__name__)
 
@@ -127,9 +128,13 @@ def _storable_output(output: Any) -> Any:
 async def _run_search(
     case_input: Dict[str, Any], config: Dict[str, Any], db, pg, source: str
 ):
-    """Run search through the EXACT same pipeline as the UI ``/search`` route
+    """Run search through the same retrieval pipeline as the UI ``/search`` route
     (same retrieval, result building, field-boost/dedup post-processing), so an
     experiment reproduces what a user sees in the app.
+
+    Document-level filters (``doc_titles``, ``region``) are resolved to ``doc_id``
+    filters here (via :func:`resolve_doc_level_filters`) because the harness calls
+    the chunk search directly and so bypasses the route handler's own resolvers.
 
     Parameters default to the ``/search`` endpoint's own defaults; the
     experiment ``config`` overrides them (e.g. ``embedding_model``, ``rerank``,
@@ -146,12 +151,15 @@ async def _run_search(
     query = case_input.get("query", "")
     limit = int(params.get("limit", 50))
     min_chunk_size = int(params.get("min_chunk_size", 0))
+    filters = case_input.get("filters") or None
+    if filters:
+        filters = resolve_doc_level_filters(filters, pg)
     raw = await _run_search_chunks(
         query,
         limit=limit,
         dense_weight=params.get("dense_weight"),
         db=db,
-        filters=case_input.get("filters") or None,
+        filters=filters,
         rerank=bool(params.get("rerank", False)),
         recency_boost=bool(params.get("recency_boost", False)),
         recency_weight=float(params.get("recency_weight", 0.15)),

--- a/ui/backend/utils/filter_helpers.py
+++ b/ui/backend/utils/filter_helpers.py
@@ -1,6 +1,6 @@
 """Helpers for building and resolving filter fields used by search routes."""
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from qdrant_client.http import models
 
@@ -150,3 +150,133 @@ def collect_range_conditions(
         models.FieldCondition(key=sf, range=models.Range(**b))
         for sf, b in bounds.items()
     ]
+
+
+# Sentinel doc_id used when a document filter resolves to no documents, so the
+# search returns nothing rather than falling back to an unfiltered run.
+NO_MATCH_DOC_ID = "00000000-0000-0000-0000-000000000000"
+
+
+def _normalize_doc_titles(value: Any) -> List[str]:
+    """Coerce a ``doc_titles`` filter value into a clean list of titles.
+
+    Accepts a list of strings, or a single/comma-joined string for convenience
+    (e.g. a CSV cell). Blank entries are dropped.
+
+    Raises:
+        ValueError: If the value is neither a string nor a list/tuple.
+    """
+    if isinstance(value, str):
+        items: List[Any] = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        items = list(value)
+    else:
+        raise ValueError("doc_titles must be a list of document titles")
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _existing_doc_id_set(value: Any) -> Optional[Set[str]]:
+    """Return the set of doc_ids already present in a filter value, or None."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        parts = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        parts = list(value)
+    else:
+        parts = []
+    return {str(part).strip() for part in parts if str(part).strip()}
+
+
+# Doc-level filters resolved to a doc_id set for the harness chunk search.
+_DOC_LEVEL_FILTER_KEYS = ("doc_titles", "region")
+
+
+def _title_doc_ids(value: Any, pg) -> Optional[Set[str]]:
+    """Resolve a ``doc_titles`` value to a doc_id set (None if no titles)."""
+    if value is None:
+        return None
+    titles = _normalize_doc_titles(value)
+    if not titles:
+        return None
+    return set(pg.fetch_doc_ids_by_exact_titles(titles))
+
+
+def _region_names(value: Any) -> List[str]:
+    """Coerce a ``region`` filter value into a list of region names.
+
+    A bare string is treated as a single region name (region names commonly
+    contain commas, so it is never comma-split). Blank entries are dropped.
+
+    Raises:
+        ValueError: If the value is neither a string nor a list/tuple.
+    """
+    if isinstance(value, str):
+        items: List[Any] = [value]
+    elif isinstance(value, (list, tuple)):
+        items = list(value)
+    else:
+        raise ValueError("region must be a string or a list of region names")
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _region_doc_ids(value: Any, pg) -> Optional[Set[str]]:
+    """Resolve a ``region`` value to the union of matching doc_ids (None if empty).
+
+    Region is a document-level field (not stamped on chunks), so each selected
+    region name is resolved to doc_ids via ``pg.fetch_doc_ids_by_region`` and the
+    per-region matches are unioned (OR within the region facet).
+    """
+    if value is None:
+        return None
+    names = _region_names(value)
+    if not names:
+        return None
+    doc_ids: Set[str] = set()
+    for name in names:
+        doc_ids.update(pg.fetch_doc_ids_by_region(name))
+    return doc_ids
+
+
+def resolve_doc_level_filters(filters: Dict[str, Any], pg) -> Dict[str, Any]:
+    """Resolve document-level filters (``doc_titles``, ``region``) to ``doc_id``.
+
+    The eval harness calls the chunk search directly and so bypasses the search
+    route's own resolvers. This lets users filter by exact document title (as
+    displayed in the UI) and by region — both document-level, not stored on
+    chunks — instead of raw doc_ids. Each is resolved to doc_ids at run time and
+    AND-combined with any existing ``doc_id`` filter (regions OR within their
+    facet). When the combination matches nothing, the filter is pinned to
+    :data:`NO_MATCH_DOC_ID` so the run returns no results (never unfiltered).
+
+    ``country`` is intentionally left untouched: it is stamped on chunks and
+    applied natively by the chunk search.
+
+    Args:
+        filters: Case ``filters`` dict. Not mutated; a new dict is returned.
+        pg: Postgres client for the case's data source.
+
+    Returns:
+        A new filters dict with resolved keys replaced by a ``doc_id`` filter, or
+        the original dict when there is nothing document-level to resolve.
+    """
+    if not isinstance(filters, dict):
+        return filters
+    if not any(key in filters for key in _DOC_LEVEL_FILTER_KEYS):
+        return filters
+    result = dict(filters)
+    constraints: List[Set[str]] = []
+    existing = _existing_doc_id_set(result.get("doc_id"))
+    if existing is not None:
+        constraints.append(existing)
+    title_ids = _title_doc_ids(result.pop("doc_titles", None), pg)
+    if title_ids is not None:
+        constraints.append(title_ids)
+    region_ids = _region_doc_ids(result.pop("region", None), pg)
+    if region_ids is not None:
+        constraints.append(region_ids)
+    if not constraints:
+        return result
+    resolved = set.intersection(*constraints)
+    result["doc_id"] = sorted(resolved) if resolved else [NO_MATCH_DOC_ID]
+    return result

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -11999,6 +11999,77 @@ a.admin-citation-clickable:hover {
   font-size: 0.75rem;
 }
 
+.testing-tag-remove {
+  background: none;
+  border: none;
+  padding: 0 0 0 0.3rem;
+  font: inherit;
+  line-height: 1;
+  color: var(--color-text-muted, #57606a);
+  cursor: pointer;
+}
+.testing-tag-remove:hover {
+  color: var(--color-danger, #cf222e);
+}
+
+/* Document-title typeahead multiselect (case editor filter builder) */
+.testing-doc-select {
+  position: relative;
+}
+.testing-doc-select input {
+  width: 100%;
+}
+.testing-doc-suggestions {
+  list-style: none;
+  margin: 0.15rem 0 0;
+  padding: 0.2rem;
+  max-height: 12rem;
+  overflow-y: auto;
+  border: 1px solid var(--color-border, #d0d7de);
+  border-radius: 6px;
+  background: var(--color-surface, #fff);
+}
+.testing-doc-suggestion {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.3rem 0.4rem;
+  font: inherit;
+  font-size: 0.8rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.testing-doc-suggestion:hover {
+  background: var(--color-surface-alt, #f6f8fa);
+}
+
+/* Publication-year min/max inputs in the case editor */
+.testing-year-range {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.testing-year-range input {
+  width: 6rem;
+}
+
+/* Collapsible filter-format help */
+.testing-filter-help {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 0.8rem;
+}
+.testing-filter-help-body {
+  margin-top: 0.35rem;
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+.testing-filter-help-body code {
+  font-size: 0.72rem;
+  word-break: break-word;
+}
+
 .testing-notes {
   font-size: 0.8rem;
   color: var(--color-text-muted, #57606a);

--- a/ui/frontend/src/components/admin/testing/CaseEditor.tsx
+++ b/ui/frontend/src/components/admin/testing/CaseEditor.tsx
@@ -1,10 +1,21 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import API_BASE_URL from '../../../config';
+import type { Facets } from '../../../types/api';
 import type { TestCase } from '../../../types/testing';
 import { prettyJson } from './testingFormat';
+import DocumentTitleSelect from './DocumentTitleSelect';
+import FacetMultiSelect from './FacetMultiSelect';
+import FilterHelp from './FilterHelp';
 
 export interface CaseDraft {
   query: string;
-  extraJson: string; // JSON object holding filters/params (everything but `query`)
+  yearMin: string; // published_year_min (empty = unset)
+  yearMax: string; // published_year_max (empty = unset)
+  docTitles: string[]; // filters.doc_titles (exact UI titles)
+  country: string[]; // filters.country
+  region: string[]; // filters.region
+  advancedJson: string; // remaining filters + params, as JSON
   tags: string; // comma separated
   notes: string;
 }
@@ -15,44 +26,134 @@ export interface CasePayload {
   notes?: string;
 }
 
+type JsonObject = Record<string, unknown>;
+
+const isPlainObject = (value: unknown): value is JsonObject =>
+  !!value && typeof value === 'object' && !Array.isArray(value);
+
+// A doc_titles value is pulled into the builder only when it is a clean list of
+// strings; anything else stays in the advanced JSON so it round-trips untouched.
+const asStringList = (value: unknown): string[] | null => {
+  if (!Array.isArray(value)) return null;
+  const strings = value.filter((item): item is string => typeof item === 'string');
+  return strings.length === value.length ? strings : null;
+};
+
+// Remove a numeric filter key from `obj` and return it as a string ('' if unset).
+const takeNumberString = (obj: JsonObject, key: string): string => {
+  const value = obj[key];
+  if (typeof value === 'number' || typeof value === 'string') {
+    delete obj[key];
+    return String(value);
+  }
+  return '';
+};
+
+// Remove a string-list filter key from `obj` and return it ([] if not a clean
+// list of strings — anything else is left in place for the advanced JSON box).
+const takeStringList = (obj: JsonObject, key: string): string[] => {
+  const list = asStringList(obj[key]);
+  if (list) {
+    delete obj[key];
+    return list;
+  }
+  return [];
+};
+
+interface SplitFilters {
+  yearMin: string;
+  yearMax: string;
+  docTitles: string[];
+  country: string[];
+  region: string[];
+  rest: JsonObject;
+}
+
+// Split a stored `filters` object into the builder-owned fields (year range,
+// doc_titles, country, region) and the remaining keys that stay in advanced JSON.
+const splitFilters = (filters: unknown): SplitFilters => {
+  if (!isPlainObject(filters)) {
+    return { yearMin: '', yearMax: '', docTitles: [], country: [], region: [], rest: {} };
+  }
+  const rest: JsonObject = { ...filters };
+  return {
+    yearMin: takeNumberString(rest, 'published_year_min'),
+    yearMax: takeNumberString(rest, 'published_year_max'),
+    docTitles: takeStringList(rest, 'doc_titles'),
+    country: takeStringList(rest, 'country'),
+    region: takeStringList(rest, 'region'),
+    rest,
+  };
+};
+
 /* ------------------------------------------------------------------ */
 /*  Draft <-> case conversion                                         */
 /* ------------------------------------------------------------------ */
 
 export const emptyDraft = (): CaseDraft => ({
   query: '',
-  extraJson: '',
+  yearMin: '',
+  yearMax: '',
+  docTitles: [],
+  country: [],
+  region: [],
+  advancedJson: '',
   tags: '',
   notes: '',
 });
 
 export const caseToDraft = (testCase: TestCase): CaseDraft => {
-  const input = testCase.input || {};
-  const { query, ...rest } = input as { query?: unknown; [k: string]: unknown };
+  const input = (testCase.input || {}) as JsonObject;
+  const { query, filters, ...restTop } = input as {
+    query?: unknown;
+    filters?: unknown;
+    [k: string]: unknown;
+  };
+  const split = splitFilters(filters);
+  const advanced: JsonObject = { ...restTop };
+  if (Object.keys(split.rest).length > 0) advanced.filters = split.rest;
   return {
     query: typeof query === 'string' ? query : '',
-    extraJson: Object.keys(rest).length > 0 ? prettyJson(rest) : '',
+    yearMin: split.yearMin,
+    yearMax: split.yearMax,
+    docTitles: split.docTitles,
+    country: split.country,
+    region: split.region,
+    advancedJson: Object.keys(advanced).length > 0 ? prettyJson(advanced) : '',
     tags: (testCase.tags || []).join(', '),
     notes: testCase.notes || '',
   };
 };
 
+const parseAdvanced = (json: string): JsonObject => {
+  if (!json.trim()) return {};
+  const parsed = JSON.parse(json);
+  if (isPlainObject(parsed)) return parsed;
+  throw new Error('Filters/params JSON must be an object');
+};
+
+// Merge the builder-owned filter fields onto any `filters` from advanced JSON.
+const buildFilters = (draft: CaseDraft, advFilters: unknown): JsonObject => {
+  const base: JsonObject = isPlainObject(advFilters) ? { ...advFilters } : {};
+  if (draft.yearMin.trim() !== '') base.published_year_min = Number(draft.yearMin);
+  if (draft.yearMax.trim() !== '') base.published_year_max = Number(draft.yearMax);
+  if (draft.docTitles.length > 0) base.doc_titles = draft.docTitles;
+  if (draft.country.length > 0) base.country = draft.country;
+  if (draft.region.length > 0) base.region = draft.region;
+  return base;
+};
+
 export const draftToPayload = (draft: CaseDraft): CasePayload => {
-  let extra: Record<string, unknown> = {};
-  if (draft.extraJson.trim()) {
-    const parsed = JSON.parse(draft.extraJson);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      extra = parsed as Record<string, unknown>;
-    } else {
-      throw new Error('Filters/params JSON must be an object');
-    }
-  }
+  const { filters: advFilters, ...advRest } = parseAdvanced(draft.advancedJson);
+  const mergedFilters = buildFilters(draft, advFilters);
+  const input: JsonObject = { query: draft.query, ...advRest };
+  if (Object.keys(mergedFilters).length > 0) input.filters = mergedFilters;
   const tags = draft.tags
     .split(',')
     .map((t) => t.trim())
     .filter((t) => t.length > 0);
   return {
-    input: { query: draft.query, ...extra },
+    input,
     tags: tags.length > 0 ? tags : undefined,
     notes: draft.notes.trim() || undefined,
   };
@@ -64,6 +165,7 @@ export const draftToPayload = (draft: CaseDraft): CasePayload => {
 
 interface CaseEditorProps {
   initial: CaseDraft;
+  dataSource: string;
   saving: boolean;
   submitLabel: string;
   onSubmit: (payload: CasePayload) => void;
@@ -72,6 +174,7 @@ interface CaseEditorProps {
 
 const CaseEditor: React.FC<CaseEditorProps> = ({
   initial,
+  dataSource,
   saving,
   submitLabel,
   onSubmit,
@@ -79,6 +182,29 @@ const CaseEditor: React.FC<CaseEditorProps> = ({
 }) => {
   const [draft, setDraft] = useState<CaseDraft>(initial);
   const [localError, setLocalError] = useState('');
+  const [countryOptions, setCountryOptions] = useState<string[]>([]);
+  const [regionOptions, setRegionOptions] = useState<string[]>([]);
+
+  // Load the data source's country/region facet values so those filters can be
+  // picked from real options instead of hand-written JSON.
+  useEffect(() => {
+    if (!dataSource) return undefined;
+    let cancelled = false;
+    axios
+      .get<Facets>(`${API_BASE_URL}/facets`, { params: { data_source: dataSource } })
+      .then((resp) => {
+        if (cancelled) return;
+        const facets = resp.data.facets || {};
+        setCountryOptions((facets.country || []).map((f) => f.value));
+        setRegionOptions((facets.region || []).map((f) => f.value));
+      })
+      .catch(() => {
+        // Non-fatal: the pickers simply offer no options if facets can't load.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSource]);
 
   const update = (patch: Partial<CaseDraft>) => setDraft((d) => ({ ...d, ...patch }));
 
@@ -107,16 +233,74 @@ const CaseEditor: React.FC<CaseEditorProps> = ({
       </div>
 
       <div className="form-group">
-        <label htmlFor="case-extra">Filters / params (JSON object, optional)</label>
+        <label>Documents (optional)</label>
+        <DocumentTitleSelect
+          dataSource={dataSource}
+          value={draft.docTitles}
+          onChange={(docTitles) => update({ docTitles })}
+        />
+        <small className="text-muted">
+          Restrict the case to specific documents by their exact UI title.
+        </small>
+      </div>
+
+      {(countryOptions.length > 0 || draft.country.length > 0) && (
+        <div className="form-group">
+          <label>Country (optional)</label>
+          <FacetMultiSelect
+            options={countryOptions}
+            value={draft.country}
+            onChange={(country) => update({ country })}
+            placeholder="Type to filter countries…"
+          />
+        </div>
+      )}
+
+      {(regionOptions.length > 0 || draft.region.length > 0) && (
+        <div className="form-group">
+          <label>Region (optional)</label>
+          <FacetMultiSelect
+            options={regionOptions}
+            value={draft.region}
+            onChange={(region) => update({ region })}
+            placeholder="Type to filter regions…"
+          />
+        </div>
+      )}
+
+      <div className="form-group">
+        <label>Publication year (optional)</label>
+        <div className="testing-year-range">
+          <input
+            type="number"
+            aria-label="Published year from"
+            value={draft.yearMin}
+            onChange={(e) => update({ yearMin: e.target.value })}
+            placeholder="From"
+          />
+          <span className="text-muted">–</span>
+          <input
+            type="number"
+            aria-label="Published year to"
+            value={draft.yearMax}
+            onChange={(e) => update({ yearMax: e.target.value })}
+            placeholder="To"
+          />
+        </div>
+      </div>
+
+      <details className="form-group testing-advanced-filters">
+        <summary className="testing-raw-toggle">Advanced filters / params (JSON)</summary>
         <textarea
           id="case-extra"
           className="testing-json-textarea"
-          value={draft.extraJson}
-          onChange={(e) => update({ extraJson: e.target.value })}
-          placeholder={'{\n  "filters": {},\n  "params": {}\n}'}
+          value={draft.advancedJson}
+          onChange={(e) => update({ advancedJson: e.target.value })}
+          placeholder={'{\n  "filters": { "country": "Kenya" },\n  "params": {}\n}'}
           rows={5}
         />
-      </div>
+        <FilterHelp />
+      </details>
 
       <div className="form-group">
         <label htmlFor="case-tags">Tags (comma separated)</label>

--- a/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
+++ b/ui/frontend/src/components/admin/testing/CreateDatasetWithExperimentModal.tsx
@@ -3,6 +3,7 @@ import axios from 'axios';
 import API_BASE_URL from '../../../config';
 import type { TestCapability } from '../../../types/testing';
 import { parseQaCsv, QaCsvRow } from './csv';
+import FilterHelp from './FilterHelp';
 import { DEFAULT_THRESHOLD, importDatasetWithExperiment } from './experimentImport';
 import {
   ConfigDraft,
@@ -246,6 +247,7 @@ const CreateDatasetWithExperimentModal: React.FC<
                 style={{ display: 'none' }}
                 onChange={(e) => setFileName(e.target.files?.[0]?.name || '')}
               />
+              <FilterHelp />
             </div>
             <button type="submit" className="auth-submit" disabled={busy}>
               {busy ? 'Creating…' : 'Create Dataset + Experiment'}

--- a/ui/frontend/src/components/admin/testing/DatasetEditor.tsx
+++ b/ui/frontend/src/components/admin/testing/DatasetEditor.tsx
@@ -292,6 +292,7 @@ const DatasetEditor: React.FC<DatasetEditorProps> = ({ dataset, onBack }) => {
           <div className="testing-case-editor-wrap">
             <CaseEditor
               initial={emptyDraft()}
+              dataSource={dataset.data_source}
               saving={saving}
               submitLabel="Create Case"
               onSubmit={createCase}
@@ -304,6 +305,7 @@ const DatasetEditor: React.FC<DatasetEditorProps> = ({ dataset, onBack }) => {
           <div className="testing-case-editor-wrap">
             <CaseEditor
               initial={caseToDraft(editingCase)}
+              dataSource={dataset.data_source}
               saving={saving}
               submitLabel="Save Case"
               onSubmit={(payload) => updateCase(editingCase.id, payload)}

--- a/ui/frontend/src/components/admin/testing/DocumentTitleSelect.tsx
+++ b/ui/frontend/src/components/admin/testing/DocumentTitleSelect.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import API_BASE_URL from '../../../config';
+
+interface DocumentTitleSelectProps {
+  dataSource: string;
+  value: string[];
+  onChange: (titles: string[]) => void;
+}
+
+interface DocumentsResponse {
+  documents?: Array<{ title?: string }>;
+}
+
+const SEARCH_DEBOUNCE_MS = 300;
+const MIN_TERM_LENGTH = 2;
+
+/**
+ * Typeahead multiselect for restricting a test case to specific documents.
+ *
+ * Suggestions come from the admin ``/documents`` listing (indexed docs for the
+ * dataset's data source), so only real, exact display titles can be selected —
+ * these resolve to doc_ids at run time on the backend. Selected titles are shown
+ * as removable chips and surfaced to the parent as ``doc_titles``.
+ */
+const DocumentTitleSelect: React.FC<DocumentTitleSelectProps> = ({
+  dataSource,
+  value,
+  onChange,
+}) => {
+  const [term, setTerm] = useState('');
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const query = term.trim();
+    if (!dataSource || query.length < MIN_TERM_LENGTH) {
+      setSuggestions([]);
+      return undefined;
+    }
+    let cancelled = false;
+    setLoading(true);
+    const handle = window.setTimeout(async () => {
+      try {
+        const resp = await axios.get<DocumentsResponse>(`${API_BASE_URL}/documents`, {
+          params: {
+            data_source: dataSource,
+            title: query,
+            status: 'indexed',
+            page_size: 20,
+          },
+        });
+        if (cancelled) return;
+        const titles = (resp.data.documents || [])
+          .map((doc) => doc.title)
+          .filter((t): t is string => Boolean(t));
+        setSuggestions(Array.from(new Set(titles)));
+      } catch {
+        if (!cancelled) setSuggestions([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [term, dataSource]);
+
+  const addTitle = (title: string) => {
+    if (!value.includes(title)) onChange([...value, title]);
+    setTerm('');
+    setSuggestions([]);
+  };
+
+  const removeTitle = (title: string) => {
+    onChange(value.filter((t) => t !== title));
+  };
+
+  const available = suggestions.filter((t) => !value.includes(t));
+
+  return (
+    <div className="testing-doc-select">
+      {value.length > 0 && (
+        <div className="testing-case-tags" style={{ marginBottom: '0.4rem' }}>
+          {value.map((title) => (
+            <span key={title} className="testing-tag" title={title}>
+              {title}
+              <button
+                type="button"
+                className="testing-tag-remove"
+                aria-label={`Remove ${title}`}
+                onClick={() => removeTitle(title)}
+              >
+                &times;
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <input
+        type="text"
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+        disabled={!dataSource}
+        placeholder={
+          dataSource
+            ? 'Type to search document titles…'
+            : 'No data source for this dataset'
+        }
+      />
+      {loading && <small className="text-muted">Searching…</small>}
+      {!loading && available.length > 0 && (
+        <ul className="testing-doc-suggestions">
+          {available.map((title) => (
+            <li key={title}>
+              <button
+                type="button"
+                className="testing-doc-suggestion"
+                onClick={() => addTitle(title)}
+              >
+                {title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default DocumentTitleSelect;

--- a/ui/frontend/src/components/admin/testing/FacetMultiSelect.tsx
+++ b/ui/frontend/src/components/admin/testing/FacetMultiSelect.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+
+interface FacetMultiSelectProps {
+  options: string[];
+  value: string[];
+  onChange: (values: string[]) => void;
+  placeholder?: string;
+}
+
+const MAX_SUGGESTIONS = 20;
+
+/**
+ * Multiselect over a fixed list of facet values (e.g. country / region).
+ *
+ * Selected values render as removable chips; typing filters the remaining
+ * options. Unlike {@link DocumentTitleSelect} the options are provided
+ * synchronously (from the data source's facets) rather than fetched per query.
+ */
+const FacetMultiSelect: React.FC<FacetMultiSelectProps> = ({
+  options,
+  value,
+  onChange,
+  placeholder,
+}) => {
+  const [term, setTerm] = useState('');
+
+  const add = (option: string) => {
+    if (!value.includes(option)) onChange([...value, option]);
+    setTerm('');
+  };
+
+  const remove = (option: string) => {
+    onChange(value.filter((v) => v !== option));
+  };
+
+  const needle = term.trim().toLowerCase();
+  const matches = options
+    .filter((opt) => !value.includes(opt))
+    .filter((opt) => !needle || opt.toLowerCase().includes(needle))
+    .slice(0, MAX_SUGGESTIONS);
+
+  return (
+    <div className="testing-doc-select">
+      {value.length > 0 && (
+        <div className="testing-case-tags" style={{ marginBottom: '0.4rem' }}>
+          {value.map((option) => (
+            <span key={option} className="testing-tag" title={option}>
+              {option}
+              <button
+                type="button"
+                className="testing-tag-remove"
+                aria-label={`Remove ${option}`}
+                onClick={() => remove(option)}
+              >
+                &times;
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+      <input
+        type="text"
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+        placeholder={placeholder || 'Type to filter…'}
+      />
+      {term.trim() !== '' && matches.length > 0 && (
+        <ul className="testing-doc-suggestions">
+          {matches.map((option) => (
+            <li key={option}>
+              <button
+                type="button"
+                className="testing-doc-suggestion"
+                onClick={() => add(option)}
+              >
+                {option}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default FacetMultiSelect;

--- a/ui/frontend/src/components/admin/testing/FilterHelp.tsx
+++ b/ui/frontend/src/components/admin/testing/FilterHelp.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+/**
+ * Collapsible help explaining how to format a test case's search filters.
+ *
+ * Shared by the manual case editor and the "Create Dataset + Experiment" upload
+ * modal so both entry points describe the same filter contract. Rendered as a
+ * native <details> disclosure (the app has no dedicated tooltip component).
+ */
+const FilterHelp: React.FC = () => (
+  <details className="testing-filter-help">
+    <summary className="testing-raw-toggle">ⓘ How do filters work?</summary>
+    <div className="text-muted testing-filter-help-body">
+      <p style={{ margin: '0.4rem 0' }}>
+        Filters restrict which documents a case searches. In JSON they live under
+        a <code>filters</code> key, e.g.
+        {' '}
+        <code>{'{ "filters": { … }, "params": { … } }'}</code>.
+      </p>
+      <ul style={{ margin: '0.4rem 0 0', paddingLeft: '1.1rem' }}>
+        <li>
+          <strong>Publication year</strong> — <code>published_year_min</code> and{' '}
+          <code>published_year_max</code> (numbers), e.g.
+          {' '}
+          <code>{'"published_year_min": 2018'}</code>.
+        </li>
+        <li>
+          <strong>Specific documents</strong> — <code>doc_titles</code>: a list of
+          exact document titles <em>as they appear in the UI</em>, e.g.
+          {' '}
+          <code>{'"doc_titles": ["Evaluation of X", "Annual Report 2021"]'}</code>.
+          Titles are matched exactly (case-insensitive); use the document picker
+          above to avoid typos.
+        </li>
+        <li>
+          <strong>Country / region</strong> — <code>country</code> and{' '}
+          <code>region</code> as lists of values, e.g.
+          {' '}
+          <code>{'"country": ["Kenya"], "region": ["Asia and the Pacific"]'}</code>.
+          Use the pickers above to choose from the data source's values.
+        </li>
+        <li>
+          <strong>Other fields</strong> — e.g. <code>organization</code>,{' '}
+          <code>document_type</code> as string values.
+        </li>
+      </ul>
+      <p style={{ margin: '0.4rem 0 0' }}>
+        Use a separate <code>params</code> key for search behaviour (e.g.{' '}
+        <code>rerank</code>, <code>limit</code>), not for document filtering.
+      </p>
+    </div>
+  </details>
+);
+
+export default FilterHelp;

--- a/ui/frontend/src/components/admin/testing/csv.ts
+++ b/ui/frontend/src/components/admin/testing/csv.ts
@@ -79,17 +79,23 @@ export const parseQaCsv = (data: ArrayBuffer | string): QaCsvRow[] => {
 
 // Same columns as the regular dataset CSV plus an "expectation" column.
 // Regular dataset sample (query, tags, notes, filters). The QA sample below is
-// the same shape plus one extra `expectation` column.
+// the same shape plus one extra `expectation` column. The `filters` cell is a
+// JSON object; use `doc_titles` (a list of exact UI document titles) to restrict
+// a case to specific documents, and `published_year_min`/`_max` for a year range.
 export const SAMPLE_DATASET_CSV = [
   'query,tags,notes,filters',
   'girls education in Kenya,regression;baseline,Core evaluation question,',
-  'cash vs in-kind transfers in Kenya,regression,Comparison question,',
+  'cash vs in-kind transfers in Kenya,regression,Recent evaluations only,'
+    + '"{""published_year_min"": 2018, ""published_year_max"": 2022}"',
   'nutrition outcomes for children,smoke,,"{""country"": ""Kenya""}"',
+  'findings in a specific report,docs,Single-document case,'
+    + '"{""doc_titles"": [""Annual Report 2021""]}"',
 ].join('\n');
 
 export const SAMPLE_QA_CSV = [
   'query,tags,notes,filters,expectation',
-  '"What were the effects of COVID-19 on WFP activities?",covid,Core question,,'
+  '"What were the effects of COVID-19 on WFP activities?",covid,Core question,'
+    + '"{""doc_titles"": [""WFP COVID-19 Response Evaluation""]}",'
     + '"The summary should cover the most commonly cited ways WFP programmes '
     + 'changed after the pandemic and the results of those changes."',
   '"How timely was WFP in responding to COVID-19 needs?",timeliness,,,'

--- a/ui/frontend/src/tests/caseEditorDraft.test.ts
+++ b/ui/frontend/src/tests/caseEditorDraft.test.ts
@@ -1,0 +1,154 @@
+import {
+  caseToDraft,
+  draftToPayload,
+  emptyDraft,
+} from '../components/admin/testing/CaseEditor';
+import type { TestCase } from '../types/testing';
+
+jest.mock('../config', () => ({ __esModule: true, default: '/api' }));
+
+const REGION = 'Asia and the Pacific';
+
+const makeCase = (input: Record<string, unknown>, extra: Partial<TestCase> = {}): TestCase =>
+  ({ id: 'c1', input, ...extra } as TestCase);
+
+describe('caseToDraft', () => {
+  test('splits year range and doc_titles out of the filters object', () => {
+    const draft = caseToDraft(
+      makeCase(
+        {
+          query: 'girls education',
+          filters: {
+            published_year_min: 2018,
+            published_year_max: 2022,
+            doc_titles: ['Report A'],
+            country: 'Kenya',
+          },
+          params: { rerank: true },
+        },
+        { tags: ['smoke'], notes: 'n' },
+      ),
+    );
+    expect(draft.query).toBe('girls education');
+    expect(draft.yearMin).toBe('2018');
+    expect(draft.yearMax).toBe('2022');
+    expect(draft.docTitles).toEqual(['Report A']);
+    // Remaining filter keys + params round-trip through the advanced JSON box.
+    expect(JSON.parse(draft.advancedJson)).toEqual({
+      filters: { country: 'Kenya' },
+      params: { rerank: true },
+    });
+    expect(draft.tags).toBe('smoke');
+    expect(draft.notes).toBe('n');
+  });
+
+  test('splits country and region lists out of the filters object', () => {
+    const draft = caseToDraft(
+      makeCase({
+        query: 'q',
+        filters: { country: ['Kenya', 'Uganda'], region: [REGION] },
+      }),
+    );
+    expect(draft.country).toEqual(['Kenya', 'Uganda']);
+    expect(draft.region).toEqual([REGION]);
+    expect(draft.advancedJson).toBe('');
+  });
+
+  test('leaves advanced JSON empty when input is only a query', () => {
+    const draft = caseToDraft(makeCase({ query: 'q' }));
+    expect(draft).toMatchObject({
+      query: 'q',
+      yearMin: '',
+      yearMax: '',
+      docTitles: [],
+      advancedJson: '',
+    });
+  });
+
+  test('keeps a non-list doc_titles value in advanced JSON', () => {
+    const draft = caseToDraft(makeCase({ query: 'q', filters: { doc_titles: 'not-a-list' } }));
+    expect(draft.docTitles).toEqual([]);
+    expect(JSON.parse(draft.advancedJson)).toEqual({ filters: { doc_titles: 'not-a-list' } });
+  });
+});
+
+describe('draftToPayload', () => {
+  test('merges builder fields into filters', () => {
+    const payload = draftToPayload({
+      ...emptyDraft(),
+      query: 'q',
+      yearMin: '2018',
+      yearMax: '2022',
+      docTitles: ['Report A'],
+    });
+    expect(payload.input).toEqual({
+      query: 'q',
+      filters: {
+        published_year_min: 2018,
+        published_year_max: 2022,
+        doc_titles: ['Report A'],
+      },
+    });
+  });
+
+  test('omits the filters key entirely when the builder is empty', () => {
+    const payload = draftToPayload({ ...emptyDraft(), query: 'q' });
+    expect(payload.input).toEqual({ query: 'q' });
+    expect(payload.tags).toBeUndefined();
+  });
+
+  test('merges country and region lists into filters', () => {
+    const payload = draftToPayload({
+      ...emptyDraft(),
+      query: 'q',
+      country: ['Kenya'],
+      region: [REGION],
+    });
+    expect(payload.input).toEqual({
+      query: 'q',
+      filters: { country: ['Kenya'], region: [REGION] },
+    });
+  });
+
+  test('merges advanced filters with builder fields (builder wins on year/docs)', () => {
+    const payload = draftToPayload({
+      ...emptyDraft(),
+      query: 'q',
+      yearMin: '2020',
+      docTitles: ['B'],
+      advancedJson: JSON.stringify({ filters: { country: 'Kenya' }, params: { limit: 10 } }),
+    });
+    expect(payload.input).toEqual({
+      query: 'q',
+      params: { limit: 10 },
+      filters: { country: 'Kenya', published_year_min: 2020, doc_titles: ['B'] },
+    });
+  });
+
+  test('throws when advanced JSON is not an object', () => {
+    expect(() =>
+      draftToPayload({ ...emptyDraft(), query: 'q', advancedJson: '[1, 2]' }),
+    ).toThrow(/must be an object/);
+  });
+});
+
+describe('caseToDraft -> draftToPayload round-trip', () => {
+  test('preserves query, filters, params, tags and notes', () => {
+    const input = {
+      query: 'q',
+      filters: {
+        published_year_max: 2022,
+        doc_titles: ['A', 'B'],
+        country: ['Kenya'],
+        region: [REGION],
+      },
+      params: { rerank: true },
+    };
+    const payload = draftToPayload(
+      caseToDraft(makeCase(input, { tags: ['t'], notes: 'n' })),
+    );
+    expect(payload.input).toEqual(input);
+    expect(payload.tags).toEqual(['t']);
+    expect(payload.notes).toBe('n');
+  });
+});

--- a/ui/frontend/src/tests/csvAssertionImport.test.ts
+++ b/ui/frontend/src/tests/csvAssertionImport.test.ts
@@ -43,6 +43,18 @@ describe('parseQaCsv', () => {
     expect(rows[0].expectation).toBe('Expected text');
   });
 
+  test('parses a doc_titles list filter into the case input', () => {
+    const csv = [
+      HEADER,
+      'covid effects,,,"{""doc_titles"": [""WFP COVID-19 Response Evaluation""]}",Expected',
+    ].join('\n');
+    const rows = parseQaCsv(csv);
+    expect(rows[0].input).toEqual({
+      query: 'covid effects',
+      filters: { doc_titles: ['WFP COVID-19 Response Evaluation'] },
+    });
+  });
+
   test('accepts header aliases (question / expected_answer)', () => {
     const csv = [
       'question,expected_answer',

--- a/ui/frontend/src/tests/documentTitleSelect.test.tsx
+++ b/ui/frontend/src/tests/documentTitleSelect.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import DocumentTitleSelect from '../components/admin/testing/DocumentTitleSelect';
+
+jest.mock('../config', () => ({ __esModule: true, default: '/api' }));
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('DocumentTitleSelect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders selected titles as chips and removes on click', () => {
+    const onChange = jest.fn();
+    render(
+      <DocumentTitleSelect
+        dataSource="uneg"
+        value={['Report A', 'Report B']}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('Report A')).toBeInTheDocument();
+    expect(screen.getByText('Report B')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Remove Report A'));
+    expect(onChange).toHaveBeenCalledWith(['Report B']);
+  });
+
+  test('disables the input when no data source is set', () => {
+    render(<DocumentTitleSelect dataSource="" value={[]} onChange={jest.fn()} />);
+    expect(screen.getByPlaceholderText(/no data source/i)).toBeDisabled();
+  });
+
+  test('fetches and adds a suggested title, excluding already-selected ones', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { documents: [{ title: 'Report A' }, { title: 'Report C' }] },
+    });
+    const onChange = jest.fn();
+    render(
+      <DocumentTitleSelect dataSource="uneg" value={['Report A']} onChange={onChange} />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/type to search/i), {
+      target: { value: 'Rep' },
+    });
+    // Only the not-yet-selected suggestion is offered.
+    const suggestion = await screen.findByRole('button', { name: 'Report C' });
+    await waitFor(() =>
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        '/api/documents',
+        expect.objectContaining({
+          params: expect.objectContaining({ data_source: 'uneg', title: 'Rep' }),
+        }),
+      ),
+    );
+    expect(screen.queryByRole('button', { name: 'Report A' })).not.toBeInTheDocument();
+    fireEvent.click(suggestion);
+    expect(onChange).toHaveBeenCalledWith(['Report A', 'Report C']);
+  });
+});

--- a/ui/frontend/src/tests/facetMultiSelect.test.tsx
+++ b/ui/frontend/src/tests/facetMultiSelect.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import FacetMultiSelect from '../components/admin/testing/FacetMultiSelect';
+
+describe('FacetMultiSelect', () => {
+  test('renders selected values as chips and removes on click', () => {
+    const onChange = jest.fn();
+    render(
+      <FacetMultiSelect
+        options={['Kenya', 'Uganda']}
+        value={['Kenya']}
+        onChange={onChange}
+      />,
+    );
+    expect(screen.getByText('Kenya')).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Remove Kenya'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  test('filters options by the typed term and adds the chosen one', () => {
+    const onChange = jest.fn();
+    render(
+      <FacetMultiSelect
+        options={['Kenya', 'Uganda', 'Tanzania']}
+        value={[]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/type to filter/i), {
+      target: { value: 'ken' },
+    });
+    expect(screen.queryByRole('button', { name: 'Uganda' })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Kenya' }));
+    expect(onChange).toHaveBeenCalledWith(['Kenya']);
+  });
+
+  test('excludes already-selected values from the suggestions', () => {
+    render(
+      <FacetMultiSelect
+        options={['Kenya', 'Uganda']}
+        value={['Kenya']}
+        onChange={jest.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText(/type to filter/i), {
+      target: { value: 'a' },
+    });
+    // 'Kenya' is selected (chip only), so only 'Uganda' is offered as a suggestion.
+    expect(screen.getByRole('button', { name: 'Uganda' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Kenya' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Description

Lets evaluation-harness users restrict a test case to specific **documents by their human-readable UI title**, and by **country / region / publication year**, instead of raw `doc_id` UUIDs.

**Root gap fixed:** the harness run path (`_run_search` → `_run_search_chunks` → `search_chunks`) calls the chunk search directly, bypassing the `/search` route's filter resolvers — so `title`/`region` filters silently did nothing there (region is a document-level field, not stamped on chunks); only a real `doc_id` worked.

### Backend
- `resolve_doc_level_filters(filters, pg)` (`ui/backend/utils/filter_helpers.py`) resolves `doc_titles` (exact, case-insensitive — new `pg.fetch_doc_ids_by_exact_titles`) and `region` (union via existing `fetch_doc_ids_by_region`) into an intersecting `doc_id` filter at run time. No match → sentinel `doc_id` ⇒ **zero** results, never an unfiltered run (no silent fallback).
- `country` is left untouched (stamped on chunks, applied natively).
- Wired into `_run_search` (`ui/backend/services/test_runner.py`).

### Frontend
- `CaseEditor` rebuilt as a **structured builder + collapsible Advanced-JSON fallback**: document typeahead (`DocumentTitleSelect`, over `/documents`), country/region pickers (`FacetMultiSelect`, from `/facets`), a year range, and a filter-format tooltip (`FilterHelp`).
- CSV upload keeps JSON but supports the same `doc_titles` / `country` / `region` lists; sample CSVs updated.
- One filter shape across every entry path: `filters = { doc_titles: [...], country: [...], region: [...], published_year_min/_max }`, stored as human-readable values and resolved at run time (robust across re-index).

### Docs
- `docs/admin/evaluation.md` — new "Filtering a case" section.

## Type of Change
- [x] New feature

## Testing
- [x] Tests pass locally
- [x] New tests added for new functionality

Backend: `tests/unit/test_harness_doc_filters.py` (19 tests). Frontend: `caseEditorDraft`, `documentTitleSelect`, `facetMultiSelect`, and extended `csvAssertionImport` (draft round-trip, pickers, CSV `doc_titles`). Full backend suite and full frontend suite (561) green; `tsc --noEmit`, ESLint, black/isort/flake8/mypy/bandit, and `code_metrics.py --fail-on-bad` all pass (pre-commit ran on commit).

> Not covered by automated tests: a live superuser click-through experiment run (auth-gated UI). Backend changes require `docker compose restart api` (uvicorn `--reload` is off) to take effect for manual UI testing.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Documentation updated
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
