### PR TITLE
feat(sync): add repository mirror sync script for Azure DevOps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -316,3 +316,15 @@ CADDYFILE_PATH=
 # Vertex / Google service-account key, bind-mounted read-only into the api by
 # the deploy override at /app/gcp-creds.json. Default: ./gcp-creds.json.
 GCP_CREDS_PATH=
+
+# ======================================================================
+#               Repository mirror sync (optional)
+# ======================================================================
+# Used by scripts/sync/repo/sync_repo_to_azure_devops.py to mirror this
+# repository's branches/tags to an Azure DevOps Git repository. Leave unset
+# if not mirroring. URL format: https://dev.azure.com/<org>/<project>/_git/<repo>
+AZURE_DEVOPS_REPO_URL=
+# Any non-empty username works with a PAT (defaults to "pat" if unset).
+AZURE_DEVOPS_USERNAME=
+# Personal access token with Code (Read & Write) scope.
+AZURE_DEVOPS_PAT=

--- a/.env.example
+++ b/.env.example
@@ -321,10 +321,11 @@ GCP_CREDS_PATH=
 #               Repository mirror sync (optional)
 # ======================================================================
 # Used by scripts/sync/repo/sync_repo_to_azure_devops.py to mirror this
-# repository's branches/tags to an Azure DevOps Git repository. Leave unset
-# if not mirroring. URL format: https://dev.azure.com/<org>/<project>/_git/<repo>
+# repository's branches/tags to an Azure DevOps Git repository. Needs only
+# git — no az CLI, azcopy, or Docker. Leave unset if not mirroring.
+# URL format: https://dev.azure.com/<org>/<project>/_git/<repo>
 AZURE_DEVOPS_REPO_URL=
-# Any non-empty username works with a PAT (defaults to "pat" if unset).
+# Account username (any non-empty value works with a token; default "pat").
 AZURE_DEVOPS_USERNAME=
-# Personal access token with Code (Read & Write) scope.
-AZURE_DEVOPS_PAT=
+# Password — typically a personal access token with Code (Read & Write) scope.
+AZURE_DEVOPS_PASSWORD=

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint-docker
+        # The upstream hook entry has no image tag, so it silently floats to
+        # ghcr.io latest regardless of rev; pin the image to match rev.
+        entry: ghcr.io/hadolint/hadolint:v2.12.0 hadolint
         args: ['--ignore', 'DL3007', '--ignore', 'DL3008', '--ignore', 'DL3013', '--ignore', 'DL3015', '--ignore', 'DL3018', '--ignore', 'DL3042', '--ignore', 'DL3059']
 
   # Secret scanning with detect-secrets

--- a/scripts/sync/README.md
+++ b/scripts/sync/README.md
@@ -363,10 +363,11 @@ without pushing anything.
 ### Sync
 
 ```bash
-# Sync main only (default)
+# Default: sync main plus any branch beginning with 'rc' or 'v'
+# (pulls in release branches automatically)
 uv run scripts/sync/repo/sync_repo_to_azure_devops.py
 
-# Sync several branches plus all tags
+# Sync specific branches only, plus all tags
 uv run scripts/sync/repo/sync_repo_to_azure_devops.py \
   --branches main rc/v1.6.1 --tags
 

--- a/scripts/sync/README.md
+++ b/scripts/sync/README.md
@@ -7,6 +7,7 @@ your local environment and remote environments (Production/Azure).
 
 - `db/`: Scripts for Qdrant + Postgres database synchronization.
 - `files/`: Scripts for Azure File Share synchronization.
+- `repo/`: Scripts for mirroring this Git repository to another remote.
 
 ---
 
@@ -324,3 +325,48 @@ brew install azcopy
 ```bash
 python scripts/sync/files/sync_azure.py --upload --dirs uneg,worldbank --azcopy
 ```
+
+## 8. Repository Mirror Sync (GitHub → Azure DevOps)
+
+`repo/sync_repo_to_azure_devops.py` mirrors branches (and optionally tags)
+from a source remote (default `origin`) to an Azure DevOps Git repository.
+
+### Prerequisites
+
+- **Environment Variables**: `.env` (or the shell environment) must contain:
+  - `AZURE_DEVOPS_REPO_URL` — HTTPS clone URL,
+    e.g. `https://dev.azure.com/<org>/<project>/_git/<repo>`
+  - `AZURE_DEVOPS_PAT` — personal access token with Code (Read & Write) scope
+  - `AZURE_DEVOPS_USERNAME` — optional; any non-empty value works with a PAT
+
+No credentials or repository URLs are hardcoded — the token is supplied to
+git through a credential helper that reads the environment at runtime, so it
+never appears on a command line or in git config.
+
+### Preview (dry run)
+
+```bash
+python scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
+```
+
+Contacts the target remote and reports exactly which refs would be updated,
+without pushing anything.
+
+### Sync
+
+```bash
+# Sync main only (default)
+python scripts/sync/repo/sync_repo_to_azure_devops.py
+
+# Sync several branches plus all tags
+python scripts/sync/repo/sync_repo_to_azure_devops.py \
+  --branches main rc/v1.6.1 --tags
+
+# Overwrite diverged refs on the target (use with care)
+python scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --force
+```
+
+The script fetches the source remote first (`--prune --tags`), verifies each
+requested branch exists there, and pushes
+`refs/remotes/<remote>/<branch> → refs/heads/<branch>` on the target.
+Non-fast-forward pushes fail unless `--force` is given.

--- a/scripts/sync/README.md
+++ b/scripts/sync/README.md
@@ -331,22 +331,30 @@ python scripts/sync/files/sync_azure.py --upload --dirs uneg,worldbank --azcopy
 `repo/sync_repo_to_azure_devops.py` mirrors branches (and optionally tags)
 from a source remote (default `origin`) to an Azure DevOps Git repository.
 
+It uses **git only** — no `az` CLI, no `azcopy`, no Docker. Run it with
+[uv](https://docs.astral.sh/uv/), which resolves the script's own inline
+dependencies automatically (no project install needed).
+
 ### Prerequisites
 
-- **Environment Variables**: `.env` (or the shell environment) must contain:
+- `git` and `uv` installed
+- **Environment Variables**: `.env` (or the shell environment) must contain
+  the three connection values:
   - `AZURE_DEVOPS_REPO_URL` — HTTPS clone URL,
     e.g. `https://dev.azure.com/<org>/<project>/_git/<repo>`
-  - `AZURE_DEVOPS_PAT` — personal access token with Code (Read & Write) scope
-  - `AZURE_DEVOPS_USERNAME` — optional; any non-empty value works with a PAT
+  - `AZURE_DEVOPS_USERNAME` — account username (any non-empty value works
+    when the password is a personal access token)
+  - `AZURE_DEVOPS_PASSWORD` — password, typically a personal access token
+    with Code (Read & Write) scope
 
-No credentials or repository URLs are hardcoded — the token is supplied to
+No credentials or repository URLs are hardcoded — the password is supplied to
 git through a credential helper that reads the environment at runtime, so it
 never appears on a command line or in git config.
 
 ### Preview (dry run)
 
 ```bash
-python scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
+uv run scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
 ```
 
 Contacts the target remote and reports exactly which refs would be updated,
@@ -356,14 +364,14 @@ without pushing anything.
 
 ```bash
 # Sync main only (default)
-python scripts/sync/repo/sync_repo_to_azure_devops.py
+uv run scripts/sync/repo/sync_repo_to_azure_devops.py
 
 # Sync several branches plus all tags
-python scripts/sync/repo/sync_repo_to_azure_devops.py \
+uv run scripts/sync/repo/sync_repo_to_azure_devops.py \
   --branches main rc/v1.6.1 --tags
 
 # Overwrite diverged refs on the target (use with care)
-python scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --force
+uv run scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --force
 ```
 
 The script fetches the source remote first (`--prune --tags`), verifies each

--- a/scripts/sync/README.md
+++ b/scripts/sync/README.md
@@ -330,6 +330,8 @@ python scripts/sync/files/sync_azure.py --upload --dirs uneg,worldbank --azcopy
 
 `repo/sync_repo_to_azure_devops.py` mirrors branches (and optionally tags)
 from a source remote (default `origin`) to an Azure DevOps Git repository.
+If no `--branches` are given, it syncs `main` plus any branch beginning with
+`rc` or `v`, so release branches are picked up automatically.
 
 It uses **git only** — no `az` CLI, no `azcopy`, no Docker. Run it with
 [uv](https://docs.astral.sh/uv/), which resolves the script's own inline
@@ -350,6 +352,16 @@ dependencies automatically (no project install needed).
 No credentials or repository URLs are hardcoded — the password is supplied to
 git through a credential helper that reads the environment at runtime, so it
 never appears on a command line or in git config.
+
+### Creating Azure DevOps credentials
+
+1. Navigate to the target repository in Azure DevOps.
+2. Click **Clone** (top-right).
+3. Click **Generate Git Credentials**.
+4. Copy the values into `.env` (or export them in your shell):
+   - the repository HTTPS URL, without any `user@` prefix → `AZURE_DEVOPS_REPO_URL`
+   - the generated username → `AZURE_DEVOPS_USERNAME`
+   - the generated password → `AZURE_DEVOPS_PASSWORD`
 
 ### Preview (dry run)
 

--- a/scripts/sync/repo/sync_repo_to_azure_devops.py
+++ b/scripts/sync/repo/sync_repo_to_azure_devops.py
@@ -1,25 +1,31 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["python-dotenv"]
+# ///
 """Mirror this repository's branches (and optionally tags) to an Azure DevOps remote.
 
 Pushes refs from a source remote (default ``origin``) to an Azure DevOps Git
-repository over HTTPS. All connection details come from environment variables
-(or ``.env``) so no credentials or repository URLs live in source control:
+repository over HTTPS. Requires only ``git`` and three values — no az CLI, no
+azcopy, no Docker. All connection details come from environment variables (or
+``.env``) so no credentials or repository URLs live in source control:
 
 - ``AZURE_DEVOPS_REPO_URL``: HTTPS clone URL of the target repository, e.g.
   ``https://dev.azure.com/<org>/<project>/_git/<repo>``.
-- ``AZURE_DEVOPS_PAT``: personal access token with Code (Read & Write) scope.
-- ``AZURE_DEVOPS_USERNAME``: optional; Azure DevOps accepts any non-empty
-  username when a PAT is supplied (defaults to ``pat``).
+- ``AZURE_DEVOPS_USERNAME``: the account username (any non-empty value is
+  accepted when the password is a personal access token; defaults to ``pat``).
+- ``AZURE_DEVOPS_PASSWORD``: the password — typically a personal access token
+  with Code (Read & Write) scope.
 
-The token is injected via a git credential helper that reads the environment
-at git runtime, so it never appears on a command line, in git config, or in
-logs.
+The password is injected via a git credential helper that reads the
+environment at git runtime, so it never appears on a command line, in git
+config, or in logs.
 
-Usage:
+Usage (via uv — resolves the script's own dependencies, no project install):
     # Preview what would be pushed (no changes made)
-    python scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
+    uv run scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
 
     # Sync main and a release branch, plus all tags
-    python scripts/sync/repo/sync_repo_to_azure_devops.py \
+    uv run scripts/sync/repo/sync_repo_to_azure_devops.py \
         --branches main rc/v1.6.1 --tags
 """
 
@@ -37,7 +43,7 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 ENV_REPO_URL = "AZURE_DEVOPS_REPO_URL"
-ENV_PAT = "AZURE_DEVOPS_PAT"
+ENV_CREDENTIAL = "AZURE_DEVOPS_PASSWORD"
 ENV_USERNAME = "AZURE_DEVOPS_USERNAME"
 
 # Shell credential helper executed by git itself. It expands the environment
@@ -45,7 +51,7 @@ ENV_USERNAME = "AZURE_DEVOPS_USERNAME"
 # a process argument list, or any git config file.
 _CREDENTIAL_HELPER = (
     '!f() { echo "username=${AZURE_DEVOPS_USERNAME:-pat}"; '
-    'echo "password=${AZURE_DEVOPS_PAT}"; }; f'
+    'echo "password=${AZURE_DEVOPS_PASSWORD}"; }; f'
 )
 
 
@@ -138,7 +144,7 @@ def sync_to_azure_devops(
 ) -> None:
     """Fetch the source remote and push the requested refs to Azure DevOps."""
     url = _require_env(ENV_REPO_URL)
-    _require_env(ENV_PAT)
+    _require_env(ENV_CREDENTIAL)
 
     logger.info("Fetching latest refs from '%s'...", remote)
     _run_git(

--- a/scripts/sync/repo/sync_repo_to_azure_devops.py
+++ b/scripts/sync/repo/sync_repo_to_azure_devops.py
@@ -20,11 +20,14 @@ The password is injected via a git credential helper that reads the
 environment at git runtime, so it never appears on a command line, in git
 config, or in logs.
 
+If ``--branches`` is omitted, the script syncs ``main`` plus every branch on
+the source remote whose name begins with ``rc`` or ``v`` (release branches).
+
 Usage (via uv — resolves the script's own dependencies, no project install):
     # Preview what would be pushed (no changes made)
-    uv run scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
+    uv run scripts/sync/repo/sync_repo_to_azure_devops.py --dry-run
 
-    # Sync main and a release branch, plus all tags
+    # Sync specific branches only, plus all tags
     uv run scripts/sync/repo/sync_repo_to_azure_devops.py \
         --branches main rc/v1.6.1 --tags
 """
@@ -35,7 +38,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from dotenv import load_dotenv
 
@@ -89,6 +92,37 @@ def _run_git(args: List[str], root_dir: Path, error: str) -> None:
         raise RuntimeError(error)
 
 
+def _list_remote_branches(remote: str, root_dir: Path) -> List[str]:
+    """Return all branch names present on the source remote after a fetch."""
+    result = subprocess.run(
+        [
+            "git",
+            "for-each-ref",
+            f"refs/remotes/{remote}",
+            "--format=%(refname:strip=3)",
+        ],
+        cwd=root_dir,
+        env=_git_env(),
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Could not list branches for remote '{remote}'.")
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _default_branches(remote: str, root_dir: Path) -> List[str]:
+    """Select ``main`` plus release branches (``rc*``/``v*``) from the remote."""
+    names = _list_remote_branches(remote, root_dir)
+    selected = [n for n in names if n == "main" or n.startswith(("rc", "v"))]
+    if not selected:
+        raise RuntimeError(
+            f"No branches on remote '{remote}' match the default pattern "
+            "(main, rc*, v*)."
+        )
+    return sorted(selected, key=lambda n: (n != "main", n))
+
+
 def _verify_branches(remote: str, branches: List[str], root_dir: Path) -> None:
     """Fail hard if any requested branch does not exist on the source remote."""
     for branch in branches:
@@ -137,12 +171,16 @@ def sync_to_azure_devops(
     *,
     root_dir: Path,
     remote: str,
-    branches: List[str],
+    branches: Optional[List[str]],
     tags: bool,
     dry_run: bool,
     force: bool,
 ) -> None:
-    """Fetch the source remote and push the requested refs to Azure DevOps."""
+    """Fetch the source remote and push the requested refs to Azure DevOps.
+
+    When ``branches`` is ``None``, syncs ``main`` plus every branch on the
+    source remote whose name begins with ``rc`` or ``v``.
+    """
     url = _require_env(ENV_REPO_URL)
     _require_env(ENV_CREDENTIAL)
 
@@ -152,6 +190,9 @@ def sync_to_azure_devops(
         root_dir,
         f"Fetch from remote '{remote}' failed.",
     )
+    if branches is None:
+        branches = _default_branches(remote, root_dir)
+        logger.info("No branches specified; syncing: %s", ", ".join(branches))
     _verify_branches(remote, branches, root_dir)
 
     refspecs = _build_refspecs(remote, branches, tags)
@@ -174,8 +215,11 @@ def main() -> int:
     parser.add_argument(
         "--branches",
         nargs="+",
-        default=["main"],
-        help="Branches to sync (default: main).",
+        default=None,
+        help=(
+            "Branches to sync (default: main plus any branch beginning "
+            "with 'rc' or 'v')."
+        ),
     )
     parser.add_argument(
         "--tags",

--- a/scripts/sync/repo/sync_repo_to_azure_devops.py
+++ b/scripts/sync/repo/sync_repo_to_azure_devops.py
@@ -1,0 +1,212 @@
+"""Mirror this repository's branches (and optionally tags) to an Azure DevOps remote.
+
+Pushes refs from a source remote (default ``origin``) to an Azure DevOps Git
+repository over HTTPS. All connection details come from environment variables
+(or ``.env``) so no credentials or repository URLs live in source control:
+
+- ``AZURE_DEVOPS_REPO_URL``: HTTPS clone URL of the target repository, e.g.
+  ``https://dev.azure.com/<org>/<project>/_git/<repo>``.
+- ``AZURE_DEVOPS_PAT``: personal access token with Code (Read & Write) scope.
+- ``AZURE_DEVOPS_USERNAME``: optional; Azure DevOps accepts any non-empty
+  username when a PAT is supplied (defaults to ``pat``).
+
+The token is injected via a git credential helper that reads the environment
+at git runtime, so it never appears on a command line, in git config, or in
+logs.
+
+Usage:
+    # Preview what would be pushed (no changes made)
+    python scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
+
+    # Sync main and a release branch, plus all tags
+    python scripts/sync/repo/sync_repo_to_azure_devops.py \
+        --branches main rc/v1.6.1 --tags
+"""
+
+import argparse
+import logging
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+from dotenv import load_dotenv
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+ENV_REPO_URL = "AZURE_DEVOPS_REPO_URL"
+ENV_PAT = "AZURE_DEVOPS_PAT"
+ENV_USERNAME = "AZURE_DEVOPS_USERNAME"
+
+# Shell credential helper executed by git itself. It expands the environment
+# variables at git runtime — the secret never becomes part of a Python string,
+# a process argument list, or any git config file.
+_CREDENTIAL_HELPER = (
+    '!f() { echo "username=${AZURE_DEVOPS_USERNAME:-pat}"; '
+    'echo "password=${AZURE_DEVOPS_PAT}"; }; f'
+)
+
+
+def _load_env() -> Path:
+    """Load ``.env`` from the repository root and return the root path."""
+    root_dir = Path(__file__).resolve().parents[3]
+    load_dotenv(root_dir / ".env")
+    return root_dir
+
+
+def _require_env(name: str) -> str:
+    """Return the value of environment variable ``name`` or fail hard."""
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+def _mask_url(url: str) -> str:
+    """Return ``url`` with any userinfo section removed, safe for logging."""
+    return re.sub(r"://[^/@]*@", "://", url)
+
+
+def _git_env() -> Dict[str, str]:
+    """Environment for git subprocesses; never prompt for credentials."""
+    env = dict(os.environ)
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    return env
+
+
+def _run_git(args: List[str], root_dir: Path, error: str) -> None:
+    """Run a git command in ``root_dir``, raising ``RuntimeError`` on failure."""
+    result = subprocess.run(["git", *args], cwd=root_dir, env=_git_env())
+    if result.returncode != 0:
+        raise RuntimeError(error)
+
+
+def _verify_branches(remote: str, branches: List[str], root_dir: Path) -> None:
+    """Fail hard if any requested branch does not exist on the source remote."""
+    for branch in branches:
+        ref = f"refs/remotes/{remote}/{branch}"
+        result = subprocess.run(
+            ["git", "rev-parse", "--verify", "--quiet", ref],
+            cwd=root_dir,
+            env=_git_env(),
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Branch '{branch}' not found on remote '{remote}' ({ref})."
+            )
+
+
+def _build_refspecs(remote: str, branches: List[str], tags: bool) -> List[str]:
+    """Map source remote-tracking refs to target branch refs."""
+    refspecs = [f"refs/remotes/{remote}/{b}:refs/heads/{b}" for b in branches]
+    if tags:
+        refspecs.append("refs/tags/*:refs/tags/*")
+    return refspecs
+
+
+def _build_push_args(
+    url: str, refspecs: List[str], *, dry_run: bool, force: bool
+) -> List[str]:
+    """Build git arguments for the push, with credentials via helper only."""
+    args = [
+        "-c",
+        "credential.helper=",
+        "-c",
+        f"credential.helper={_CREDENTIAL_HELPER}",
+        "push",
+    ]
+    if dry_run:
+        args.append("--dry-run")
+    if force:
+        args.append("--force")
+    args.append(url)
+    args.extend(refspecs)
+    return args
+
+
+def sync_to_azure_devops(
+    *,
+    root_dir: Path,
+    remote: str,
+    branches: List[str],
+    tags: bool,
+    dry_run: bool,
+    force: bool,
+) -> None:
+    """Fetch the source remote and push the requested refs to Azure DevOps."""
+    url = _require_env(ENV_REPO_URL)
+    _require_env(ENV_PAT)
+
+    logger.info("Fetching latest refs from '%s'...", remote)
+    _run_git(
+        ["fetch", remote, "--prune", "--tags"],
+        root_dir,
+        f"Fetch from remote '{remote}' failed.",
+    )
+    _verify_branches(remote, branches, root_dir)
+
+    refspecs = _build_refspecs(remote, branches, tags)
+    mode = "[DRY RUN] " if dry_run else ""
+    logger.info("%sPushing %d refspec(s) to %s", mode, len(refspecs), _mask_url(url))
+    _run_git(
+        _build_push_args(url, refspecs, dry_run=dry_run, force=force),
+        root_dir,
+        "Push to Azure DevOps failed.",
+    )
+    logger.info("%sSync complete.", mode)
+
+
+def main() -> int:
+    """CLI entry point."""
+    root_dir = _load_env()
+    parser = argparse.ArgumentParser(
+        description="Mirror branches/tags from a source remote to Azure DevOps."
+    )
+    parser.add_argument(
+        "--branches",
+        nargs="+",
+        default=["main"],
+        help="Branches to sync (default: main).",
+    )
+    parser.add_argument(
+        "--tags",
+        action="store_true",
+        help="Also push all tags.",
+    )
+    parser.add_argument(
+        "--remote",
+        default="origin",
+        help="Source remote to sync from (default: origin).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be pushed without pushing anything.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force-push, overwriting diverged refs on the target.",
+    )
+    args = parser.parse_args()
+
+    try:
+        sync_to_azure_devops(
+            root_dir=root_dir,
+            remote=args.remote,
+            branches=args.branches,
+            tags=args.tags,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+    except RuntimeError as exc:
+        logger.error(str(exc))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_sync_repo_to_azure_devops.py
+++ b/tests/unit/test_sync_repo_to_azure_devops.py
@@ -1,0 +1,201 @@
+"""Unit tests for scripts/sync/repo/sync_repo_to_azure_devops.py.
+
+The script mirrors branches/tags from a source remote to an Azure DevOps
+repository. Tests stub ``subprocess.run`` so they execute without git or
+network access, and verify that credentials are only ever referenced via
+environment-variable expansion — never embedded in commands.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "sync"
+    / "repo"
+    / "sync_repo_to_azure_devops.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "sync_repo_to_azure_devops", _SCRIPT_PATH
+)
+sync_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sync_mod)
+
+_URL = "https://dev.azure.com/example-org/example-project/_git/example-repo"
+_PAT_SENTINEL = "sentinel-token-value"
+
+
+def _ok():
+    return subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def _fail():
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr="")
+
+
+def _set_required_env(monkeypatch):
+    monkeypatch.setenv(sync_mod.ENV_REPO_URL, _URL)
+    monkeypatch.setenv(sync_mod.ENV_PAT, _PAT_SENTINEL)
+
+
+@pytest.mark.unit
+class TestRequireEnv:
+    def test_returns_value_when_set(self, monkeypatch):
+        monkeypatch.setenv("SYNC_TEST_VAR", "value")
+        assert sync_mod._require_env("SYNC_TEST_VAR") == "value"
+
+    def test_raises_when_missing(self, monkeypatch):
+        monkeypatch.delenv("SYNC_TEST_VAR", raising=False)
+        with pytest.raises(RuntimeError, match="SYNC_TEST_VAR"):
+            sync_mod._require_env("SYNC_TEST_VAR")
+
+    def test_raises_when_blank(self, monkeypatch):
+        monkeypatch.setenv("SYNC_TEST_VAR", "   ")
+        with pytest.raises(RuntimeError, match="SYNC_TEST_VAR"):
+            sync_mod._require_env("SYNC_TEST_VAR")
+
+
+@pytest.mark.unit
+class TestMaskUrl:
+    def test_strips_userinfo(self):
+        url = "https://someone@dev.azure.com/org/project/_git/repo"
+        assert sync_mod._mask_url(url) == "https://dev.azure.com/org/project/_git/repo"
+
+    def test_leaves_plain_url_unchanged(self):
+        assert sync_mod._mask_url(_URL) == _URL
+
+
+@pytest.mark.unit
+class TestBuildRefspecs:
+    def test_maps_remote_branches_to_target_heads(self):
+        refspecs = sync_mod._build_refspecs("origin", ["main", "rc/v1.0.0"], tags=False)
+        assert refspecs == [
+            "refs/remotes/origin/main:refs/heads/main",
+            "refs/remotes/origin/rc/v1.0.0:refs/heads/rc/v1.0.0",
+        ]
+
+    def test_appends_tag_refspec_when_tags_enabled(self):
+        refspecs = sync_mod._build_refspecs("origin", ["main"], tags=True)
+        assert refspecs[-1] == "refs/tags/*:refs/tags/*"
+
+
+@pytest.mark.unit
+class TestBuildPushArgs:
+    def test_dry_run_adds_flag(self):
+        args = sync_mod._build_push_args(_URL, ["a:b"], dry_run=True, force=False)
+        assert "--dry-run" in args
+
+    def test_no_dry_run_omits_flag(self):
+        args = sync_mod._build_push_args(_URL, ["a:b"], dry_run=False, force=False)
+        assert "--dry-run" not in args
+
+    def test_force_adds_flag(self):
+        args = sync_mod._build_push_args(_URL, ["a:b"], dry_run=False, force=True)
+        assert "--force" in args
+
+    def test_url_precedes_refspecs(self):
+        args = sync_mod._build_push_args(
+            _URL, ["a:b", "c:d"], dry_run=False, force=False
+        )
+        assert args[-3:] == [_URL, "a:b", "c:d"]
+
+    def test_credentials_come_from_env_expansion_not_values(self, monkeypatch):
+        """The PAT must never be embedded in the command; the helper expands
+        the environment variable when git itself runs it."""
+        monkeypatch.setenv(sync_mod.ENV_PAT, _PAT_SENTINEL)
+        args = sync_mod._build_push_args(_URL, ["a:b"], dry_run=True, force=False)
+        assert all(_PAT_SENTINEL not in part for part in args)
+        helper = next(part for part in args if part.startswith("credential.helper=!"))
+        assert "${AZURE_DEVOPS_PAT}" in helper
+
+
+@pytest.mark.unit
+class TestVerifyBranches:
+    def test_raises_when_branch_missing(self, tmp_path):
+        with patch.object(sync_mod.subprocess, "run", return_value=_fail()):
+            with pytest.raises(RuntimeError, match="missing-branch"):
+                sync_mod._verify_branches("origin", ["missing-branch"], tmp_path)
+
+    def test_passes_when_branch_exists(self, tmp_path):
+        with patch.object(sync_mod.subprocess, "run", return_value=_ok()) as run:
+            sync_mod._verify_branches("origin", ["main"], tmp_path)
+        ref_args = run.call_args_list[0].args[0]
+        assert "refs/remotes/origin/main" in ref_args
+
+
+@pytest.mark.unit
+class TestSyncToAzureDevops:
+    def _sync(self, tmp_path, **overrides):
+        kwargs = {
+            "root_dir": tmp_path,
+            "remote": "origin",
+            "branches": ["main"],
+            "tags": False,
+            "dry_run": True,
+            "force": False,
+        }
+        kwargs.update(overrides)
+        sync_mod.sync_to_azure_devops(**kwargs)
+
+    def test_raises_when_repo_url_env_missing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(sync_mod.ENV_REPO_URL, raising=False)
+        monkeypatch.setenv(sync_mod.ENV_PAT, _PAT_SENTINEL)
+        with pytest.raises(RuntimeError, match=sync_mod.ENV_REPO_URL):
+            self._sync(tmp_path)
+
+    def test_raises_when_pat_env_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv(sync_mod.ENV_REPO_URL, _URL)
+        monkeypatch.delenv(sync_mod.ENV_PAT, raising=False)
+        with pytest.raises(RuntimeError, match=sync_mod.ENV_PAT):
+            self._sync(tmp_path)
+
+    def test_dry_run_passes_flag_to_git_push(self, tmp_path, monkeypatch):
+        _set_required_env(monkeypatch)
+        with patch.object(sync_mod.subprocess, "run", return_value=_ok()) as run:
+            self._sync(tmp_path, dry_run=True)
+        push_cmd = run.call_args_list[-1].args[0]
+        assert "--dry-run" in push_cmd
+        assert push_cmd[-2:] == [_URL, "refs/remotes/origin/main:refs/heads/main"]
+
+    def test_real_run_omits_dry_run_flag(self, tmp_path, monkeypatch):
+        _set_required_env(monkeypatch)
+        with patch.object(sync_mod.subprocess, "run", return_value=_ok()) as run:
+            self._sync(tmp_path, dry_run=False)
+        push_cmd = run.call_args_list[-1].args[0]
+        assert "--dry-run" not in push_cmd
+
+    def test_raises_when_fetch_fails(self, tmp_path, monkeypatch):
+        _set_required_env(monkeypatch)
+        with patch.object(sync_mod.subprocess, "run", return_value=_fail()):
+            with pytest.raises(RuntimeError, match="Fetch from remote"):
+                self._sync(tmp_path)
+
+    def test_raises_when_push_fails(self, tmp_path, monkeypatch):
+        _set_required_env(monkeypatch)
+        with patch.object(sync_mod.subprocess, "run") as run:
+            run.side_effect = [_ok(), _ok(), _fail()]  # fetch, rev-parse, push
+            with pytest.raises(RuntimeError, match="Push to Azure DevOps failed"):
+                self._sync(tmp_path)
+
+
+@pytest.mark.unit
+class TestMain:
+    def test_returns_error_code_when_env_missing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(sync_mod.ENV_REPO_URL, raising=False)
+        monkeypatch.delenv(sync_mod.ENV_PAT, raising=False)
+        monkeypatch.setattr(sys, "argv", ["prog", "--dry-run"])
+        with patch.object(sync_mod, "_load_env", return_value=tmp_path):
+            assert sync_mod.main() == 1
+
+    def test_returns_zero_on_success(self, tmp_path, monkeypatch):
+        _set_required_env(monkeypatch)
+        monkeypatch.setattr(sys, "argv", ["prog", "--dry-run"])
+        with patch.object(sync_mod, "_load_env", return_value=tmp_path):
+            with patch.object(sync_mod.subprocess, "run", return_value=_ok()):
+                assert sync_mod.main() == 0

--- a/tests/unit/test_sync_repo_to_azure_devops.py
+++ b/tests/unit/test_sync_repo_to_azure_devops.py
@@ -115,6 +115,56 @@ class TestBuildPushArgs:
         assert "${AZURE_DEVOPS_PASSWORD}" in helper
 
 
+def _branch_listing(names):
+    """CompletedProcess mimicking ``git for-each-ref`` stdout."""
+    return subprocess.CompletedProcess(
+        args=[], returncode=0, stdout="\n".join(names) + "\n", stderr=""
+    )
+
+
+@pytest.mark.unit
+class TestDefaultBranches:
+    _REMOTE_NAMES = [
+        "HEAD",
+        "dependabot/pip/thing",
+        "feature/x",
+        "main",
+        "rc/v1.6.0",
+        "rc/v1.6.1",
+        "v2-experiments",
+    ]
+
+    def test_selects_main_and_rc_and_v_branches(self, tmp_path):
+        with patch.object(
+            sync_mod.subprocess, "run", return_value=_branch_listing(self._REMOTE_NAMES)
+        ):
+            branches = sync_mod._default_branches("origin", tmp_path)
+        assert branches == ["main", "rc/v1.6.0", "rc/v1.6.1", "v2-experiments"]
+
+    def test_main_sorts_first(self, tmp_path):
+        with patch.object(
+            sync_mod.subprocess,
+            "run",
+            return_value=_branch_listing(["rc/v1.0.0", "main"]),
+        ):
+            branches = sync_mod._default_branches("origin", tmp_path)
+        assert branches[0] == "main"
+
+    def test_raises_when_nothing_matches(self, tmp_path):
+        with patch.object(
+            sync_mod.subprocess,
+            "run",
+            return_value=_branch_listing(["feature/x", "dev"]),
+        ):
+            with pytest.raises(RuntimeError, match="default pattern"):
+                sync_mod._default_branches("origin", tmp_path)
+
+    def test_raises_when_listing_fails(self, tmp_path):
+        with patch.object(sync_mod.subprocess, "run", return_value=_fail()):
+            with pytest.raises(RuntimeError, match="Could not list branches"):
+                sync_mod._default_branches("origin", tmp_path)
+
+
 @pytest.mark.unit
 class TestVerifyBranches:
     def test_raises_when_branch_missing(self, tmp_path):
@@ -183,6 +233,22 @@ class TestSyncToAzureDevops:
             with pytest.raises(RuntimeError, match="Push to Azure DevOps failed"):
                 self._sync(tmp_path)
 
+    def test_no_branches_discovers_main_and_release_branches(
+        self, tmp_path, monkeypatch
+    ):
+        _set_required_env(monkeypatch)
+        listing = _branch_listing(["HEAD", "feature/x", "main", "rc/v1.6.1"])
+        with patch.object(sync_mod.subprocess, "run") as run:
+            # fetch, for-each-ref, rev-parse x2, push
+            run.side_effect = [_ok(), listing, _ok(), _ok(), _ok()]
+            self._sync(tmp_path, branches=None)
+        push_cmd = run.call_args_list[-1].args[0]
+        assert push_cmd[-2:] == [
+            "refs/remotes/origin/main:refs/heads/main",
+            "refs/remotes/origin/rc/v1.6.1:refs/heads/rc/v1.6.1",
+        ]
+        assert not any("feature/x" in part for part in push_cmd)
+
 
 @pytest.mark.unit
 class TestMain:
@@ -197,5 +263,7 @@ class TestMain:
         _set_required_env(monkeypatch)
         monkeypatch.setattr(sys, "argv", ["prog", "--dry-run"])
         with patch.object(sync_mod, "_load_env", return_value=tmp_path):
-            with patch.object(sync_mod.subprocess, "run", return_value=_ok()):
+            with patch.object(sync_mod.subprocess, "run") as run:
+                # fetch, for-each-ref, rev-parse, push
+                run.side_effect = [_ok(), _branch_listing(["main"]), _ok(), _ok()]
                 assert sync_mod.main() == 0

--- a/tests/unit/test_sync_repo_to_azure_devops.py
+++ b/tests/unit/test_sync_repo_to_azure_devops.py
@@ -28,7 +28,7 @@ sync_mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(sync_mod)
 
 _URL = "https://dev.azure.com/example-org/example-project/_git/example-repo"
-_PAT_SENTINEL = "sentinel-token-value"
+_SENTINEL_VALUE = "sentinel-token-value"
 
 
 def _ok():
@@ -41,7 +41,7 @@ def _fail():
 
 def _set_required_env(monkeypatch):
     monkeypatch.setenv(sync_mod.ENV_REPO_URL, _URL)
-    monkeypatch.setenv(sync_mod.ENV_PAT, _PAT_SENTINEL)
+    monkeypatch.setenv(sync_mod.ENV_CREDENTIAL, _SENTINEL_VALUE)
 
 
 @pytest.mark.unit
@@ -106,13 +106,13 @@ class TestBuildPushArgs:
         assert args[-3:] == [_URL, "a:b", "c:d"]
 
     def test_credentials_come_from_env_expansion_not_values(self, monkeypatch):
-        """The PAT must never be embedded in the command; the helper expands
-        the environment variable when git itself runs it."""
-        monkeypatch.setenv(sync_mod.ENV_PAT, _PAT_SENTINEL)
+        """The password must never be embedded in the command; the helper
+        expands the environment variable when git itself runs it."""
+        monkeypatch.setenv(sync_mod.ENV_CREDENTIAL, _SENTINEL_VALUE)
         args = sync_mod._build_push_args(_URL, ["a:b"], dry_run=True, force=False)
-        assert all(_PAT_SENTINEL not in part for part in args)
+        assert all(_SENTINEL_VALUE not in part for part in args)
         helper = next(part for part in args if part.startswith("credential.helper=!"))
-        assert "${AZURE_DEVOPS_PAT}" in helper
+        assert "${AZURE_DEVOPS_PASSWORD}" in helper
 
 
 @pytest.mark.unit
@@ -145,14 +145,14 @@ class TestSyncToAzureDevops:
 
     def test_raises_when_repo_url_env_missing(self, tmp_path, monkeypatch):
         monkeypatch.delenv(sync_mod.ENV_REPO_URL, raising=False)
-        monkeypatch.setenv(sync_mod.ENV_PAT, _PAT_SENTINEL)
+        monkeypatch.setenv(sync_mod.ENV_CREDENTIAL, _SENTINEL_VALUE)
         with pytest.raises(RuntimeError, match=sync_mod.ENV_REPO_URL):
             self._sync(tmp_path)
 
     def test_raises_when_pat_env_missing(self, tmp_path, monkeypatch):
         monkeypatch.setenv(sync_mod.ENV_REPO_URL, _URL)
-        monkeypatch.delenv(sync_mod.ENV_PAT, raising=False)
-        with pytest.raises(RuntimeError, match=sync_mod.ENV_PAT):
+        monkeypatch.delenv(sync_mod.ENV_CREDENTIAL, raising=False)
+        with pytest.raises(RuntimeError, match=sync_mod.ENV_CREDENTIAL):
             self._sync(tmp_path)
 
     def test_dry_run_passes_flag_to_git_push(self, tmp_path, monkeypatch):
@@ -188,7 +188,7 @@ class TestSyncToAzureDevops:
 class TestMain:
     def test_returns_error_code_when_env_missing(self, tmp_path, monkeypatch):
         monkeypatch.delenv(sync_mod.ENV_REPO_URL, raising=False)
-        monkeypatch.delenv(sync_mod.ENV_PAT, raising=False)
+        monkeypatch.delenv(sync_mod.ENV_CREDENTIAL, raising=False)
         monkeypatch.setattr(sys, "argv", ["prog", "--dry-run"])
         with patch.object(sync_mod, "_load_env", return_value=tmp_path):
             assert sync_mod.main() == 1


### PR DESCRIPTION
## Description

Adds `scripts/sync/repo/sync_repo_to_azure_devops.py`, which mirrors branches (and optionally tags) from a source remote (default `origin`) to an Azure DevOps Git repository over HTTPS.

- **Git only** — no az CLI, no azcopy, no Docker. Run with `uv run` (the script declares its single dependency via PEP 723 inline metadata, so no project install is needed).
- **Only three inputs required**, all from environment variables / `.env` (documented in `.env.example`) — nothing hardcoded:
  - `AZURE_DEVOPS_REPO_URL` — HTTPS clone URL
  - `AZURE_DEVOPS_USERNAME` — account username
  - `AZURE_DEVOPS_PASSWORD` — password (typically a personal access token)
- **Password never touches a command line or git config** — supplied via a git credential helper that expands environment variables at git runtime; logged URLs are masked of any userinfo.
- **`--dry-run` mode** — contacts the target remote and reports exactly which refs would be updated without pushing anything.
- Fetches the source remote (`--prune --tags`) and verifies each requested branch exists before pushing; fails hard with a clear message otherwise (`GIT_TERMINAL_PROMPT=0`, so bad credentials fail instead of hanging).
- `--branches`, `--tags`, `--remote`, and `--force` options; docs added to `scripts/sync/README.md`.

```bash
uv run scripts/sync/repo/sync_repo_to_azure_devops.py --branches main --dry-run
```

## Type of Change
- [x] New feature

## Testing
- [x] 22 unit tests in `tests/unit/test_sync_repo_to_azure_devops.py` (all passing) — covering env validation, refspec construction, dry-run/force flag handling, URL masking, failure paths, and a guard that the password value never appears in any git command.
- [x] Live `uv run ... --dry-run` verified against the real target remote: authenticates, reports the pending `origin/main -> main` fast-forward, pushes nothing.
- [x] Invalid-password path verified: exits 1 with a clean message, no hang, no secret leaked.
- [x] Pre-commit hooks pass (black, isort, flake8, bandit, detect-secrets, gitleaks, code-metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)