### PR TITLE
fix: include page numbers in evaluation AI-summary references

### DIFF
--- a/tests/unit/test_citations.py
+++ b/tests/unit/test_citations.py
@@ -1,0 +1,80 @@
+"""Unit tests for the Python citation/reference rendering.
+
+This module (``ui.backend.services.citations``) is the server-side mirror of the
+frontend ``citations.ts`` / ``AiSummaryReferences.tsx`` logic. These tests pin
+the behaviour the search UI has — grouping citations by document and appending
+each citation's page number — so the evaluation harness stays in lock-step.
+"""
+
+import pytest
+
+from ui.backend.services.citations import group_references, render_reference_lines
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_group_references_groups_by_document_in_first_cited_order():
+    references = [
+        {"number": 1, "title": "Doc A", "page_num": 5},
+        {"number": 2, "title": "Doc B", "page_num": 3},
+        {"number": 3, "title": "Doc A", "page_num": 12},
+    ]
+    groups = group_references(references)
+    assert [g["title"] for g in groups] == ["Doc A", "Doc B"]
+    # Doc A collapses its two citations into one group, preserving page numbers.
+    assert groups[0]["refs"] == [
+        {"number": 1, "page_num": 5},
+        {"number": 3, "page_num": 12},
+    ]
+    assert groups[1]["refs"] == [{"number": 2, "page_num": 3}]
+
+
+def test_group_references_falls_back_to_doc_id_then_unknown():
+    groups = group_references(
+        [
+            {"number": 1, "doc_id": "d1"},
+            {"number": 2},
+        ]
+    )
+    assert [g["title"] for g in groups] == ["d1", "Unknown"]
+
+
+def test_render_reference_lines_includes_metadata_and_pages():
+    lines = render_reference_lines(
+        [
+            {
+                "number": 1,
+                "title": "Kenya SMP",
+                "organization": "WFP",
+                "year": 2018,
+                "page_num": 12,
+            }
+        ]
+    )
+    assert lines == ["Kenya SMP, WFP, 2018 | [1] p.12"]
+
+
+def test_render_reference_lines_shows_page_range_per_document():
+    lines = render_reference_lines(
+        [
+            {"number": 1, "title": "Kenya SMP", "organization": "WFP", "page_num": 5},
+            {"number": 3, "title": "Kenya SMP", "organization": "WFP", "page_num": 12},
+        ]
+    )
+    assert lines == ["Kenya SMP, WFP | [1] p.5 [3] p.12"]
+
+
+def test_render_reference_lines_omits_page_when_falsy():
+    # A missing page or an unknown page of 0 renders no ``p.`` suffix, matching
+    # the frontend's truthiness check.
+    lines = render_reference_lines(
+        [
+            {"number": 1, "title": "No Page"},
+            {"number": 2, "title": "Zero Page", "page_num": 0},
+        ]
+    )
+    assert lines == ["No Page | [1]", "Zero Page | [2]"]
+
+
+def test_render_reference_lines_empty_when_no_references():
+    assert render_reference_lines([]) == []

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -24,6 +24,7 @@ from ui.backend.services.test_runner import (
     _default_summary_model,
     _execute,
     _format_judge_context,
+    _format_judge_references,
     _group_settings_to_config,
     _mirror_run_to_experiment,
     _parse_judgement,
@@ -181,6 +182,14 @@ async def test_build_references_ignores_out_of_range_citations():
     assert refs == []
 
 
+async def test_build_references_carries_page_num():
+    # The page of the cited chunk must be carried through so the rendered
+    # References can show it, exactly as the search UI does.
+    results = [{"title": "Kenya SMP", "page_num": 7}]
+    refs = _build_references("finding [1]", results)
+    assert refs[0]["page_num"] == 7
+
+
 async def test_references_text_renders_appended_section():
     text = _references_text(
         [
@@ -190,11 +199,50 @@ async def test_references_text_renders_appended_section():
                 "organization": "WFP",
                 "year": 2018,
                 "url": "http://x",
+                "page_num": 12,
             }
         ]
     )
     assert "## References" in text
-    assert "[1] Kenya SMP (WFP, 2018) — http://x" in text
+    # Grouped-by-document layout with the citation's page number, mirroring the
+    # search UI's References list (no bare URL, unlike the old flat format).
+    assert "Kenya SMP, WFP, 2018 | [1] p.12" in text
+
+
+async def test_references_text_includes_page_ranges_per_document():
+    # Two chunks of the same document cited on different pages group into one
+    # References line, each citation keeping its own page number — the "page
+    # ranges" the search UI shows and the eval harness previously dropped.
+    references = [
+        {"number": 1, "title": "Kenya SMP", "organization": "WFP", "page_num": 5},
+        {"number": 3, "title": "Kenya SMP", "organization": "WFP", "page_num": 12},
+    ]
+    text = _references_text(references)
+    assert "Kenya SMP, WFP | [1] p.5 [3] p.12" in text
+
+
+async def test_references_text_omits_page_when_unknown():
+    # A page of 0 (unknown) shows no page suffix, matching the frontend, which
+    # only renders ``p.<page>`` for a truthy page number.
+    text = _references_text([{"number": 1, "title": "No Page Doc", "page_num": 0}])
+    assert "No Page Doc | [1]" in text
+    assert "p.0" not in text
+
+
+async def test_format_judge_references_grouped_with_pages():
+    # The judge context uses the same grouped, page-numbered rendering (without
+    # the markdown header) so what is judged matches what search shows.
+    references = [
+        {"number": 1, "title": "Kenya SMP", "organization": "WFP", "page_num": 5},
+        {"number": 2, "title": "Kenya SMP", "organization": "WFP", "page_num": 9},
+    ]
+    text = _format_judge_references(references)
+    assert text == "Kenya SMP, WFP | [1] p.5 [2] p.9"
+    assert "## References" not in text
+
+
+async def test_format_judge_references_empty_when_no_citations():
+    assert _format_judge_references([]) == "(no citations resolved in the summary)"
 
 
 async def test_storable_output_is_json_safe_and_trimmed():

--- a/ui/backend/services/citations.py
+++ b/ui/backend/services/citations.py
@@ -1,0 +1,91 @@
+"""Group and render an AI summary's resolved citations into a References list.
+
+The search UI resolves the inline ``[N]`` citation markers an AI summary emits
+into a References list *in the browser*: it groups the citations by document and
+appends each cited chunk's page number. That logic lives in TypeScript at
+``ui/frontend/src/utils/citations.ts`` (``buildGroupedReferences``) and
+``ui/frontend/src/components/AiSummaryReferences.tsx`` (the ``p.<page>`` suffix).
+
+The evaluation harness runs server-side and cannot reuse that TypeScript, so this
+module ports the same grouping-and-page-number rendering to Python. Keeping the
+two in lock-step means an evaluated summary's references match what a user sees
+in search — including the page numbers that were previously missing on the eval
+side.
+
+The one deliberate deviation from the frontend: the ``[N]`` numbers are kept as
+the model emitted them rather than renumbered to a sequential ``1..k`` run. The
+harness leaves the inline markers in the summary body untouched, so the
+References must keep the same original numbers to stay consistent with them.
+"""
+
+from typing import Any, Dict, List
+
+
+def group_references(references: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Group flat citation references by document title, preserving order.
+
+    Mirrors the frontend ``buildGroupedReferences``: repeated citations of the
+    same document collapse into one group, in first-appearance order. Each group
+    carries the document metadata plus the list of its cited ``[N]`` numbers and
+    their page numbers.
+
+    Args:
+        references: Flat citation dicts (as built by the harness), each with at
+            least ``number`` and optionally ``title``, ``organization``,
+            ``year``, ``page_num``.
+
+    Returns:
+        One dict per document, in first-cited order, with keys ``title``,
+        ``organization``, ``year`` and a ``refs`` list of ``{number, page_num}``.
+    """
+    groups: Dict[str, Dict[str, Any]] = {}
+    order: List[str] = []
+    for ref in references:
+        title = ref.get("title") or ref.get("doc_id") or "Unknown"
+        group = groups.get(title)
+        if group is None:
+            group = {
+                "title": title,
+                "organization": ref.get("organization"),
+                "year": ref.get("year"),
+                "refs": [],
+            }
+            groups[title] = group
+            order.append(title)
+        group["refs"].append(
+            {"number": ref.get("number"), "page_num": ref.get("page_num")}
+        )
+    return [groups[title] for title in order]
+
+
+def _render_ref(ref: Dict[str, Any]) -> str:
+    """Render one citation as ``[N]`` with an optional ``p.<page>`` suffix.
+
+    The page suffix is shown only for a truthy page number, matching the
+    frontend, which renders ``p.{page_num}`` only when ``page_num`` is truthy —
+    so an unknown page (``0`` or missing) shows no page at all.
+    """
+    page = ref.get("page_num")
+    suffix = f" p.{page}" if page else ""
+    return f"[{ref.get('number')}]{suffix}"
+
+
+def _render_group(group: Dict[str, Any]) -> str:
+    """Render one document group as ``Title, Org, Year | [N] p.X [M] p.Y``."""
+    meta = ", ".join(
+        str(part)
+        for part in (group.get("title"), group.get("organization"), group.get("year"))
+        if part
+    )
+    refs = " ".join(_render_ref(ref) for ref in group.get("refs", []))
+    return f"{meta} | {refs}" if refs else meta
+
+
+def render_reference_lines(references: List[Dict[str, Any]]) -> List[str]:
+    """Render references as one text line per document group.
+
+    Each line matches the search UI's References layout — the document metadata,
+    then a ``|`` separator, then its cited ``[N]`` markers each with their page
+    number (``Title, Org, Year | [N] p.X [M] p.Y``).
+    """
+    return [_render_group(group) for group in group_references(references)]

--- a/ui/backend/services/test_runner.py
+++ b/ui/backend/services/test_runner.py
@@ -39,6 +39,7 @@ from ui.backend.auth.testing_models import (
     TestResult,
     TestRun,
 )
+from ui.backend.services.citations import render_reference_lines
 from ui.backend.services.evaluation_metrics import compute_summary_stats
 from ui.backend.services.test_evaluators import evaluate_assertions
 from ui.backend.utils.filter_helpers import resolve_doc_level_filters
@@ -288,23 +289,22 @@ def _build_references(
                 "country": r.get("country"),
                 "doc_id": r.get("doc_id"),
                 "url": r.get("url") or r.get("link"),
+                # Page of the cited chunk, carried through so the rendered
+                # References can show ``p.<page>`` exactly as the search UI does.
+                "page_num": r.get("page_num"),
             }
         )
     return references
 
 
 def _references_text(references: List[Dict[str, Any]]) -> str:
-    """Render references as an appended, human/LLM-readable section."""
-    if not references:
+    """Render references as an appended section, grouped by document with each
+    citation's page number — the same shape the search UI shows (see
+    :mod:`ui.backend.services.citations`)."""
+    lines = render_reference_lines(references)
+    if not lines:
         return ""
-    lines = ["", "", "## References"]
-    for r in references:
-        meta = ", ".join(str(x) for x in (r.get("organization"), r.get("year")) if x)
-        suffix = f" ({meta})" if meta else ""
-        url = f" — {r['url']}" if r.get("url") else ""
-        title = r.get("title") or r.get("doc_id") or "Unknown"
-        lines.append(f"[{r['number']}] {title}{suffix}{url}")
-    return "\n".join(lines)
+    return "\n".join(["", "", "## References", *lines])
 
 
 def _resolve_combo(name: Optional[str]) -> Dict[str, Optional[str]]:
@@ -473,15 +473,12 @@ _JUDGE_CONTEXT_TEXT_LIMIT = 1200
 
 
 def _format_judge_references(references: List[Dict[str, Any]]) -> str:
-    """A plain numbered list of the cited documents (no markdown header)."""
-    if not references:
+    """Grouped, page-numbered citation list for the judge (no markdown header) —
+    the same rendering the search UI and the stored summary use (see
+    :mod:`ui.backend.services.citations`)."""
+    lines = render_reference_lines(references)
+    if not lines:
         return "(no citations resolved in the summary)"
-    lines = []
-    for r in references:
-        meta = ", ".join(str(x) for x in (r.get("organization"), r.get("year")) if x)
-        suffix = f" ({meta})" if meta else ""
-        title = r.get("title") or r.get("doc_id") or "Unknown"
-        lines.append(f"[{r.get('number')}] {title}{suffix}")
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Description

In regular search, the AI summary's **References** list groups citations by document and shows each cited chunk's page number (e.g. `Title, Org, Year | [1] p.5 [3] p.12`). The **evaluation harness** produced a different References list: it re-implemented the `[N]` citation resolution in Python and dropped both the page numbers and the group-by-document layout. So the AI summary scored/compared by the harness differed from what a user actually sees in search.

Root cause: the search-side reference rendering lives in the **frontend** (`ui/frontend/src/utils/citations.ts` + `AiSummaryReferences.tsx`), while the harness re-implemented it in **Python** (`ui/backend/services/test_runner.py`) and never read `page_num`. The two drifted.

## What changed

- **New `ui/backend/services/citations.py`** — a server-side Python mirror of the frontend citation logic: `group_references` + `render_reference_lines`, producing the same `Title, Org, Year | [1] p.5 [3] p.12` layout. Page suffixes appear only for a truthy page number, matching the frontend's truthiness check (an unknown page of `0` shows nothing).
- **`ui/backend/services/test_runner.py`** — `_build_references` now carries `page_num`; both `_references_text` (the stored/compared summary) and `_format_judge_references` (the LLM-judge context) render via the shared module.

### Deliberate parity notes
- The rendered references now drop the bare `— url` and group by document to match the search UI. The structured `references` field keeps `url` (still used for links in the Experiment Detail screen), so nothing is lost there.
- Inline `[N]` markers in the summary **body** are left as the model emitted them (not renumbered to `1..k` like the frontend), so the References keep matching numbers and the judged summary text is unchanged apart from the References block.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Performance improvement

## Testing
- [x] `docker compose exec -T pipeline pytest tests/unit/test_test_runner.py tests/unit/test_citations.py` → **46 passed**
- [x] New unit tests: page numbers rendered, page-per-document ("ranges"), page omitted when `0`/missing, grouping order, judge-context format, and the new `citations` module.
- [x] Full `pytest tests/unit/` — all pass except pre-existing, unrelated failures in `test_summarize` / `test_tagger_taxonomy` / `test_toc_classification` / `test_a2a_task_handler` (verified identical on the clean base branch, i.e. not introduced here).
- [x] `pre-commit run --files ...` → black, isort, flake8, mypy, bandit, detect-secrets, code-metrics all pass.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] New tests added for new functionality
- [x] No breaking changes to the structured output

Refs 00393

🤖 Generated with [Claude Code](https://claude.com/claude-code)