### PR TITLE
ci: pin hadolint docker image to v2.12.0 (cherry-pick to rc/v1.6.0)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint-docker
+        # The upstream hook entry has no image tag, so it silently floats to
+        # ghcr.io latest regardless of rev; pin the image to match rev.
+        entry: ghcr.io/hadolint/hadolint:v2.12.0 hadolint
         args: ['--ignore', 'DL3007', '--ignore', 'DL3008', '--ignore', 'DL3013', '--ignore', 'DL3015', '--ignore', 'DL3018', '--ignore', 'DL3042', '--ignore', 'DL3059']
 
   # Secret scanning with detect-secrets


### PR DESCRIPTION
Cherry-pick of 4c39a84 from main. The upstream hadolint-docker pre-commit hook entry has no image tag, so it floats to ghcr.io latest; hadolint 2.15.0 introduced DL3064, which fails the code-quality job on every branch based on rc/v1.6.0 — including all open Dependabot PRs. Pinning the image to v2.12.0 (matching the declared rev) fixes CI for the 11 currently failing Dependabot PRs once they rebase.