### PR TITLE
ci: point dependabot target-branch at rc/v1.6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "rc/v1.6.0"
+    target-branch: "rc/v1.6.1"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -21,7 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.6.0"
+    target-branch: "rc/v1.6.1"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -36,7 +36,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "rc/v1.6.0"
+    target-branch: "rc/v1.6.1"
     schedule:
       interval: "monthly"
     labels:
@@ -49,7 +49,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
-    target-branch: "rc/v1.6.0"
+    target-branch: "rc/v1.6.1"
     schedule:
       interval: "monthly"
     labels:
@@ -62,7 +62,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.6.0"
+    target-branch: "rc/v1.6.1"
     schedule:
       interval: "monthly"
     labels:
@@ -75,7 +75,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "rc/v1.6.0"
+    target-branch: "rc/v1.6.1"
     schedule:
       interval: "monthly"
     labels:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -89,6 +89,9 @@ repos:
     rev: v2.12.0
     hooks:
       - id: hadolint-docker
+        # The upstream hook entry has no image tag, so it silently floats to
+        # ghcr.io latest regardless of rev; pin the image to match rev.
+        entry: ghcr.io/hadolint/hadolint:v2.12.0 hadolint
         args: ['--ignore', 'DL3007', '--ignore', 'DL3008', '--ignore', 'DL3013', '--ignore', 'DL3015', '--ignore', 'DL3018', '--ignore', 'DL3042', '--ignore', 'DL3059']
 
   # Secret scanning with detect-secrets


### PR DESCRIPTION
rc/v1.6.0 has been superseded by rc/v1.6.1; update all six dependabot update blocks so new dependency PRs target the current release candidate branch. Open Dependabot PRs #407 and #414 have been retargeted to rc/v1.6.1 manually.