### PR TITLE
feat(brief): Brief Central — server-side briefs, sharing, templates and voice & tone profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,9 @@ python scripts/sync/db/sync_backup_to_remote.py \
 - **NEVER manually update `alembic_version`** or any Alembic internal tables. Direct `UPDATE alembic_version ...` only masks the underlying bug — it does not fix it. If a migration state is broken, diagnose the root cause and fix it properly: create a corrective migration, or surface the problem to the user so it can be resolved correctly.
 - **NEVER rename a migration's `revision` ID after it has been applied to any environment.** Doing so breaks every existing DB that has the old ID stored. If a revision ID is wrong (e.g., too long for varchar(32)), fix it before the migration is ever run anywhere — not after.
 
+### UI Style
+- **Never use side moustaches (left/side accent bars) on highlighted or active items** — e.g. `border-left` or inset box-shadow stripes on nav rows, list items, or cards. Indicate the active state with a background tint and/or type weight instead.
+
 ### Code Quality
 - **NEVER use `noqa`, `type: ignore`, or similar suppressions to bypass pre-commit hooks or linters.** Fix the actual issue instead. Only use suppressions if explicitly requested by the user.
 - **NEVER code fallbacks or graceful degradation unless explicitly requested.** If a dependency or feature is required, fail hard and loud. Silent fallbacks hide bugs.

--- a/alembic/versions/0030_add_brief_central.py
+++ b/alembic/versions/0030_add_brief_central.py
@@ -1,0 +1,185 @@
+"""Add Brief Central tables: briefs, brief_templates, voice_profiles, brief_shares.
+
+Briefs move from browser localStorage to server-side storage so they can be
+shared (viewer-only) with other users and groups. Templates save a heading
+structure for reuse; voice profiles hold style instructions applied when
+sections are written.
+
+Revision ID: 0030_add_brief_central
+Revises: 0029_add_test_runs
+Create Date: 2026-08-09
+
+Note: the revision ID is intentionally kept under 32 characters to fit the
+stock ``alembic_version.version_num`` column type (``varchar(32)``).
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+revision = "0030_add_brief_central"
+down_revision = "0029_add_test_runs"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "voice_profiles",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("instructions", sa.Text, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_voice_profiles_user_id", "voice_profiles", ["user_id"])
+
+    op.create_table(
+        "brief_templates",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("headings", JSONB, nullable=False),
+        sa.Column(
+            "with_text", sa.Boolean, nullable=False, server_default=sa.text("false")
+        ),
+        sa.Column("use_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_brief_templates_user_id", "brief_templates", ["user_id"])
+
+    op.create_table(
+        "briefs",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("title", sa.String(500), nullable=False),
+        sa.Column("query", sa.Text, nullable=True),
+        sa.Column("data_source", sa.String(255), nullable=True),
+        sa.Column(
+            "voice_profile_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("voice_profiles.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("content", JSONB, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_briefs_user_id", "briefs", ["user_id"])
+
+    op.create_table(
+        "brief_shares",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "brief_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("briefs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "shared_user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "group_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("user_groups.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "(shared_user_id IS NOT NULL) OR (group_id IS NOT NULL)",
+            name="ck_brief_shares_target",
+        ),
+        sa.UniqueConstraint("brief_id", "shared_user_id", name="uq_brief_shares_user"),
+        sa.UniqueConstraint("brief_id", "group_id", name="uq_brief_shares_group"),
+    )
+    op.create_index("ix_brief_shares_brief_id", "brief_shares", ["brief_id"])
+    op.create_index(
+        "ix_brief_shares_shared_user_id", "brief_shares", ["shared_user_id"]
+    )
+    op.create_index("ix_brief_shares_group_id", "brief_shares", ["group_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("brief_shares")
+    op.drop_table("briefs")
+    op.drop_table("brief_templates")
+    op.drop_table("voice_profiles")

--- a/prompts/brief_revise_user.j2
+++ b/prompts/brief_revise_user.j2
@@ -3,6 +3,10 @@
     that the model would echo back into the revised section. -#}
 {% autoescape false -%}
 Instruction: {{ instruction }}
+{% if voice_instructions %}
+Voice & tone profile (apply to any text you rewrite; do not rewrite untouched text just to restyle it):
+{{ voice_instructions }}
+{% endif %}
 
 Current section markdown:
 """

--- a/tests/unit/test_brief_central.py
+++ b/tests/unit/test_brief_central.py
@@ -1,0 +1,207 @@
+"""Unit tests for Brief Central schemas, route helpers and prompt injection."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from ui.backend.auth.schemas import (
+    BriefCreate,
+    BriefShareCreate,
+    BriefTemplateCreate,
+    BriefTemplateHeading,
+    BriefUpdate,
+    VoiceProfileCreate,
+    VoiceProfileUpdate,
+)
+from ui.backend.routes.brief_central import _owner_name, _to_list_item
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Voice profile schemas
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceProfileSchemas:
+    """Validation rules for voice & tone profiles."""
+
+    def test_valid_create(self):
+        vp = VoiceProfileCreate(
+            name="Policy brief",
+            description="Measured register",
+            instructions="Write in a measured, evaluative register.",
+        )
+        assert vp.name == "Policy brief"
+
+    def test_create_requires_name(self):
+        with pytest.raises(ValidationError):
+            VoiceProfileCreate(name="", instructions="Some instructions")
+
+    def test_create_requires_instructions(self):
+        with pytest.raises(ValidationError):
+            VoiceProfileCreate(name="Name", instructions="")
+
+    def test_instructions_length_capped(self):
+        with pytest.raises(ValidationError):
+            VoiceProfileCreate(name="Name", instructions="x" * 10_001)
+
+    def test_update_all_optional(self):
+        upd = VoiceProfileUpdate()
+        assert upd.name is None
+        assert upd.instructions is None
+
+
+# ---------------------------------------------------------------------------
+# Template schemas
+# ---------------------------------------------------------------------------
+
+
+class TestBriefTemplateSchemas:
+    """Validation rules for brief templates."""
+
+    def test_valid_create(self):
+        tpl = BriefTemplateCreate(
+            name="Evaluation synthesis",
+            headings=[
+                BriefTemplateHeading(title="Context and scope"),
+                BriefTemplateHeading(title="Findings", sub=True),
+            ],
+        )
+        assert tpl.with_text is False
+        assert tpl.headings[0].sub is False
+        assert tpl.headings[1].sub is True
+
+    def test_headings_required_nonempty(self):
+        with pytest.raises(ValidationError):
+            BriefTemplateCreate(name="Empty", headings=[])
+
+    def test_heading_title_required(self):
+        with pytest.raises(ValidationError):
+            BriefTemplateCreate(name="Bad", headings=[BriefTemplateHeading(title="")])
+
+    def test_headings_capped_at_100(self):
+        headings = [BriefTemplateHeading(title=f"H{i}") for i in range(101)]
+        with pytest.raises(ValidationError):
+            BriefTemplateCreate(name="Too many", headings=headings)
+
+    def test_heading_text_optional(self):
+        heading = BriefTemplateHeading(title="With text", text="Saved draft text.")
+        assert heading.text == "Saved draft text."
+
+
+# ---------------------------------------------------------------------------
+# Brief schemas
+# ---------------------------------------------------------------------------
+
+
+class TestBriefSchemas:
+    """Validation rules for brief create/update payloads."""
+
+    def test_valid_create(self):
+        brief = BriefCreate(
+            title="Cash transfers",
+            query="Effectiveness of cash",
+            data_source="wfp",
+            content={"sections": [], "sourceCount": 0},
+        )
+        assert brief.voice_profile_id is None
+        assert brief.content["sections"] == []
+
+    def test_title_required(self):
+        with pytest.raises(ValidationError):
+            BriefCreate(title="", content={})
+
+    def test_content_size_capped(self):
+        # Content shares the saved-research JSONB cap (10 MB serialised).
+        with pytest.raises(ValidationError):
+            BriefCreate(title="Huge", content={"blob": "x" * 10_000_001})
+
+    def test_update_partial(self):
+        upd = BriefUpdate(title="New title")
+        assert upd.content is None
+        assert upd.voice_profile_id is None
+
+    def test_share_target_required(self):
+        with pytest.raises(ValidationError):
+            BriefShareCreate(target="")
+
+
+# ---------------------------------------------------------------------------
+# Route helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeUser:
+    def __init__(self, full_name, email):
+        self.full_name = full_name
+        self.email = email
+
+
+class _FakeBrief:
+    def __init__(self, content):
+        self.id = uuid.uuid4()
+        self.title = "T"
+        self.query = "Q"
+        self.data_source = "wfp"
+        self.voice_profile_id = None
+        self.content = content
+        self.created_at = datetime.now(timezone.utc)
+        self.updated_at = datetime.now(timezone.utc)
+
+
+class TestRouteHelpers:
+    """Pure helpers in routes/brief_central.py."""
+
+    def test_owner_name_prefers_full_name(self):
+        assert _owner_name(_FakeUser("Priya Raman", "p@x.org")) == "Priya Raman"
+
+    def test_owner_name_falls_back_to_email(self):
+        assert _owner_name(_FakeUser(None, "p@x.org")) == "p@x.org"
+
+    def test_to_list_item_counts_sections_and_sources(self):
+        brief = _FakeBrief({"sections": [{}, {}, {}], "sourceCount": 41})
+        item = _to_list_item(brief, "Owner", 2)
+        assert item.section_count == 3
+        assert item.source_count == 41
+        assert item.owner_name == "Owner"
+        assert item.share_count == 2
+
+    def test_to_list_item_handles_empty_content(self):
+        item = _to_list_item(_FakeBrief({}), None, 0)
+        assert item.section_count == 0
+        assert item.source_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Voice injection into the revise prompt
+# ---------------------------------------------------------------------------
+
+
+class TestRevisePromptVoiceInjection:
+    """The brief_revise_user.j2 template renders voice instructions when given."""
+
+    @staticmethod
+    def _render(**kwargs):
+        from ui.backend.services.llm_service import _brief_revise_user_template
+
+        return _brief_revise_user_template.render(**kwargs)
+
+    def test_voice_block_present(self):
+        prompt = self._render(
+            instruction="Tighten the opening.",
+            content="Some section text.",
+            voice_instructions="Short sentences. Active voice.",
+        )
+        assert "Voice & tone profile" in prompt
+        assert "Short sentences. Active voice." in prompt
+
+    def test_voice_block_absent_when_none(self):
+        prompt = self._render(
+            instruction="Tighten the opening.",
+            content="Some section text.",
+            voice_instructions=None,
+        )
+        assert "Voice & tone profile" not in prompt

--- a/ui/backend/auth/models.py
+++ b/ui/backend/auth/models.py
@@ -246,6 +246,134 @@ class SavedResearch(Base):
     )
 
 
+class VoiceProfile(Base):
+    """User-owned voice & tone profile applied when brief sections are written."""
+
+    __tablename__ = "voice_profiles"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    instructions: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class BriefTemplate(Base):
+    """User-owned brief template: a saved heading structure (optionally with text)."""
+
+    __tablename__ = "brief_templates"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # List of {"title": str, "sub": bool, "text": str | None}
+    headings: Mapped[list] = mapped_column(JSONB, nullable=False)
+    with_text: Mapped[bool] = mapped_column(
+        Boolean, default=False, server_default="false"
+    )
+    use_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+
+class Brief(Base):
+    """User-owned evidence brief (sections, references and metadata)."""
+
+    __tablename__ = "briefs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    query: Mapped[str | None] = mapped_column(Text, nullable=True)
+    data_source: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    voice_profile_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("voice_profiles.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # Full SavedBrief payload from the frontend (sections, source counts, ...)
+    content: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    shares: Mapped[list["BriefShare"]] = relationship(
+        "BriefShare", back_populates="brief", cascade="all, delete-orphan"
+    )
+
+
+class BriefShare(Base):
+    """Viewer-only grant on a brief for a user or a group."""
+
+    __tablename__ = "brief_shares"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    brief_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("briefs.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    shared_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user_groups.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    brief: Mapped["Brief"] = relationship("Brief", back_populates="shares")
+
+
 class ConversationThread(Base):
     """Research assistant conversation thread."""
 

--- a/ui/backend/auth/schemas.py
+++ b/ui/backend/auth/schemas.py
@@ -473,6 +473,164 @@ class SavedResearchListItem(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Brief Central schemas (briefs, templates, voice profiles, shares)
+# ---------------------------------------------------------------------------
+
+
+class VoiceProfileCreate(BaseModel):
+    """Payload for creating a voice & tone profile."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=1000)
+    instructions: str = Field(..., min_length=1, max_length=10_000)
+
+
+class VoiceProfileUpdate(BaseModel):
+    """Payload for updating a voice & tone profile."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=1000)
+    instructions: Optional[str] = Field(None, min_length=1, max_length=10_000)
+
+
+class VoiceProfileRead(BaseModel):
+    """Voice & tone profile returned by read endpoints."""
+
+    id: uuid.UUID
+    name: str
+    description: Optional[str] = None
+    instructions: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BriefTemplateHeading(BaseModel):
+    """One heading in a brief template."""
+
+    title: str = Field(..., min_length=1, max_length=500)
+    sub: bool = False
+    text: Optional[str] = Field(None, max_length=100_000)
+
+
+class BriefTemplateCreate(BaseModel):
+    """Payload for creating a brief template."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=1000)
+    headings: List[BriefTemplateHeading] = Field(..., min_length=1, max_length=100)
+    with_text: bool = False
+
+
+class BriefTemplateUpdate(BaseModel):
+    """Payload for updating a brief template."""
+
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    description: Optional[str] = Field(None, max_length=1000)
+    headings: Optional[List[BriefTemplateHeading]] = Field(
+        None, min_length=1, max_length=100
+    )
+    with_text: Optional[bool] = None
+
+
+class BriefTemplateRead(BaseModel):
+    """Brief template returned by read endpoints."""
+
+    id: uuid.UUID
+    name: str
+    description: Optional[str] = None
+    headings: List[BriefTemplateHeading]
+    with_text: bool
+    use_count: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BriefCreate(BaseModel):
+    """Payload for saving a brief."""
+
+    title: str = Field(..., min_length=1, max_length=500)
+    query: Optional[str] = Field(None, max_length=5000)
+    data_source: Optional[str] = Field(None, max_length=255)
+    voice_profile_id: Optional[uuid.UUID] = None
+    content: dict
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, v: dict) -> dict:
+        return _validate_research_jsonb(v)
+
+
+class BriefUpdate(BaseModel):
+    """Payload for updating a brief."""
+
+    title: Optional[str] = Field(None, min_length=1, max_length=500)
+    query: Optional[str] = Field(None, max_length=5000)
+    voice_profile_id: Optional[uuid.UUID] = None
+    content: Optional[dict] = None
+
+    @field_validator("content")
+    @classmethod
+    def validate_content(cls, v: Optional[dict]) -> Optional[dict]:
+        return _validate_research_jsonb(v)
+
+
+class BriefShareTarget(BaseModel):
+    """One person or group a brief is shared with."""
+
+    id: uuid.UUID
+    name: str
+    kind: str  # the user's email, or "Group · N members"
+    is_group: bool
+
+
+class BriefRead(BaseModel):
+    """Full brief returned by read endpoints."""
+
+    id: uuid.UUID
+    user_id: uuid.UUID
+    title: str
+    query: Optional[str] = None
+    data_source: Optional[str] = None
+    voice_profile_id: Optional[uuid.UUID] = None
+    content: dict
+    owner_name: Optional[str] = None
+    can_edit: bool = True
+    shared_with: List[BriefShareTarget] = []
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BriefListItem(BaseModel):
+    """Compact brief for card/list views (omits full content)."""
+
+    id: uuid.UUID
+    title: str
+    query: Optional[str] = None
+    data_source: Optional[str] = None
+    voice_profile_id: Optional[uuid.UUID] = None
+    section_count: int = 0
+    source_count: int = 0
+    owner_name: Optional[str] = None
+    share_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BriefShareCreate(BaseModel):
+    """Add a viewer (user by email, or group by name) to a brief."""
+
+    target: str = Field(..., min_length=1, max_length=320)
+
+
+# ---------------------------------------------------------------------------
 # API key schemas
 # ---------------------------------------------------------------------------
 

--- a/ui/backend/main.py
+++ b/ui/backend/main.py
@@ -853,6 +853,7 @@ if USER_MODULE:
 
     from ui.backend.routes import activity as activity_routes
     from ui.backend.routes import api_keys as api_keys_routes
+    from ui.backend.routes import brief_central as brief_central_routes
     from ui.backend.routes import llm_usage as llm_usage_routes
     from ui.backend.routes import mcp_audit as mcp_audit_routes
     from ui.backend.routes import ratings as ratings_routes
@@ -863,6 +864,7 @@ if USER_MODULE:
     app.include_router(ratings_routes.router, prefix="/ratings", tags=["ratings"])
     app.include_router(activity_routes.router, prefix="/activity", tags=["activity"])
     app.include_router(research_routes.router, prefix="/research", tags=["research"])
+    app.include_router(brief_central_routes.router, tags=["brief-central"])
     app.include_router(api_keys_routes.router, prefix="/api-keys", tags=["api-keys"])
     app.include_router(mcp_audit_routes.router, prefix="/mcp-audit", tags=["mcp-audit"])
     app.include_router(llm_usage_routes.router, prefix="/llm-usage", tags=["llm-usage"])

--- a/ui/backend/routes/brief.py
+++ b/ui/backend/routes/brief.py
@@ -157,6 +157,7 @@ async def revise_section(
             content=content,
             instruction=instruction,
             model_key=model_key,
+            voice_instructions=(body.voice_instructions or "").strip() or None,
         )
         return BriefReviseResponse(content=revised)
     except Exception:

--- a/ui/backend/routes/brief_central.py
+++ b/ui/backend/routes/brief_central.py
@@ -1,0 +1,581 @@
+"""Brief Central routes — briefs, sharing, templates and voice profiles.
+
+Briefs are user-owned. Sharing is viewer-only: a share row grants read access
+to a single user (matched by email) or to every member of a group (matched by
+group name). Templates and voice profiles are private to their owner.
+"""
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ui.backend.auth.db import get_async_session
+from ui.backend.auth.models import (
+    Brief,
+    BriefShare,
+    BriefTemplate,
+    User,
+    UserGroup,
+    UserGroupMember,
+    VoiceProfile,
+)
+from ui.backend.auth.schemas import (
+    BriefCreate,
+    BriefListItem,
+    BriefRead,
+    BriefShareCreate,
+    BriefShareTarget,
+    BriefTemplateCreate,
+    BriefTemplateRead,
+    BriefTemplateUpdate,
+    BriefUpdate,
+    VoiceProfileCreate,
+    VoiceProfileRead,
+    VoiceProfileUpdate,
+)
+from ui.backend.auth.users import current_active_user
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_BRIEF_NOT_FOUND = "Brief not found"
+_TEMPLATE_NOT_FOUND = "Template not found"
+_PROFILE_NOT_FOUND = "Voice profile not found"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _owner_name(user: User) -> str:
+    """Display name for a brief owner."""
+    return user.full_name or user.email
+
+
+async def _user_group_ids(session: AsyncSession, user_id: uuid.UUID) -> list[uuid.UUID]:
+    """IDs of every group the user belongs to."""
+    result = await session.execute(
+        select(UserGroupMember.group_id).where(UserGroupMember.user_id == user_id)
+    )
+    return [row[0] for row in result.all()]
+
+
+async def _get_owned_brief(
+    session: AsyncSession, brief_id: uuid.UUID, user: User
+) -> Brief:
+    """Load a brief owned by *user* or raise 404."""
+    result = await session.execute(
+        select(Brief).where(Brief.id == brief_id, Brief.user_id == user.id)
+    )
+    brief = result.scalars().first()
+    if not brief:
+        raise HTTPException(status_code=404, detail=_BRIEF_NOT_FOUND)
+    return brief
+
+
+async def _get_viewable_brief(
+    session: AsyncSession, brief_id: uuid.UUID, user: User
+) -> tuple[Brief, bool]:
+    """Load a brief the user owns or was granted view access to.
+
+    Returns (brief, can_edit). Raises 404 when the brief does not exist or the
+    user has no access — the two cases are indistinguishable on purpose.
+    """
+    result = await session.execute(select(Brief).where(Brief.id == brief_id))
+    brief = result.scalars().first()
+    if not brief:
+        raise HTTPException(status_code=404, detail=_BRIEF_NOT_FOUND)
+    if brief.user_id == user.id:
+        return brief, True
+    group_ids = await _user_group_ids(session, user.id)
+    condition = BriefShare.shared_user_id == user.id
+    if group_ids:
+        condition = condition | BriefShare.group_id.in_(group_ids)
+    share_rows = await session.execute(
+        select(BriefShare.id).where(BriefShare.brief_id == brief_id, condition)
+    )
+    if not share_rows.scalars().first():
+        raise HTTPException(status_code=404, detail=_BRIEF_NOT_FOUND)
+    return brief, False
+
+
+async def _share_targets(
+    session: AsyncSession, brief_id: uuid.UUID
+) -> list[BriefShareTarget]:
+    """Resolve share rows to display targets."""
+    result = await session.execute(
+        select(BriefShare).where(BriefShare.brief_id == brief_id)
+    )
+    targets: list[BriefShareTarget] = []
+    for share in result.scalars().all():
+        if share.shared_user_id:
+            user_row = await session.get(User, share.shared_user_id)
+            if user_row:
+                targets.append(
+                    BriefShareTarget(
+                        id=share.id,
+                        name=user_row.full_name or user_row.email,
+                        kind=user_row.email,
+                        is_group=False,
+                    )
+                )
+        elif share.group_id:
+            group = await session.get(UserGroup, share.group_id)
+            if group:
+                member_count = len(group.members)
+                targets.append(
+                    BriefShareTarget(
+                        id=share.id,
+                        name=group.name,
+                        kind=f"Group · {member_count} members",
+                        is_group=True,
+                    )
+                )
+    return targets
+
+
+async def _to_brief_read(
+    session: AsyncSession, brief: Brief, can_edit: bool
+) -> BriefRead:
+    """Build the full read model, including owner name and share targets."""
+    owner = await session.get(User, brief.user_id)
+    return BriefRead(
+        id=brief.id,
+        user_id=brief.user_id,
+        title=brief.title,
+        query=brief.query,
+        data_source=brief.data_source,
+        voice_profile_id=brief.voice_profile_id,
+        content=brief.content,
+        owner_name=_owner_name(owner) if owner else None,
+        can_edit=can_edit,
+        shared_with=await _share_targets(session, brief.id) if can_edit else [],
+        created_at=brief.created_at,
+        updated_at=brief.updated_at,
+    )
+
+
+def _to_list_item(
+    brief: Brief, owner_name: str | None, share_count: int
+) -> BriefListItem:
+    """Compact card model for list views."""
+    content = brief.content or {}
+    sections = content.get("sections") or []
+    return BriefListItem(
+        id=brief.id,
+        title=brief.title,
+        query=brief.query,
+        data_source=brief.data_source,
+        voice_profile_id=brief.voice_profile_id,
+        section_count=len(sections),
+        source_count=content.get("sourceCount") or 0,
+        owner_name=owner_name,
+        share_count=share_count,
+        created_at=brief.created_at,
+        updated_at=brief.updated_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Briefs
+# ---------------------------------------------------------------------------
+
+
+@router.post("/briefs/", response_model=BriefRead, tags=["briefs"])
+async def create_brief(
+    body: BriefCreate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Save a new brief."""
+    brief = Brief(
+        user_id=user.id,
+        title=body.title,
+        query=body.query,
+        data_source=body.data_source,
+        voice_profile_id=body.voice_profile_id,
+        content=body.content,
+    )
+    session.add(brief)
+    await session.commit()
+    await session.refresh(brief)
+    return await _to_brief_read(session, brief, can_edit=True)
+
+
+@router.get("/briefs/", tags=["briefs"])
+async def list_briefs(
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """List the current user's briefs (compact, newest first)."""
+    result = await session.execute(
+        select(Brief).where(Brief.user_id == user.id).order_by(Brief.updated_at.desc())
+    )
+    briefs = result.scalars().all()
+    counts = await session.execute(
+        select(BriefShare.brief_id, func.count(BriefShare.id))
+        .where(BriefShare.brief_id.in_([b.id for b in briefs]))
+        .group_by(BriefShare.brief_id)
+    )
+    count_map: dict[uuid.UUID, int] = {row[0]: row[1] for row in counts.all()}
+    return [_to_list_item(b, None, count_map.get(b.id, 0)) for b in briefs]
+
+
+@router.get("/briefs/shared", tags=["briefs"])
+async def list_shared_briefs(
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """List briefs shared with the current user (directly or via a group)."""
+    group_ids = await _user_group_ids(session, user.id)
+    condition = BriefShare.shared_user_id == user.id
+    if group_ids:
+        condition = condition | BriefShare.group_id.in_(group_ids)
+    result = await session.execute(
+        select(Brief)
+        .join(BriefShare, BriefShare.brief_id == Brief.id)
+        .where(condition, Brief.user_id != user.id)
+        .order_by(Brief.updated_at.desc())
+        .distinct()
+    )
+    items = []
+    for brief in result.scalars().all():
+        owner = await session.get(User, brief.user_id)
+        items.append(_to_list_item(brief, _owner_name(owner) if owner else None, 0))
+    return items
+
+
+@router.get("/briefs/{brief_id}", response_model=BriefRead, tags=["briefs"])
+async def get_brief(
+    brief_id: uuid.UUID,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Load a single brief the user owns or can view."""
+    brief, can_edit = await _get_viewable_brief(session, brief_id, user)
+    return await _to_brief_read(session, brief, can_edit)
+
+
+@router.put("/briefs/{brief_id}", response_model=BriefRead, tags=["briefs"])
+async def update_brief(
+    brief_id: uuid.UUID,
+    body: BriefUpdate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Update a brief (owner only)."""
+    brief = await _get_owned_brief(session, brief_id, user)
+    if body.title is not None:
+        brief.title = body.title
+    if body.query is not None:
+        brief.query = body.query
+    if body.voice_profile_id is not None:
+        brief.voice_profile_id = body.voice_profile_id
+    if body.content is not None:
+        brief.content = body.content
+    await session.commit()
+    await session.refresh(brief)
+    return await _to_brief_read(session, brief, can_edit=True)
+
+
+@router.delete("/briefs/{brief_id}", status_code=204, tags=["briefs"])
+async def delete_brief(
+    brief_id: uuid.UUID,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Delete a brief (owner only)."""
+    brief = await _get_owned_brief(session, brief_id, user)
+    await session.delete(brief)
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Shares
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_share_target(
+    session: AsyncSession, target: str
+) -> tuple[uuid.UUID | None, uuid.UUID | None]:
+    """Resolve a share target string to (user_id, group_id).
+
+    An address containing "@" is matched against user emails; anything else is
+    matched against group names. Unknown targets raise 404.
+    """
+    if "@" in target:
+        result = await session.execute(
+            select(User).where(func.lower(User.email) == target.lower())
+        )
+        matched_user = result.scalars().first()
+        if not matched_user:
+            raise HTTPException(
+                status_code=404, detail="No user with that email address"
+            )
+        return matched_user.id, None
+    result = await session.execute(
+        select(UserGroup).where(func.lower(UserGroup.name) == target.lower())
+    )
+    group = result.scalars().first()
+    if not group:
+        raise HTTPException(status_code=404, detail="No group with that name")
+    return None, group.id
+
+
+@router.post("/briefs/{brief_id}/shares", response_model=BriefRead, tags=["briefs"])
+async def add_brief_share(
+    brief_id: uuid.UUID,
+    body: BriefShareCreate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Grant viewer access to a user (by email) or group (by name)."""
+    brief = await _get_owned_brief(session, brief_id, user)
+    shared_user_id, group_id = await _resolve_share_target(session, body.target.strip())
+    if shared_user_id == user.id:
+        raise HTTPException(status_code=400, detail="You already own this brief")
+    existing = await session.execute(
+        select(BriefShare).where(
+            BriefShare.brief_id == brief.id,
+            BriefShare.shared_user_id == shared_user_id,
+            BriefShare.group_id == group_id,
+        )
+    )
+    if existing.scalars().first():
+        raise HTTPException(status_code=409, detail="Already shared")
+    session.add(
+        BriefShare(brief_id=brief.id, shared_user_id=shared_user_id, group_id=group_id)
+    )
+    await session.commit()
+    await session.refresh(brief)
+    return await _to_brief_read(session, brief, can_edit=True)
+
+
+@router.delete("/briefs/{brief_id}/shares/{share_id}", status_code=204, tags=["briefs"])
+async def remove_brief_share(
+    brief_id: uuid.UUID,
+    share_id: uuid.UUID,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Revoke a share (owner only)."""
+    brief = await _get_owned_brief(session, brief_id, user)
+    result = await session.execute(
+        select(BriefShare).where(
+            BriefShare.id == share_id, BriefShare.brief_id == brief.id
+        )
+    )
+    share = result.scalars().first()
+    if not share:
+        raise HTTPException(status_code=404, detail="Share not found")
+    await session.delete(share)
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Templates
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/brief-templates/", response_model=BriefTemplateRead, tags=["brief-templates"]
+)
+async def create_template(
+    body: BriefTemplateCreate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Create a brief template."""
+    template = BriefTemplate(
+        user_id=user.id,
+        name=body.name,
+        description=body.description,
+        headings=[h.model_dump() for h in body.headings],
+        with_text=body.with_text,
+    )
+    session.add(template)
+    await session.commit()
+    await session.refresh(template)
+    return BriefTemplateRead.model_validate(template)
+
+
+@router.get("/brief-templates/", tags=["brief-templates"])
+async def list_templates(
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """List the current user's templates."""
+    result = await session.execute(
+        select(BriefTemplate)
+        .where(BriefTemplate.user_id == user.id)
+        .order_by(BriefTemplate.updated_at.desc())
+    )
+    return [BriefTemplateRead.model_validate(t) for t in result.scalars().all()]
+
+
+async def _get_owned_template(
+    session: AsyncSession, template_id: uuid.UUID, user: User
+) -> BriefTemplate:
+    """Load a template owned by *user* or raise 404."""
+    result = await session.execute(
+        select(BriefTemplate).where(
+            BriefTemplate.id == template_id, BriefTemplate.user_id == user.id
+        )
+    )
+    template = result.scalars().first()
+    if not template:
+        raise HTTPException(status_code=404, detail=_TEMPLATE_NOT_FOUND)
+    return template
+
+
+@router.put(
+    "/brief-templates/{template_id}",
+    response_model=BriefTemplateRead,
+    tags=["brief-templates"],
+)
+async def update_template(
+    template_id: uuid.UUID,
+    body: BriefTemplateUpdate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Update a template (owner only)."""
+    template = await _get_owned_template(session, template_id, user)
+    if body.name is not None:
+        template.name = body.name
+    if body.description is not None:
+        template.description = body.description
+    if body.headings is not None:
+        template.headings = [h.model_dump() for h in body.headings]
+    if body.with_text is not None:
+        template.with_text = body.with_text
+    await session.commit()
+    await session.refresh(template)
+    return BriefTemplateRead.model_validate(template)
+
+
+@router.post(
+    "/brief-templates/{template_id}/use",
+    response_model=BriefTemplateRead,
+    tags=["brief-templates"],
+)
+async def use_template(
+    template_id: uuid.UUID,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Record one use of a template and return it."""
+    template = await _get_owned_template(session, template_id, user)
+    template.use_count = (template.use_count or 0) + 1
+    await session.commit()
+    await session.refresh(template)
+    return BriefTemplateRead.model_validate(template)
+
+
+@router.delete(
+    "/brief-templates/{template_id}", status_code=204, tags=["brief-templates"]
+)
+async def delete_template(
+    template_id: uuid.UUID,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Delete a template (owner only)."""
+    template = await _get_owned_template(session, template_id, user)
+    await session.delete(template)
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Voice profiles
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/voice-profiles/", response_model=VoiceProfileRead, tags=["voice-profiles"]
+)
+async def create_voice_profile(
+    body: VoiceProfileCreate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Create a voice & tone profile."""
+    profile = VoiceProfile(
+        user_id=user.id,
+        name=body.name,
+        description=body.description,
+        instructions=body.instructions,
+    )
+    session.add(profile)
+    await session.commit()
+    await session.refresh(profile)
+    return VoiceProfileRead.model_validate(profile)
+
+
+@router.get("/voice-profiles/", tags=["voice-profiles"])
+async def list_voice_profiles(
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """List the current user's voice profiles."""
+    result = await session.execute(
+        select(VoiceProfile)
+        .where(VoiceProfile.user_id == user.id)
+        .order_by(VoiceProfile.created_at.asc())
+    )
+    return [VoiceProfileRead.model_validate(p) for p in result.scalars().all()]
+
+
+async def _get_owned_profile(
+    session: AsyncSession, profile_id: uuid.UUID, user: User
+) -> VoiceProfile:
+    """Load a voice profile owned by *user* or raise 404."""
+    result = await session.execute(
+        select(VoiceProfile).where(
+            VoiceProfile.id == profile_id, VoiceProfile.user_id == user.id
+        )
+    )
+    profile = result.scalars().first()
+    if not profile:
+        raise HTTPException(status_code=404, detail=_PROFILE_NOT_FOUND)
+    return profile
+
+
+@router.put(
+    "/voice-profiles/{profile_id}",
+    response_model=VoiceProfileRead,
+    tags=["voice-profiles"],
+)
+async def update_voice_profile(
+    profile_id: uuid.UUID,
+    body: VoiceProfileUpdate,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Update a voice profile (owner only)."""
+    profile = await _get_owned_profile(session, profile_id, user)
+    if body.name is not None:
+        profile.name = body.name
+    if body.description is not None:
+        profile.description = body.description
+    if body.instructions is not None:
+        profile.instructions = body.instructions
+    await session.commit()
+    await session.refresh(profile)
+    return VoiceProfileRead.model_validate(profile)
+
+
+@router.delete("/voice-profiles/{profile_id}", status_code=204, tags=["voice-profiles"])
+async def delete_voice_profile(
+    profile_id: uuid.UUID,
+    user: User = Depends(current_active_user),
+    session: AsyncSession = Depends(get_async_session),
+):
+    """Delete a voice profile (owner only)."""
+    profile = await _get_owned_profile(session, profile_id, user)
+    await session.delete(profile)
+    await session.commit()

--- a/ui/backend/schemas/__init__.py
+++ b/ui/backend/schemas/__init__.py
@@ -209,6 +209,8 @@ class BriefReviseRequest(BaseModel):
     instruction: str
     data_source: str
     model: Optional[str] = None
+    # Optional voice & tone profile instructions applied to the rewritten text.
+    voice_instructions: Optional[str] = None
 
 
 class BriefReviseResponse(BaseModel):

--- a/ui/backend/services/llm_service.py
+++ b/ui/backend/services/llm_service.py
@@ -500,6 +500,7 @@ async def revise_brief_section(
     model_key: str | None = None,
     temperature: float | None = None,
     max_tokens: int | None = None,
+    voice_instructions: str | None = None,
 ) -> str:
     """Surgically revise one brief section's markdown per an instruction.
 
@@ -518,6 +519,9 @@ async def revise_brief_section(
     user_prompt = _brief_revise_user_template.render(
         instruction=html.unescape(instruction.strip()),
         content=html.unescape(content),
+        voice_instructions=(
+            html.unescape(voice_instructions.strip()) if voice_instructions else None
+        ),
     )
     llm = get_llm(
         model=model_key,

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -3853,6 +3853,11 @@ h6,
   font-size: 0.75rem;
   color: var(--gray-500);
 }
+/* LLM-selected excerpt snippets render quoted and italic. */
+.citation-hover-snippets {
+  font-style: italic;
+}
+
 .citation-hover-excerpt {
   margin-top: 8px;
   padding-top: 8px;
@@ -3864,7 +3869,6 @@ h6,
 /* Heading breadcrumb shown as an italic section path at the top of the excerpt. */
 .citation-hover-section {
   margin-bottom: 6px;
-  font-style: italic;
   font-size: 0.75rem;
   line-height: 1.4;
   color: var(--gray-500);

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -2970,6 +2970,7 @@ function App() {
           <BriefTab
             dataSource={dataSource}
             assistantModelConfig={assistantModelConfig}
+            semanticModelConfig={semanticHighlightModelConfig}
             rerankerModel={rerankModel}
             searchSettings={{
               denseWeight: searchDenseWeight,

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -422,6 +422,8 @@ const getTabFromPath = (): TabName => {
     return 'search';
   }
   const path = stripBasePath(window.location.pathname).replace('/', '').toLowerCase();
+  // /brief/<id> share links open the Brief tab (BriefTab reads the id itself).
+  if (path.startsWith('brief/')) return 'brief';
   return VALID_TABS.includes(path as TabName) ? (path as TabName) : 'search';
 };
 

--- a/ui/frontend/src/components/brief/BriefCentral.tsx
+++ b/ui/frontend/src/components/brief/BriefCentral.tsx
@@ -267,9 +267,7 @@ export const BriefCentral: React.FC<BriefCentralProps> = ({
           <div className="brief-eyebrow">Brief Central</div>
           <h2 className="bc-title">Turn a topic into a structured, evidence-backed brief</h2>
           <p className="bc-lede">
-            A brief generates an outline grounded in the document library, researches each heading
-            into cited prose, and exports to Word with citations linked back to the source
-            documents.
+            Use AI to help write a brief document based on the document library.
           </p>
         </div>
         <button

--- a/ui/frontend/src/components/brief/BriefCentral.tsx
+++ b/ui/frontend/src/components/brief/BriefCentral.tsx
@@ -1,0 +1,367 @@
+import React, { useState } from 'react';
+import { recordTemplateUse } from './briefCentralApi';
+import {
+  BriefNewModal,
+  BriefShareModal,
+  BriefTemplateModal,
+  BriefVoiceModal,
+  NewBriefSubmit,
+  TemplateDraft,
+  VoiceDraft,
+  numberHeadings,
+} from './BriefCentralModals';
+import { IconEdit, IconPlus, IconShare } from './BriefIcons';
+import { BriefListItem, BriefTemplate, VoiceProfile } from './briefTypes';
+import { CentralTab, UseBriefCentralReturn } from './useBriefCentral';
+
+/**
+ * Brief Central — the Brief tab's landing page. Four tabs: the user's briefs,
+ * briefs shared with them (viewer-only), templates and voice & tone profiles.
+ */
+
+const formatWhen = (iso: string): string => {
+  try {
+    const d = new Date(iso);
+    return `${d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} · ${d.toLocaleTimeString(
+      undefined,
+      { hour: 'numeric', minute: '2-digit' },
+    )}`;
+  } catch {
+    return '';
+  }
+};
+
+const TAB_LABELS: Record<CentralTab, (c: UseBriefCentralReturn) => string> = {
+  mine: (c) => `My briefs (${c.myBriefs.length})`,
+  shared: (c) => `Shared with me (${c.sharedBriefs.length})`,
+  templates: (c) => `Templates (${c.templates.length})`,
+  voices: (c) => `Voice & tone (${c.voices.length})`,
+};
+
+const BriefCard: React.FC<{
+  brief: BriefListItem;
+  voiceName: string | null;
+  shared: boolean;
+  onOpen: () => void;
+  onShare?: () => void;
+  onDelete?: () => void;
+}> = ({ brief, voiceName, shared, onOpen, onShare, onDelete }) => (
+  <div className="bc-card">
+    <button className="bc-card-main" onClick={onOpen}>
+      <div className="bc-card-title">{brief.title}</div>
+      {brief.query && <div className="bc-card-query">{brief.query}</div>}
+      <div className="bc-card-meta">
+        {brief.section_count} sections · {brief.source_count} sources ·{' '}
+        {formatWhen(brief.updated_at)}
+      </div>
+    </button>
+    <div className="bc-card-foot">
+      {shared ? (
+        <>
+          <span className="bc-chip bc-chip-muted">Viewer</span>
+          <span className="bc-card-foot-note">Shared by {brief.owner_name}</span>
+        </>
+      ) : (
+        <>
+          <span className="bc-chip">{voiceName || 'No voice'}</span>
+          <span className="bc-card-foot-note">
+            {brief.share_count ? `Shared with ${brief.share_count}` : 'Private'}
+          </span>
+          <button className="bc-card-act" title="Share this brief" onClick={onShare}>
+            <IconShare size={12} /> Share
+          </button>
+          <button
+            className="bc-icon-btn bc-icon-danger"
+            title="Delete this brief"
+            aria-label="Delete this brief"
+            onClick={onDelete}
+          >
+            ×
+          </button>
+        </>
+      )}
+    </div>
+  </div>
+);
+
+const TemplateCard: React.FC<{
+  template: BriefTemplate;
+  onUse: () => void;
+  onDelete: () => void;
+}> = ({ template, onUse, onDelete }) => (
+  <div className="bc-card">
+    <div className="bc-card-main bc-card-static">
+      <div className="bc-card-title">{template.name}</div>
+      {template.description && <div className="bc-card-query">{template.description}</div>}
+      <div className="bc-template-headings">
+        {numberHeadings(template.headings).map((h, i) => (
+          <div key={i} className={`bc-heading-row${h.sub ? ' bc-heading-sub' : ''}`}>
+            <span className="bc-heading-num">{h.num}</span>
+            <span>{h.title}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+    <div className="bc-card-foot">
+      <span className="bc-card-foot-note">
+        {template.headings.length} headings
+        {template.with_text ? ' · includes text' : ''}
+        {template.use_count ? ` · used ${template.use_count} times` : ''}
+      </span>
+      <button className="bc-card-act bc-card-act-right" title="Use this template" onClick={onUse}>
+        <IconPlus size={12} /> Use
+      </button>
+      <button
+        className="bc-icon-btn bc-icon-danger"
+        title="Delete template"
+        aria-label="Delete template"
+        onClick={onDelete}
+      >
+        ×
+      </button>
+    </div>
+  </div>
+);
+
+const VoiceCard: React.FC<{
+  voice: VoiceProfile;
+  onEdit: () => void;
+  onDelete: () => void;
+}> = ({ voice, onEdit, onDelete }) => (
+  <div className="bc-card">
+    <div className="bc-card-main bc-card-static">
+      <div className="bc-card-title">{voice.name}</div>
+      {voice.description && <div className="bc-card-query">{voice.description}</div>}
+      <div className="bc-inline-panel">
+        <div className="bc-kicker">Style instructions</div>
+        <div className="bc-card-query">
+          {voice.instructions.length > 180
+            ? `${voice.instructions.slice(0, 180)}…`
+            : voice.instructions}
+        </div>
+      </div>
+    </div>
+    <div className="bc-card-foot">
+      <button className="bc-card-act bc-card-act-right" title="Edit this profile" onClick={onEdit}>
+        <IconEdit size={12} /> Edit
+      </button>
+      <button
+        className="bc-icon-btn bc-icon-danger"
+        title="Delete profile"
+        aria-label="Delete profile"
+        onClick={onDelete}
+      >
+        ×
+      </button>
+    </div>
+  </div>
+);
+
+interface BriefCentralProps {
+  central: UseBriefCentralReturn;
+  onOpenBrief: (id: string) => void;
+  onCreateBrief: (args: NewBriefSubmit) => void;
+}
+
+export const BriefCentral: React.FC<BriefCentralProps> = ({
+  central,
+  onOpenBrief,
+  onCreateBrief,
+}) => {
+  const [modal, setModal] = useState<'new' | 'template' | 'voice' | 'share' | null>(null);
+  const [newTemplateId, setNewTemplateId] = useState<string | null>(null);
+  const [voiceDraft, setVoiceDraft] = useState<VoiceDraft | null>(null);
+  const [shareBrief, setShareBrief] = useState<BriefListItem | null>(null);
+
+  const emptyTemplateDraft: TemplateDraft = {
+    fromBrief: false,
+    name: '',
+    description: '',
+    headings: [{ title: '', sub: false }],
+    withText: false,
+  };
+
+  const submitNew = (args: NewBriefSubmit) => {
+    setModal(null);
+    if (args.template) void recordTemplateUse(args.template.id).catch(() => undefined);
+    onCreateBrief(args);
+  };
+
+  const gridFor = (tab: CentralTab): React.ReactNode => {
+    if (tab === 'mine') {
+      return central.myBriefs.map((b) => (
+        <BriefCard
+          key={b.id}
+          brief={b}
+          voiceName={central.voiceById(b.voice_profile_id)?.name || null}
+          shared={false}
+          onOpen={() => onOpenBrief(b.id)}
+          onShare={() => {
+            setShareBrief(b);
+            setModal('share');
+          }}
+          onDelete={() => void central.removeBrief(b.id).catch(() => undefined)}
+        />
+      ));
+    }
+    if (tab === 'shared') {
+      return central.sharedBriefs.map((b) => (
+        <BriefCard key={b.id} brief={b} voiceName={null} shared onOpen={() => onOpenBrief(b.id)} />
+      ));
+    }
+    if (tab === 'templates') {
+      return (
+        <>
+          <button className="bc-add-card" onClick={() => setModal('template')}>
+            <IconPlus size={15} /> New template
+          </button>
+          {central.templates.map((t) => (
+            <TemplateCard
+              key={t.id}
+              template={t}
+              onUse={() => {
+                setNewTemplateId(t.id);
+                setModal('new');
+              }}
+              onDelete={() => void central.removeTemplate(t.id).catch(() => undefined)}
+            />
+          ))}
+        </>
+      );
+    }
+    return (
+      <>
+        <button
+          className="bc-add-card"
+          onClick={() => {
+            setVoiceDraft({ id: null, name: '', description: '', instructions: '' });
+            setModal('voice');
+          }}
+        >
+          <IconPlus size={15} /> New voice &amp; tone profile
+        </button>
+        {central.voices.map((v) => (
+          <VoiceCard
+            key={v.id}
+            voice={v}
+            onEdit={() => {
+              setVoiceDraft({
+                id: v.id,
+                name: v.name,
+                description: v.description || '',
+                instructions: v.instructions,
+              });
+              setModal('voice');
+            }}
+            onDelete={() => void central.removeVoice(v.id).catch(() => undefined)}
+          />
+        ))}
+      </>
+    );
+  };
+
+  return (
+    <div className="bc-page">
+      <div className="bc-header">
+        <div>
+          <div className="brief-eyebrow">Brief Central</div>
+          <h2 className="bc-title">Turn a topic into a structured, evidence-backed brief</h2>
+          <p className="bc-lede">
+            A brief generates an outline grounded in the document library, researches each heading
+            into cited prose, and exports to Word with citations linked back to the source
+            documents.
+          </p>
+        </div>
+        <button
+          className="brief-btn brief-btn-primary bc-new-btn"
+          onClick={() => {
+            setNewTemplateId(null);
+            setModal('new');
+          }}
+        >
+          <IconPlus /> New brief
+        </button>
+      </div>
+
+      {central.error && <div className="brief-error brief-error-banner">{central.error}</div>}
+
+      <div className="bc-tabs" role="tablist">
+        {(Object.keys(TAB_LABELS) as CentralTab[]).map((t) => (
+          <button
+            key={t}
+            role="tab"
+            aria-selected={central.tab === t}
+            className={`bc-tab${central.tab === t ? ' bc-tab-on' : ''}`}
+            onClick={() => central.setTab(t)}
+          >
+            {TAB_LABELS[t](central)}
+          </button>
+        ))}
+      </div>
+
+      {central.loading ? (
+        <div className="bc-empty">Loading…</div>
+      ) : (
+        <div className="bc-grid">{gridFor(central.tab)}</div>
+      )}
+      {!central.loading && central.tab === 'mine' && central.myBriefs.length === 0 && (
+        <div className="bc-empty">No briefs yet — create your first with “New brief”.</div>
+      )}
+      {!central.loading && central.tab === 'shared' && central.sharedBriefs.length === 0 && (
+        <div className="bc-empty">Nothing has been shared with you yet.</div>
+      )}
+
+      {modal === 'new' && (
+        <BriefNewModal
+          templates={central.templates}
+          voices={central.voices}
+          initialTemplateId={newTemplateId}
+          onSubmit={submitNew}
+          onClose={() => setModal(null)}
+        />
+      )}
+      {modal === 'template' && (
+        <BriefTemplateModal
+          draft={emptyTemplateDraft}
+          onSave={async (d) => {
+            await central.saveTemplate({
+              name: d.name,
+              description: d.description || null,
+              headings: d.headings,
+              withText: d.withText,
+            });
+            setModal(null);
+          }}
+          onClose={() => setModal(null)}
+        />
+      )}
+      {modal === 'voice' && voiceDraft && (
+        <BriefVoiceModal
+          draft={voiceDraft}
+          onSave={async (d) => {
+            await central.saveVoice({
+              id: d.id,
+              name: d.name,
+              description: d.description || null,
+              instructions: d.instructions,
+            });
+            setModal(null);
+          }}
+          onDelete={async (id) => {
+            await central.removeVoice(id);
+            setModal(null);
+          }}
+          onClose={() => setModal(null)}
+        />
+      )}
+      {modal === 'share' && shareBrief && (
+        <BriefShareModal
+          briefId={shareBrief.id}
+          briefTitle={shareBrief.title}
+          onChanged={() => void central.refresh()}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </div>
+  );
+};

--- a/ui/frontend/src/components/brief/BriefCentral.tsx
+++ b/ui/frontend/src/components/brief/BriefCentral.tsx
@@ -32,7 +32,7 @@ const formatWhen = (iso: string): string => {
 };
 
 const TAB_LABELS: Record<CentralTab, (c: UseBriefCentralReturn) => string> = {
-  mine: (c) => `My briefs (${c.myBriefs.length})`,
+  mine: (c) => `Saved Briefs (${c.myBriefs.length})`,
   shared: (c) => `Shared with me (${c.sharedBriefs.length})`,
   templates: (c) => `Templates (${c.templates.length})`,
   voices: (c) => `Voice & tone (${c.voices.length})`,

--- a/ui/frontend/src/components/brief/BriefCentralModals.tsx
+++ b/ui/frontend/src/components/brief/BriefCentralModals.tsx
@@ -1,0 +1,660 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { addBriefShare, getBrief, removeBriefShare } from './briefCentralApi';
+import { IconCopy, IconPlus, IconSparkle } from './BriefIcons';
+import {
+  BriefShareTarget,
+  BriefTemplate,
+  BriefTemplateHeading,
+  VoiceProfile,
+} from './briefTypes';
+
+/**
+ * The Brief Central modals: New brief, template editor (new + save-from-brief),
+ * voice & tone profile editor, and viewer-only sharing. All reuse the existing
+ * `.brief-modal-*` shell classes plus `.bc-*` styles from brief.css.
+ */
+
+const errMessage = (e: unknown, fallback: string): string =>
+  e instanceof Error ? e.message : fallback;
+
+// Numbering matching the brief document: 1, 1.1, 1.2, 2, …
+export const numberHeadings = (
+  headings: BriefTemplateHeading[],
+): { num: string; title: string; sub: boolean }[] => {
+  let top = 0;
+  let sub = 0;
+  return headings.map((h) => {
+    if (h.sub && top > 0) {
+      sub += 1;
+      return { num: `${top}.${sub}`, title: h.title, sub: true };
+    }
+    top += 1;
+    sub = 0;
+    return { num: `${top}`, title: h.title, sub: false };
+  });
+};
+
+// ---------------------------------------------------------------------------
+// New brief
+// ---------------------------------------------------------------------------
+
+export interface NewBriefSubmit {
+  mode: 'ai' | 'manual';
+  title: string;
+  instructions: string;
+  voiceId: string | null;
+  numHeadings: number;
+  template: BriefTemplate | null;
+}
+
+export const BriefNewModal: React.FC<{
+  templates: BriefTemplate[];
+  voices: VoiceProfile[];
+  initialTemplateId?: string | null;
+  onSubmit: (args: NewBriefSubmit) => void;
+  onClose: () => void;
+}> = ({ templates, voices, initialTemplateId, onSubmit, onClose }) => {
+  const [mode, setMode] = useState<'ai' | 'manual'>(initialTemplateId ? 'manual' : 'ai');
+  const [title, setTitle] = useState('');
+  const [instructions, setInstructions] = useState('');
+  const [voiceId, setVoiceId] = useState<string | null>(null);
+  const [numHeadings, setNumHeadings] = useState(6);
+  const [templateId, setTemplateId] = useState<string>(initialTemplateId || '');
+
+  const template = templates.find((t) => t.id === templateId) || null;
+  const voice = voices.find((v) => v.id === voiceId) || null;
+  const numbered = useMemo(
+    () => (template ? numberHeadings(template.headings) : []),
+    [template],
+  );
+
+  const submit = () => {
+    onSubmit({ mode, title: title.trim(), instructions: instructions.trim(), voiceId, numHeadings, template });
+  };
+
+  return (
+    <div className="brief-modal-overlay" onClick={onClose}>
+      <div className="brief-modal bc-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="brief-modal-head">
+          <div>
+            <div className="brief-modal-title">New brief</div>
+            <div className="brief-modal-sub">
+              Generate an outline with AI, or start from your own headings.
+            </div>
+          </div>
+          <button className="brief-modal-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="bc-modal-body">
+          <div className="bc-mode-toggle" role="tablist">
+            <button
+              role="tab"
+              aria-selected={mode === 'ai'}
+              className={mode === 'ai' ? 'bc-mode-on' : ''}
+              onClick={() => setMode('ai')}
+            >
+              Generate using AI
+            </button>
+            <button
+              role="tab"
+              aria-selected={mode === 'manual'}
+              className={mode === 'manual' ? 'bc-mode-on' : ''}
+              onClick={() => setMode('manual')}
+            >
+              Manual
+            </button>
+          </div>
+
+          <label className="brief-label" htmlFor="bc-new-title">
+            Title
+          </label>
+          <textarea
+            id="bc-new-title"
+            className="brief-textarea bc-title-input"
+            rows={2}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Enter your brief title here"
+          />
+
+          {mode === 'ai' ? (
+            <>
+              <label className="brief-label brief-label-spaced" htmlFor="bc-new-instructions">
+                Instructions <span className="brief-label-hint">(optional — guides the headings)</span>
+              </label>
+              <textarea
+                id="bc-new-instructions"
+                className="brief-textarea brief-textarea-sm"
+                rows={2}
+                value={instructions}
+                onChange={(e) => setInstructions(e.target.value)}
+                placeholder="e.g. focus on East Africa, prioritise RCTs since 2018, structure around outcomes"
+              />
+              <div className="bc-field-row">
+                <div className="bc-field">
+                  <label className="brief-label brief-label-spaced" htmlFor="bc-new-voice">
+                    Voice &amp; tone profile
+                  </label>
+                  <select
+                    id="bc-new-voice"
+                    className="bc-select"
+                    value={voiceId || ''}
+                    onChange={(e) => setVoiceId(e.target.value || null)}
+                  >
+                    <option value="">No voice profile</option>
+                    {voices.map((v) => (
+                      <option key={v.id} value={v.id}>
+                        {v.name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="bc-field bc-field-num">
+                  <label className="brief-label brief-label-spaced" htmlFor="bc-new-headings">
+                    Sections
+                  </label>
+                  <input
+                    id="bc-new-headings"
+                    className="brief-number"
+                    type="number"
+                    min={2}
+                    max={12}
+                    value={numHeadings}
+                    onChange={(e) => setNumHeadings(Number(e.target.value) || 6)}
+                  />
+                </div>
+              </div>
+              {voice && <div className="bc-hint">{voice.instructions.slice(0, 160)}</div>}
+            </>
+          ) : (
+            <>
+              <label className="brief-label brief-label-spaced" htmlFor="bc-new-template">
+                Template
+              </label>
+              <select
+                id="bc-new-template"
+                className="bc-select"
+                value={templateId}
+                onChange={(e) => setTemplateId(e.target.value)}
+              >
+                <option value="">No template — blank outline</option>
+                {templates.map((t) => (
+                  <option key={t.id} value={t.id}>
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+              <div className="bc-template-preview">
+                <div className="bc-kicker">
+                  {template ? "Headings you'll start with" : "You'll add headings yourself"}
+                </div>
+                {template ? (
+                  numbered.map((h, i) => (
+                    <div key={i} className={`bc-heading-row${h.sub ? ' bc-heading-sub' : ''}`}>
+                      <span className="bc-heading-num">{h.num}</span>
+                      <span>{h.title}</span>
+                    </div>
+                  ))
+                ) : (
+                  <div className="bc-hint">
+                    The brief starts empty — add each heading in the contents panel as you go.
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          <div className="bc-modal-actions">
+            <button className="brief-btn brief-btn-primary" onClick={submit} disabled={!title.trim() && mode === 'ai'}>
+              {mode === 'ai' ? <IconSparkle size={15} /> : <IconPlus />}
+              {mode === 'ai' ? 'Generate outline' : 'Create brief'}
+            </button>
+            <button className="brief-btn brief-btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Template editor (new template, or save-from-brief)
+// ---------------------------------------------------------------------------
+
+export interface TemplateDraft {
+  fromBrief: boolean;
+  name: string;
+  description: string;
+  headings: BriefTemplateHeading[];
+  withText: boolean;
+}
+
+export const BriefTemplateModal: React.FC<{
+  draft: TemplateDraft;
+  onSave: (draft: TemplateDraft) => Promise<void>;
+  onClose: () => void;
+}> = ({ draft: initial, onSave, onClose }) => {
+  const [draft, setDraft] = useState<TemplateDraft>(initial);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const numbered = useMemo(() => numberHeadings(draft.headings), [draft.headings]);
+
+  const patchHeading = (i: number, title: string) =>
+    setDraft((d) => ({
+      ...d,
+      headings: d.headings.map((h, j) => (j === i ? { ...h, title } : h)),
+    }));
+
+  const addSub = (i: number) =>
+    setDraft((d) => {
+      const list = [...d.headings];
+      let at = i + 1;
+      while (at < list.length && list[at].sub) at += 1;
+      list.splice(at, 0, { title: '', sub: true });
+      return { ...d, headings: list };
+    });
+
+  const removeHeading = (i: number) =>
+    setDraft((d) => ({ ...d, headings: d.headings.filter((_, j) => j !== i) }));
+
+  const save = async () => {
+    const headings = draft.headings
+      .map((h) => ({ ...h, title: h.title.trim() }))
+      .filter((h) => h.title);
+    if (!draft.name.trim() || !headings.length) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onSave({ ...draft, headings });
+    } catch (e) {
+      setError(errMessage(e, 'Could not save the template.'));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="brief-modal-overlay" onClick={onClose}>
+      <div className="brief-modal bc-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="brief-modal-head">
+          <div>
+            <div className="brief-modal-title">
+              {draft.fromBrief ? 'Save brief as template' : 'New template'}
+            </div>
+            <div className="brief-modal-sub">
+              Templates save the headings so the next brief starts structured.
+            </div>
+          </div>
+          <button className="brief-modal-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="bc-modal-body">
+          {error && <div className="brief-error">{error}</div>}
+          <label className="brief-label" htmlFor="bc-tpl-name">
+            Template name
+          </label>
+          <input
+            id="bc-tpl-name"
+            className="bc-input"
+            value={draft.name}
+            onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+            placeholder="e.g. Standard evaluation synthesis"
+          />
+          <label className="brief-label brief-label-spaced" htmlFor="bc-tpl-desc">
+            Description
+          </label>
+          <input
+            id="bc-tpl-desc"
+            className="bc-input"
+            value={draft.description}
+            onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))}
+            placeholder="When to reach for this template"
+          />
+
+          {draft.fromBrief && (
+            <div className="bc-inline-panel">
+              <div className="bc-inline-panel-row">
+                <span className="bc-inline-panel-title">Include section text</span>
+                <button
+                  role="switch"
+                  aria-checked={draft.withText}
+                  className={`brief-switch${draft.withText ? ' brief-switch-on' : ''}`}
+                  onClick={() => setDraft((d) => ({ ...d, withText: !d.withText }))}
+                >
+                  <span className="brief-switch-thumb" />
+                </button>
+              </div>
+              <div className="bc-hint">
+                {draft.withText
+                  ? 'The researched text is saved with each heading, so new briefs start from this draft.'
+                  : 'Only the headings are saved — new briefs start empty under each one.'}
+              </div>
+            </div>
+          )}
+
+          <div className="bc-kicker bc-kicker-spaced">Headings</div>
+          <div className="bc-heading-list">
+            {draft.headings.map((h, i) => (
+              <div key={i} className={`bc-heading-edit${h.sub ? ' bc-heading-sub' : ''}`}>
+                <span className="bc-heading-num">{numbered[i].num}.</span>
+                <input
+                  className="bc-input"
+                  value={h.title}
+                  onChange={(e) => patchHeading(i, e.target.value)}
+                  placeholder={h.sub ? 'Sub-heading name' : 'Heading name'}
+                  aria-label={h.sub ? 'Sub-heading name' : 'Heading name'}
+                />
+                <button
+                  className="bc-icon-btn"
+                  title="Add a sub-heading"
+                  aria-label="Add a sub-heading"
+                  onClick={() => addSub(i)}
+                >
+                  <IconPlus size={13} />
+                </button>
+                <button
+                  className="bc-icon-btn bc-icon-danger"
+                  title="Remove heading"
+                  aria-label="Remove heading"
+                  onClick={() => removeHeading(i)}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+          <button
+            className="bc-add-dashed"
+            onClick={() => setDraft((d) => ({ ...d, headings: [...d.headings, { title: '', sub: false }] }))}
+          >
+            <IconPlus size={14} /> Add heading
+          </button>
+
+          <div className="bc-modal-actions">
+            <button
+              className="brief-btn brief-btn-primary"
+              onClick={() => void save()}
+              disabled={busy || !draft.name.trim()}
+            >
+              Save template
+            </button>
+            <button className="brief-btn brief-btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Voice & tone profile editor
+// ---------------------------------------------------------------------------
+
+export interface VoiceDraft {
+  id: string | null;
+  name: string;
+  description: string;
+  instructions: string;
+}
+
+export const BriefVoiceModal: React.FC<{
+  draft: VoiceDraft;
+  onSave: (draft: VoiceDraft) => Promise<void>;
+  onDelete: ((id: string) => Promise<void>) | null;
+  onClose: () => void;
+}> = ({ draft: initial, onSave, onDelete, onClose }) => {
+  const [draft, setDraft] = useState<VoiceDraft>(initial);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (fn: () => Promise<void>, fallback: string) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await fn();
+    } catch (e) {
+      setError(errMessage(e, fallback));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="brief-modal-overlay" onClick={onClose}>
+      <div className="brief-modal bc-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="brief-modal-head">
+          <div>
+            <div className="brief-modal-title">
+              {draft.id ? 'Edit voice & tone profile' : 'New voice & tone profile'}
+            </div>
+            <div className="brief-modal-sub">
+              Instructions are applied when each section is written.
+            </div>
+          </div>
+          <button className="brief-modal-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="bc-modal-body">
+          {error && <div className="brief-error">{error}</div>}
+          <label className="brief-label" htmlFor="bc-voice-name">
+            Name
+          </label>
+          <input
+            id="bc-voice-name"
+            className="bc-input"
+            value={draft.name}
+            onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+            placeholder="e.g. Donor board memo"
+          />
+          <label className="brief-label brief-label-spaced" htmlFor="bc-voice-desc">
+            Description
+          </label>
+          <input
+            id="bc-voice-desc"
+            className="bc-input"
+            value={draft.description}
+            onChange={(e) => setDraft((d) => ({ ...d, description: e.target.value }))}
+            placeholder="One line on when to use this profile"
+          />
+          <label className="brief-label brief-label-spaced" htmlFor="bc-voice-instructions">
+            Style instructions
+          </label>
+          <textarea
+            id="bc-voice-instructions"
+            className="brief-textarea bc-voice-textarea"
+            rows={7}
+            value={draft.instructions}
+            onChange={(e) => setDraft((d) => ({ ...d, instructions: e.target.value }))}
+            placeholder="e.g. Write in plain English at reading level B2. Lead each section with the finding, then the evidence. Avoid agency jargon and acronyms on first use. Keep paragraphs under four sentences."
+          />
+          <div className="bc-modal-actions">
+            <button
+              className="brief-btn brief-btn-primary"
+              disabled={busy || !draft.name.trim() || !draft.instructions.trim()}
+              onClick={() => void run(() => onSave(draft), 'Could not save the profile.')}
+            >
+              Save profile
+            </button>
+            <button className="brief-btn brief-btn-secondary" onClick={onClose}>
+              Cancel
+            </button>
+            {draft.id && onDelete && (
+              <button
+                className="bc-delete-btn"
+                disabled={busy}
+                onClick={() =>
+                  void run(() => onDelete(draft.id as string), 'Could not delete the profile.')
+                }
+              >
+                Delete profile
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Share (viewer-only)
+// ---------------------------------------------------------------------------
+
+const initialsOf = (name: string): string =>
+  name
+    .split(' ')
+    .map((w) => w[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+
+export const BriefShareModal: React.FC<{
+  briefId: string;
+  briefTitle: string;
+  onChanged?: () => void;
+  onClose: () => void;
+}> = ({ briefId, briefTitle, onChanged, onClose }) => {
+  const [targets, setTargets] = useState<BriefShareTarget[]>([]);
+  const [input, setInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const shareUrl = `${window.location.origin}/brief/${briefId}`;
+
+  useEffect(() => {
+    let cancelled = false;
+    getBrief(briefId)
+      .then((b) => {
+        if (!cancelled) setTargets(b.shared_with);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(errMessage(e, 'Could not load sharing.'));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [briefId]);
+
+  const add = useCallback(async () => {
+    const target = input.trim();
+    if (!target || busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await addBriefShare(briefId, target);
+      setTargets(updated.shared_with);
+      setInput('');
+      onChanged?.();
+    } catch (e) {
+      setError(errMessage(e, 'Could not share the brief.'));
+    } finally {
+      setBusy(false);
+    }
+  }, [briefId, input, busy, onChanged]);
+
+  const remove = useCallback(
+    async (shareId: string) => {
+      setError(null);
+      try {
+        await removeBriefShare(briefId, shareId);
+        setTargets((prev) => prev.filter((t) => t.id !== shareId));
+        onChanged?.();
+      } catch (e) {
+        setError(errMessage(e, 'Could not remove access.'));
+      }
+    },
+    [briefId, onChanged],
+  );
+
+  const copy = () => {
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(shareUrl).catch(() => {});
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="brief-modal-overlay" onClick={onClose}>
+      <div className="brief-modal bc-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="brief-modal-head">
+          <div>
+            <div className="brief-modal-title">Share “{briefTitle}”</div>
+            <div className="brief-modal-sub">
+              People you add can read this brief. Only you can edit it.
+            </div>
+          </div>
+          <button className="brief-modal-close" onClick={onClose} aria-label="Close">
+            ×
+          </button>
+        </div>
+        <div className="bc-modal-body">
+          {error && <div className="brief-error">{error}</div>}
+          <label className="brief-label" htmlFor="bc-share-url">
+            Brief link
+          </label>
+          <div className="bc-share-row">
+            <input id="bc-share-url" className="bc-input bc-share-url" readOnly value={shareUrl} />
+            <button className="brief-btn brief-btn-secondary" onClick={copy}>
+              <IconCopy size={14} />
+              {copied ? 'Copied' : 'Copy link'}
+            </button>
+          </div>
+          <div className="bc-hint">Only people and groups added below can open this link.</div>
+
+          <label className="brief-label brief-label-spaced" htmlFor="bc-share-add">
+            Add people or groups
+          </label>
+          <div className="bc-share-row">
+            <input
+              id="bc-share-add"
+              className="bc-input"
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void add();
+              }}
+              placeholder="name@org.org or group name"
+            />
+            <button className="brief-btn brief-btn-primary" disabled={busy} onClick={() => void add()}>
+              Add
+            </button>
+          </div>
+
+          <div className="bc-share-list">
+            {targets.map((t) => (
+              <div key={t.id} className="bc-share-item">
+                <span className="bc-avatar">{initialsOf(t.name)}</span>
+                <div className="bc-share-item-main">
+                  <div className="bc-share-item-name">{t.name}</div>
+                  <div className="bc-share-item-kind">{t.kind}</div>
+                </div>
+                <span className="bc-viewer-chip">Viewer</span>
+                <button
+                  className="bc-icon-btn bc-icon-danger"
+                  title="Remove access"
+                  aria-label="Remove access"
+                  onClick={() => void remove(t.id)}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+          </div>
+
+          <div className="bc-modal-actions">
+            <button className="brief-btn brief-btn-primary" onClick={onClose}>
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -594,6 +594,9 @@ interface BriefDocumentProps {
   // Brief Central integrations (remote mode only).
   onOpenShare?: () => void;
   onSaveTemplate?: () => void;
+  // False when the Contents panel renders in the workspace side rail instead
+  // (logged-in layout); true keeps the inline panel (anonymous layout).
+  showToc?: boolean;
 }
 
 const autoSizeTitle = (el: HTMLTextAreaElement | null) => {
@@ -609,6 +612,7 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
   exportBusy,
   onOpenShare,
   onSaveTemplate,
+  showToc = true,
 }) => {
   const { sections, numbers } = brief;
   const [logOpen, setLogOpen] = useState(false);
@@ -744,7 +748,7 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
         )}
       </div>
 
-      {sections.length > 0 && <BriefToc brief={brief} canEdit={canEditStructure} />}
+      {showToc && sections.length > 0 && <BriefToc brief={brief} canEdit={canEditStructure} />}
 
       {sections.map((s, i) => (
         <BriefSectionView

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -599,6 +599,37 @@ interface BriefDocumentProps {
   showToc?: boolean;
 }
 
+// Floating bar fixed to the bottom of the viewport while research runs: which
+// section is being written, overall progress, and a Stop control.
+const ResearchStatusBar: React.FC<{ brief: UseBriefReturn }> = ({ brief }) => {
+  const current = brief.sections.find((s) => s.status === 'researching');
+  if (!current) return null;
+  const total = brief.sections.length;
+  return (
+    <div className="brief-status-bar" role="status">
+      <span className="brief-spinner brief-status-bar-spinner" />
+      <div className="brief-status-bar-main">
+        <div className="brief-status-bar-label">
+          {current.revising ? 'Revising' : 'Researching'} “{current.title}”
+          <span className="brief-status-bar-count">
+            {brief.doneCount}/{total} sections
+          </span>
+        </div>
+        <div className="brief-status-bar-track">
+          <div className="brief-status-bar-fill" style={{ width: `${brief.totalProgress}%` }} />
+        </div>
+      </div>
+      <button
+        className="brief-status-bar-stop"
+        onClick={brief.stopResearch}
+        title="Stop all research"
+      >
+        ■ Stop
+      </button>
+    </div>
+  );
+};
+
 const autoSizeTitle = (el: HTMLTextAreaElement | null) => {
   if (!el) return;
   el.style.height = 'auto';
@@ -801,6 +832,8 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
           </div>
         </section>
       )}
+
+      <ResearchStatusBar brief={brief} />
     </div>
   );
 };

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -2,7 +2,15 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { SearchResult, SourceReference } from '../../types/api';
 import { CitedMarkdown, CitedReferences } from '../citations/CitedContent';
 import { buildGlobalCitations, SectionDisplay } from './briefCitations';
-import { IconClock, IconDownload, IconEdit, IconRefresh, IconSparkle } from './BriefIcons';
+import {
+  IconClock,
+  IconCopy,
+  IconDownload,
+  IconEdit,
+  IconRefresh,
+  IconShare,
+  IconSparkle,
+} from './BriefIcons';
 import { BriefToc } from './BriefToc';
 import { BriefSection, SectionAuditEntry } from './briefTypes';
 import { UseBriefReturn } from './useBrief';
@@ -96,6 +104,8 @@ interface SectionViewProps {
   onSourceClick: (source: SourceReference) => void;
   // Globally-renumbered content + sources for the done view (see buildGlobalCitations).
   display?: SectionDisplay;
+  // Viewer-only (shared brief): no editing or AI actions.
+  readOnly?: boolean;
 }
 
 // A textarea for editing a section's heading guidance / regenerating, shown for
@@ -105,6 +115,8 @@ const GuidancePanel: React.FC<{ section: BriefSection; brief: UseBriefReturn }> 
   brief,
 }) => {
   const isPending = section.status === 'pending';
+  const briefVoice = brief.voices.find((v) => v.id === brief.briefVoiceId) || null;
+  const ownVoice = brief.voices.find((v) => v.id === section.voiceId) || null;
   return (
     <div className="brief-regen-panel">
       <div className="brief-regen-title">
@@ -116,6 +128,33 @@ const GuidancePanel: React.FC<{ section: BriefSection; brief: UseBriefReturn }> 
         rows={2}
         placeholder="Optional: add focus or guidance — e.g. ‘emphasise sub-Saharan Africa & 2020 onward’"
       />
+      {brief.voices.length > 0 && (
+        <>
+          <div className="brief-regen-voice-label">Voice &amp; tone profile</div>
+          <select
+            className="brief-regen-voice-select"
+            value={section.voiceId || ''}
+            onChange={(e) => brief.setSectionVoiceId(section.id, e.target.value || null)}
+            aria-label="Voice and tone profile for this section"
+          >
+            <option value="">
+              Use brief default{briefVoice ? ` — ${briefVoice.name}` : ''}
+            </option>
+            {brief.voices.map((v) => (
+              <option key={v.id} value={v.id}>
+                {v.name}
+              </option>
+            ))}
+          </select>
+          <div className="brief-regen-voice-hint">
+            {ownVoice
+              ? ownVoice.instructions.slice(0, 150)
+              : briefVoice
+                ? `Inherits the brief profile — ${briefVoice.instructions.slice(0, 120)}`
+                : 'No voice profile applied'}
+          </div>
+        </>
+      )}
       <div className="brief-regen-actions">
         <button
           className="brief-btn brief-btn-primary"
@@ -299,6 +338,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   brief,
   onSourceClick,
   display,
+  readOnly = false,
 }) => {
   const [editing, setEditing] = useState(false);
   // AI Edit/Update instruction panel + audit modal + changes toggle.
@@ -346,10 +386,11 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
           value={section.title}
           onChange={(e) => brief.editTitle(section.id, e.target.value)}
           onBlur={brief.commitEdits}
+          readOnly={readOnly}
         />
       </div>
 
-      {isDone && (
+      {isDone && !readOnly && (
         <SectionTools
           editing={editing}
           auditCount={auditCount}
@@ -398,7 +439,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
 
       {panelOpen && <GuidancePanel section={section} brief={brief} />}
 
-      {section.status === 'pending' && !panelOpen && !anyResearching && (
+      {section.status === 'pending' && !panelOpen && !anyResearching && !readOnly && (
         <SectionPending sample={section.sample} onResearch={() => brief.openRegen(section.id)} />
       )}
 
@@ -422,6 +463,127 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   );
 };
 
+// The dropdown behind "Export to Word": references-list vs footnotes style.
+const ExportMenu: React.FC<{
+  disabled: boolean;
+  busy: boolean;
+  open: boolean;
+  setOpen: (fn: (open: boolean) => boolean) => void;
+  onExportWord: (style: 'links' | 'footnotes') => void;
+}> = ({ disabled, busy, open, setOpen, onExportWord }) => (
+  <div className="dropdown-container brief-export-menu">
+    <button
+      className="brief-export-word"
+      onClick={() => setOpen((o) => !o)}
+      onBlur={() => setTimeout(() => setOpen(() => false), 200)}
+      disabled={disabled || busy}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      title="Export this brief to Word, with citations linked to the source documents"
+    >
+      {busy ? 'Exporting…' : <><IconDownload /> Export to Word ▾</>}
+    </button>
+    {open && !busy && (
+      <div className="brief-export-dropdown" role="menu">
+        <button
+          className="brief-export-option"
+          role="menuitem"
+          onClick={() => { setOpen(() => false); onExportWord('links'); }}
+        >
+          References list
+          <span className="brief-export-option-hint">Inline [n] citations + reference excerpts</span>
+        </button>
+        <button
+          className="brief-export-option"
+          role="menuitem"
+          onClick={() => { setOpen(() => false); onExportWord('footnotes'); }}
+        >
+          Footnotes on page
+          <span className="brief-export-option-hint">Each citation as a footnote on the relevant page</span>
+        </button>
+      </div>
+    )}
+  </div>
+);
+
+// The document-level action row: regenerate/update all, share, save-as-template
+// and the Word export menu. Owner-only actions are hidden for viewers.
+const HeaderActions: React.FC<{
+  brief: UseBriefReturn;
+  readOnly: boolean;
+  canEditStructure: boolean;
+  onOpenShare?: () => void;
+  onSaveTemplate?: () => void;
+  onExportWord?: (style: 'links' | 'footnotes') => void;
+  exportBusy?: boolean;
+  exportMenuOpen: boolean;
+  setExportMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}> = ({
+  brief,
+  readOnly,
+  canEditStructure,
+  onOpenShare,
+  onSaveTemplate,
+  onExportWord,
+  exportBusy,
+  exportMenuOpen,
+  setExportMenuOpen,
+}) => {
+  const { sections } = brief;
+  const hasSections = sections.length > 0;
+  return (
+    <div className="brief-doc-header-actions">
+      {!readOnly && hasSections && (
+        <button
+          className="brief-regen-all"
+          onClick={brief.startResearch}
+          disabled={!canEditStructure}
+          title="Re-research every section from scratch"
+        >
+          <IconRefresh /> AI Regenerate All
+        </button>
+      )}
+      {!readOnly && sections.some((s) => s.status === 'done') && (
+        <button
+          className="brief-regen-all"
+          onClick={brief.updateAll}
+          disabled={!canEditStructure}
+          title="Fold sources published since each section was last run into every section"
+        >
+          <IconClock /> AI Get All Recent Updates
+        </button>
+      )}
+      {!readOnly && onOpenShare && (
+        <button
+          className="brief-regen-all"
+          onClick={onOpenShare}
+          title="Share this brief (viewer-only) with people or groups"
+        >
+          <IconShare /> Share
+        </button>
+      )}
+      {!readOnly && onSaveTemplate && hasSections && (
+        <button
+          className="brief-regen-all"
+          onClick={onSaveTemplate}
+          title="Save this brief's headings as a reusable template"
+        >
+          <IconCopy /> Save as Template
+        </button>
+      )}
+      {onExportWord && (
+        <ExportMenu
+          disabled={!hasSections}
+          busy={!!exportBusy}
+          open={exportMenuOpen}
+          setOpen={setExportMenuOpen}
+          onExportWord={onExportWord}
+        />
+      )}
+    </div>
+  );
+};
+
 interface BriefDocumentProps {
   brief: UseBriefReturn;
   onResultClick?: (result: SearchResult) => void;
@@ -429,6 +591,9 @@ interface BriefDocumentProps {
   // renders each citation as a Word footnote on the relevant page.
   onExportWord?: (style: 'links' | 'footnotes') => void;
   exportBusy?: boolean;
+  // Brief Central integrations (remote mode only).
+  onOpenShare?: () => void;
+  onSaveTemplate?: () => void;
 }
 
 const autoSizeTitle = (el: HTMLTextAreaElement | null) => {
@@ -442,6 +607,8 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
   onResultClick,
   onExportWord,
   exportBusy,
+  onOpenShare,
+  onSaveTemplate,
 }) => {
   const { sections, numbers } = brief;
   const [logOpen, setLogOpen] = useState(false);
@@ -452,8 +619,10 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
 
   useEffect(() => autoSizeTitle(titleRef.current), [brief.briefTitle]);
 
+  // Viewer-only: a brief shared with (not owned by) this user renders read-only.
+  const readOnly = !brief.canEdit;
   // Structural edits (reorder/add/remove via the TOC) lock while research runs.
-  const canEditStructure = !sections.some((s) => s.status === 'researching');
+  const canEditStructure = !readOnly && !sections.some((s) => s.status === 'researching');
 
   // Convert an assistant SourceReference into the SearchResult the app's
   // document preview expects (same mapping the Research Assistant uses).
@@ -477,63 +646,17 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
       <div className="brief-doc-header">
         <div className="brief-doc-header-top">
           <div className="brief-eyebrow">EVIDENCE BRIEF</div>
-          <div className="brief-doc-header-actions">
-            {sections.length > 0 && (
-              <button
-                className="brief-regen-all"
-                onClick={brief.startResearch}
-                disabled={!canEditStructure}
-                title="Re-research every section from scratch"
-              >
-                <IconRefresh /> AI Regenerate All
-              </button>
-            )}
-            {sections.some((s) => s.status === 'done') && (
-              <button
-                className="brief-regen-all"
-                onClick={brief.updateAll}
-                disabled={!canEditStructure}
-                title="Fold sources published since each section was last run into every section"
-              >
-                <IconClock /> AI Get All Recent Updates
-              </button>
-            )}
-            {onExportWord && (
-              <div className="dropdown-container brief-export-menu">
-                <button
-                  className="brief-export-word"
-                  onClick={() => setExportMenuOpen((open) => !open)}
-                  onBlur={() => setTimeout(() => setExportMenuOpen(false), 200)}
-                  disabled={!sections.length || exportBusy}
-                  aria-haspopup="menu"
-                  aria-expanded={exportMenuOpen}
-                  title="Export this brief to Word, with citations linked to the source documents"
-                >
-                  {exportBusy ? 'Exporting…' : <><IconDownload /> Export to Word ▾</>}
-                </button>
-                {exportMenuOpen && !exportBusy && (
-                  <div className="brief-export-dropdown" role="menu">
-                    <button
-                      className="brief-export-option"
-                      role="menuitem"
-                      onClick={() => { setExportMenuOpen(false); onExportWord('links'); }}
-                    >
-                      References list
-                      <span className="brief-export-option-hint">Inline [n] citations + reference excerpts</span>
-                    </button>
-                    <button
-                      className="brief-export-option"
-                      role="menuitem"
-                      onClick={() => { setExportMenuOpen(false); onExportWord('footnotes'); }}
-                    >
-                      Footnotes on page
-                      <span className="brief-export-option-hint">Each citation as a footnote on the relevant page</span>
-                    </button>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
+          <HeaderActions
+            brief={brief}
+            readOnly={readOnly}
+            canEditStructure={canEditStructure}
+            onOpenShare={onOpenShare}
+            onSaveTemplate={onSaveTemplate}
+            onExportWord={onExportWord}
+            exportBusy={exportBusy}
+            exportMenuOpen={exportMenuOpen}
+            setExportMenuOpen={setExportMenuOpen}
+          />
         </div>
         <textarea
           ref={titleRef}
@@ -546,11 +669,18 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
           onBlur={brief.commitEdits}
           rows={1}
           aria-label="Brief title"
+          readOnly={readOnly}
         />
         <div className="brief-doc-meta">
           <span>{sections.length} sections</span>
           <span>·</span>
           <span>{brief.totalSources} sources synthesised</span>
+          {readOnly && brief.ownerName && (
+            <>
+              <span>·</span>
+              <span className="brief-viewer-chip">Shared by {brief.ownerName} — view only</span>
+            </>
+          )}
           {hasOutlineLog && (
             <>
               <span>·</span>
@@ -563,7 +693,7 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
               </button>
             </>
           )}
-          {sections.length > 0 && (
+          {!readOnly && sections.length > 0 && (
             <span className="brief-edit-hint">
               <span className="brief-icon">✎</span> Click on titles to edit research topics
             </span>
@@ -624,10 +754,11 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
           brief={brief}
           onSourceClick={handleSourceClick}
           display={display.get(s.id)}
+          readOnly={readOnly}
         />
       ))}
 
-      {brief.stage === 'outline' && (
+      {brief.stage === 'outline' && !readOnly && (
         <div className="brief-doc-actions">
           <button
             className="brief-btn brief-btn-primary"

--- a/ui/frontend/src/components/brief/BriefIcons.tsx
+++ b/ui/frontend/src/components/brief/BriefIcons.tsx
@@ -26,6 +26,23 @@ export const IconPlus: React.FC<IconProps> = ({ size = 15 }) => (
   </svg>
 );
 
+export const IconShare: React.FC<IconProps> = ({ size = 14 }) => (
+  <svg {...svgProps(size)}>
+    <circle cx="18" cy="5" r="3" />
+    <circle cx="6" cy="12" r="3" />
+    <circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  </svg>
+);
+
+export const IconArrowLeft: React.FC<IconProps> = ({ size = 14 }) => (
+  <svg {...svgProps(size)}>
+    <line x1="19" y1="12" x2="5" y2="12" />
+    <polyline points="12 19 5 12 12 5" />
+  </svg>
+);
+
 export const IconHistory: React.FC<IconProps> = ({ size = 15 }) => (
   <svg {...svgProps(size)}>
     <path d="M3 3v5h5" />

--- a/ui/frontend/src/components/brief/BriefSeed.tsx
+++ b/ui/frontend/src/components/brief/BriefSeed.tsx
@@ -4,6 +4,32 @@ import { UseBriefReturn } from './useBrief';
 
 const tagClass = (tag: string): string => `brief-tag brief-tag-${tag.toLowerCase()}`;
 
+// The live outline-generation panel: spinner + streamed research activity.
+// Shown by BriefSeed (anonymous) and BriefTab's Brief Central flow (logged in).
+export const BriefGeneratingPanel: React.FC<{ brief: UseBriefReturn }> = ({ brief }) => (
+  <div className="brief-seed">
+    <div className="brief-eyebrow">EVIDENCE BRIEF</div>
+    <h2 className="brief-seed-title">Researching “{brief.query.trim()}”</h2>
+    <p className="brief-seed-lede">
+      Surveying the document library to shape an outline grounded in what the system contains…
+    </p>
+    <div className="brief-generating">
+      <div className="brief-researching-head">
+        <span className="brief-spinner" />
+        <span className="brief-researching-label">Deep research in progress</span>
+      </div>
+      <div className="brief-activity">
+        {brief.generatingActivity.map((ev, i) => (
+          <div className="brief-activity-row" key={`${ev.tag}-${i}`}>
+            <span className={tagClass(ev.tag)}>{ev.tag}</span>
+            <span>{ev.text}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+);
+
 interface BriefSeedProps {
   brief: UseBriefReturn;
 }
@@ -24,29 +50,7 @@ export const BriefSeed: React.FC<BriefSeedProps> = ({ brief }) => {
 
   // While the outline-generation deep research runs, show its live activity.
   if (outlineLoading) {
-    return (
-      <div className="brief-seed">
-        <div className="brief-eyebrow">EVIDENCE BRIEF</div>
-        <h2 className="brief-seed-title">Researching “{query.trim()}”</h2>
-        <p className="brief-seed-lede">
-          Surveying the document library to shape an outline grounded in what the system contains…
-        </p>
-        <div className="brief-generating">
-          <div className="brief-researching-head">
-            <span className="brief-spinner" />
-            <span className="brief-researching-label">Deep research in progress</span>
-          </div>
-          <div className="brief-activity">
-            {brief.generatingActivity.map((ev, i) => (
-              <div className="brief-activity-row" key={`${ev.tag}-${i}`}>
-                <span className={tagClass(ev.tag)}>{ev.tag}</span>
-                <span>{ev.text}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    );
+    return <BriefGeneratingPanel brief={brief} />;
   }
 
   return (
@@ -105,7 +109,7 @@ export const BriefSeed: React.FC<BriefSeedProps> = ({ brief }) => {
         <div className="brief-seed-actions">
           <button
             className="brief-btn brief-btn-primary"
-            onClick={generateOutline}
+            onClick={() => void generateOutline()}
             disabled={!query.trim()}
           >
             <IconSparkle /> Generate outline

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -19,6 +19,7 @@ import {
 import { BriefDocument } from './BriefDocument';
 import { BriefHistoryModal } from './BriefHistoryModal';
 import { BriefHistoryRail } from './BriefHistoryRail';
+import { BriefToc } from './BriefToc';
 import { IconArrowLeft } from './BriefIcons';
 import { BriefGeneratingPanel, BriefSeed } from './BriefSeed';
 import { DEFAULT_BRIEF_TITLE } from './briefTypes';
@@ -102,7 +103,11 @@ const BriefWorkspace: React.FC<{
   exportBusy: boolean;
   onOpenModal: (modal: 'share' | 'template') => void;
 }> = ({ brief, loggedIn, onBack, onResultClick, onExportWord, exportBusy, onOpenModal }) => {
-  const withRail = !loggedIn || brief.canEdit;
+  // Logged-in layout (Brief Central): the side rail is the sticky Contents
+  // panel — history lives on the landing page. Anonymous layout keeps the
+  // saved-briefs history rail and the inline Contents panel.
+  const canEditStructure =
+    brief.canEdit && !brief.sections.some((s) => s.status === 'researching');
   return (
     <>
       {brief.error && <div className="brief-error brief-error-banner">{brief.error}</div>}
@@ -113,8 +118,14 @@ const BriefWorkspace: React.FC<{
           </button>
         </div>
       )}
-      <div className={`brief-builder${withRail ? '' : ' brief-builder-solo'}`}>
-        {withRail && <BriefHistoryRail brief={brief} />}
+      <div className="brief-builder">
+        {loggedIn ? (
+          <aside className="brief-toc-rail">
+            <BriefToc brief={brief} canEdit={canEditStructure} />
+          </aside>
+        ) : (
+          <BriefHistoryRail brief={brief} />
+        )}
         <BriefDocument
           brief={brief}
           onResultClick={onResultClick}
@@ -124,6 +135,7 @@ const BriefWorkspace: React.FC<{
             loggedIn && brief.currentBriefId ? () => onOpenModal('share') : undefined
           }
           onSaveTemplate={loggedIn ? () => onOpenModal('template') : undefined}
+          showToc={!loggedIn}
         />
       </div>
     </>

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -108,6 +108,18 @@ const BriefWorkspace: React.FC<{
   // saved-briefs history rail and the inline Contents panel.
   const canEditStructure =
     brief.canEdit && !brief.sections.some((s) => s.status === 'researching');
+  // Offset the sticky rail below the app's sticky top bar so the first
+  // headings never slide underneath it.
+  const [railTop, setRailTop] = useState(88);
+  useEffect(() => {
+    const measure = () => {
+      const bar = document.querySelector('.top-bar');
+      setRailTop((bar instanceof HTMLElement ? bar.offsetHeight : 72) + 16);
+    };
+    measure();
+    window.addEventListener('resize', measure);
+    return () => window.removeEventListener('resize', measure);
+  }, []);
   return (
     <>
       {brief.error && <div className="brief-error brief-error-banner">{brief.error}</div>}
@@ -120,7 +132,10 @@ const BriefWorkspace: React.FC<{
       )}
       <div className="brief-builder">
         {loggedIn ? (
-          <aside className="brief-toc-rail">
+          <aside
+            className="brief-toc-rail"
+            style={{ top: railTop, maxHeight: `calc(100vh - ${railTop + 16}px)` }}
+          >
             <BriefToc brief={brief} canEdit={canEditStructure} />
           </aside>
         ) : (
@@ -150,6 +165,9 @@ interface BriefTabProps {
   // users). Applied to brief searches only when logged in.
   rerankerModel?: string | null;
   searchSettings?: Partial<SearchSettings> | null;
+  // Model for the LLM semantic highlighter (combo.semantic_highlighting_model),
+  // used to mark claim-supporting spans in citation excerpts.
+  semanticModelConfig?: SummaryModelConfig | null;
   // Opens the document preview (citations/footnotes click through to it).
   onResultClick?: (result: SearchResult) => void;
 }
@@ -159,6 +177,7 @@ export const BriefTab: React.FC<BriefTabProps> = ({
   assistantModelConfig,
   rerankerModel,
   searchSettings,
+  semanticModelConfig,
   onResultClick,
 }) => {
   const auth = useAuth();
@@ -179,6 +198,7 @@ export const BriefTab: React.FC<BriefTabProps> = ({
     userKey,
     remote: loggedIn,
     voices: central.voices,
+    semanticModelConfig,
   });
   const [exportBusy, setExportBusy] = useState(false);
   const [workspaceModal, setWorkspaceModal] = useState<'share' | 'template' | null>(null);

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -294,7 +294,7 @@ export const BriefTab: React.FC<BriefTabProps> = ({
   );
 
   return (
-    <div className="brief-tab">
+    <div className={`brief-tab${brief.stage === 'seed' ? '' : ' brief-tab-full'}`}>
       {brief.stage === 'seed' ? (
         landing
       ) : (

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -1,6 +1,6 @@
 import { saveAs } from 'file-saver';
-import React, { useCallback, useState } from 'react';
-import API_BASE_URL, { USER_MODULE } from '../../config';
+import React, { useCallback, useEffect, useState } from 'react';
+import API_BASE_URL, { APP_BASE_PATH, USER_MODULE } from '../../config';
 import { useAuth } from '../../hooks/useAuth';
 import { SearchResult, SourceReference, SummaryModelConfig } from '../../types/api';
 import { SearchSettings } from '../../types/auth';
@@ -9,12 +9,34 @@ import {
   exportResultsToDocxBlob,
 } from '../../utils/exportResultsToDocx';
 import { buildGlobalCitations } from './briefCitations';
+import { BriefCentral } from './BriefCentral';
+import {
+  BriefShareModal,
+  BriefTemplateModal,
+  NewBriefSubmit,
+  TemplateDraft,
+} from './BriefCentralModals';
 import { BriefDocument } from './BriefDocument';
 import { BriefHistoryModal } from './BriefHistoryModal';
 import { BriefHistoryRail } from './BriefHistoryRail';
-import { BriefSeed } from './BriefSeed';
+import { IconArrowLeft } from './BriefIcons';
+import { BriefGeneratingPanel, BriefSeed } from './BriefSeed';
+import { DEFAULT_BRIEF_TITLE } from './briefTypes';
 import { useBrief } from './useBrief';
+import { useBriefCentral } from './useBriefCentral';
 import './brief.css';
+
+// /brief/<server-uuid> deep links (share URLs). Base-path aware.
+const briefPath = (id: string | null): string => {
+  const suffix = id ? `/brief/${id}` : '/brief';
+  return `${APP_BASE_PATH || ''}${suffix}`;
+};
+
+const briefIdFromLocation = (): string | null => {
+  const path = window.location.pathname;
+  const match = path.match(/\/brief\/([0-9a-f-]{36})\/?$/i);
+  return match ? match[1] : null;
+};
 
 export const sourceToResult = (src: SourceReference, dataSource: string): SearchResult => ({
   chunk_id: src.chunkId,
@@ -69,6 +91,45 @@ const assembleBriefForExport = (
   return { summary: lines.join('\n'), results };
 };
 
+// The open-brief view: back button (logged in), history rail (owners) and the
+// document itself. Extracted from BriefTab to keep each component simple.
+const BriefWorkspace: React.FC<{
+  brief: ReturnType<typeof useBrief>;
+  loggedIn: boolean;
+  onBack: () => void;
+  onResultClick?: (result: SearchResult) => void;
+  onExportWord: (style: 'links' | 'footnotes') => void;
+  exportBusy: boolean;
+  onOpenModal: (modal: 'share' | 'template') => void;
+}> = ({ brief, loggedIn, onBack, onResultClick, onExportWord, exportBusy, onOpenModal }) => {
+  const withRail = !loggedIn || brief.canEdit;
+  return (
+    <>
+      {brief.error && <div className="brief-error brief-error-banner">{brief.error}</div>}
+      {loggedIn && (
+        <div className="brief-back-row">
+          <button className="brief-back-btn" onClick={onBack}>
+            <IconArrowLeft /> Brief Central
+          </button>
+        </div>
+      )}
+      <div className={`brief-builder${withRail ? '' : ' brief-builder-solo'}`}>
+        {withRail && <BriefHistoryRail brief={brief} />}
+        <BriefDocument
+          brief={brief}
+          onResultClick={onResultClick}
+          onExportWord={onExportWord}
+          exportBusy={exportBusy}
+          onOpenShare={
+            loggedIn && brief.currentBriefId ? () => onOpenModal('share') : undefined
+          }
+          onSaveTemplate={loggedIn ? () => onOpenModal('template') : undefined}
+        />
+      </div>
+    </>
+  );
+};
+
 interface BriefTabProps {
   dataSource: string;
   // The configured chat / deep-research model, used for outline + section research.
@@ -92,6 +153,9 @@ export const BriefTab: React.FC<BriefTabProps> = ({
   // Logged-in users get their own saved-briefs bucket; anonymous users share one.
   const userKey = USER_MODULE && auth.user ? String(auth.user.id) : null;
   const loggedIn = userKey != null;
+  // Logged-in users get Brief Central: server-side briefs, sharing, templates
+  // and voice & tone profiles. Anonymous users keep the localStorage flow.
+  const central = useBriefCentral(loggedIn);
   const brief = useBrief({
     apiBaseUrl: API_BASE_URL,
     dataSource,
@@ -101,8 +165,55 @@ export const BriefTab: React.FC<BriefTabProps> = ({
     rerankerModel: loggedIn ? rerankerModel ?? null : null,
     searchSettings: loggedIn ? searchSettings ?? null : null,
     userKey,
+    remote: loggedIn,
+    voices: central.voices,
   });
   const [exportBusy, setExportBusy] = useState(false);
+  const [workspaceModal, setWorkspaceModal] = useState<'share' | 'template' | null>(null);
+
+  // Deep link: open /brief/<id> (a share URL) once auth has resolved.
+  const { openBriefById } = brief;
+  useEffect(() => {
+    if (!loggedIn) return;
+    const id = briefIdFromLocation();
+    if (id) openBriefById(id);
+  }, [loggedIn, openBriefById]);
+
+  const openBrief = useCallback(
+    (id: string) => {
+      brief.openBriefById(id);
+      window.history.pushState(null, '', briefPath(id));
+    },
+    [brief],
+  );
+
+  const backToCentral = useCallback(() => {
+    brief.reset();
+    window.history.pushState(null, '', briefPath(null));
+    void central.refresh();
+  }, [brief, central]);
+
+  const createBrief = useCallback(
+    (args: NewBriefSubmit) => {
+      brief.setQuery(args.title);
+      brief.setInstructions(args.instructions);
+      brief.setNumHeadings(args.numHeadings);
+      brief.setBriefVoiceId(args.voiceId);
+      if (args.mode === 'ai') {
+        void brief.generateOutline({
+          topic: args.title,
+          instructions: args.instructions,
+          numHeadings: args.numHeadings,
+        });
+        return;
+      }
+      brief.startFromTemplate(
+        args.title || args.template?.name || DEFAULT_BRIEF_TITLE,
+        args.template ? args.template.headings : [],
+      );
+    },
+    [brief],
+  );
 
   const handleExportWord = useCallback(
     async (citationStyle: 'links' | 'footnotes' = 'links') => {
@@ -111,12 +222,12 @@ export const BriefTab: React.FC<BriefTabProps> = ({
       try {
         const { summary, results } = assembleBriefForExport(brief, dataSource);
         const blob = await exportResultsToDocxBlob({
-          query: brief.briefTitle || 'Evidence Brief',
+          query: brief.briefTitle || DEFAULT_BRIEF_TITLE,
           aiSummary: summary,
           results,
           dataSource,
           documentTitle: 'AI-generated Research Brief',
-          summaryHeading: brief.briefTitle || 'Evidence Brief',
+          summaryHeading: brief.briefTitle || DEFAULT_BRIEF_TITLE,
           infoBox: BRIEF_DISCLAIMER,
           tableOfContents: true,
           resultsSectionTitle: 'Reference Excerpts',
@@ -139,25 +250,79 @@ export const BriefTab: React.FC<BriefTabProps> = ({
     [exportBusy, brief, dataSource],
   );
 
+  // The template draft when saving the open brief's headings as a template.
+  const templateFromBrief: TemplateDraft = {
+    fromBrief: true,
+    name: `${brief.briefTitle.slice(0, 40)} template`,
+    description: 'Saved from a brief',
+    headings: brief.sections.map((s) => ({
+      title: s.title,
+      sub: s.level === 2,
+      text: s.content || null,
+    })),
+    withText: false,
+  };
+
+  // Logged-in outline generation runs from the New-brief modal — surface the
+  // live research activity instead of silently sitting on the landing page.
+  const landing = loggedIn ? (
+    brief.outlineLoading ? (
+      <>
+        {brief.error && <div className="brief-error brief-error-banner">{brief.error}</div>}
+        <BriefGeneratingPanel brief={brief} />
+      </>
+    ) : (
+      <>
+        {brief.error && <div className="brief-error brief-error-banner">{brief.error}</div>}
+        <BriefCentral central={central} onOpenBrief={openBrief} onCreateBrief={createBrief} />
+      </>
+    )
+  ) : (
+    <BriefSeed brief={brief} />
+  );
+
   return (
     <div className="brief-tab">
       {brief.stage === 'seed' ? (
-        <BriefSeed brief={brief} />
+        landing
       ) : (
-        <>
-          {brief.error && <div className="brief-error brief-error-banner">{brief.error}</div>}
-          <div className="brief-builder">
-            <BriefHistoryRail brief={brief} />
-            <BriefDocument
-              brief={brief}
-              onResultClick={onResultClick}
-              onExportWord={handleExportWord}
-              exportBusy={exportBusy}
-            />
-          </div>
-        </>
+        <BriefWorkspace
+          brief={brief}
+          loggedIn={loggedIn}
+          onBack={backToCentral}
+          onResultClick={onResultClick}
+          onExportWord={handleExportWord}
+          exportBusy={exportBusy}
+          onOpenModal={setWorkspaceModal}
+        />
       )}
       <BriefHistoryModal brief={brief} />
+      {workspaceModal === 'share' && brief.currentBriefId && (
+        <BriefShareModal
+          briefId={brief.currentBriefId}
+          briefTitle={brief.briefTitle}
+          onChanged={() => void central.refresh()}
+          onClose={() => setWorkspaceModal(null)}
+        />
+      )}
+      {workspaceModal === 'template' && (
+        <BriefTemplateModal
+          draft={templateFromBrief}
+          onSave={async (d) => {
+            await central.saveTemplate({
+              name: d.name,
+              description: d.description || null,
+              headings: d.headings.map((h) => ({
+                ...h,
+                text: d.withText ? h.text : null,
+              })),
+              withText: d.withText,
+            });
+            setWorkspaceModal(null);
+          }}
+          onClose={() => setWorkspaceModal(null)}
+        />
+      )}
     </div>
   );
 };

--- a/ui/frontend/src/components/brief/BriefToc.tsx
+++ b/ui/frontend/src/components/brief/BriefToc.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   closestCenter,
   DndContext,
@@ -30,14 +30,41 @@ const scrollToSection = (id: string): void => {
   el.scrollIntoView({ behavior: 'smooth', block: 'start' });
 };
 
+// Scroll-spy: the id of the section heading nearest above the viewport top
+// (accounting for the sticky top bar), so the TOC can highlight where you are.
+const useActiveSection = (sections: BriefSection[]): string | null => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  useEffect(() => {
+    const track = () => {
+      const bar = document.querySelector('.top-bar');
+      const offset = (bar instanceof HTMLElement ? bar.offsetHeight : 0) + 80;
+      let active: string | null = null;
+      for (const section of sections) {
+        const el = document.getElementById(`brief-section-${section.id}`);
+        if (el && el.getBoundingClientRect().top <= offset) active = section.id;
+      }
+      setActiveId(active ?? (sections.length ? sections[0].id : null));
+    };
+    track();
+    window.addEventListener('scroll', track, { passive: true });
+    window.addEventListener('resize', track);
+    return () => {
+      window.removeEventListener('scroll', track);
+      window.removeEventListener('resize', track);
+    };
+  }, [sections]);
+  return activeId;
+};
+
 interface TocRowProps {
   section: BriefSection;
   num: string;
   brief: UseBriefReturn;
   canEdit: boolean;
+  active: boolean;
 }
 
-const TocRow: React.FC<TocRowProps> = ({ section, num, brief, canEdit }) => {
+const TocRow: React.FC<TocRowProps> = ({ section, num, brief, canEdit, active }) => {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: section.id,
     disabled: !canEdit,
@@ -64,7 +91,9 @@ const TocRow: React.FC<TocRowProps> = ({ section, num, brief, canEdit }) => {
     <div
       ref={setNodeRef}
       style={style}
-      className={`brief-toc-row${section.level === 2 ? ' brief-toc-row-sub' : ''}`}
+      className={`brief-toc-row${section.level === 2 ? ' brief-toc-row-sub' : ''}${
+        active ? ' brief-toc-row-active' : ''
+      }`}
     >
       <div className="brief-toc-row-line">
         {canEdit && (
@@ -143,6 +172,7 @@ interface BriefTocProps {
  */
 export const BriefToc: React.FC<BriefTocProps> = ({ brief, canEdit }) => {
   const { sections, numbers, numberHeadings } = brief;
+  const activeId = useActiveSection(sections);
   const [addingHeading, setAddingHeading] = useState(false);
   const [headingName, setHeadingName] = useState('');
   const closeHeading = (): void => {
@@ -195,6 +225,7 @@ export const BriefToc: React.FC<BriefTocProps> = ({ brief, canEdit }) => {
                 num={numberHeadings ? numbers[i] : ''}
                 brief={brief}
                 canEdit={canEdit}
+                active={s.id === activeId}
               />
             ))}
           </div>

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -100,8 +100,11 @@
   flex-shrink: 0;
 }
 .brief-btn-primary {
-  background: var(--brand-accent);
+  background: var(--color-button-primary, var(--brand-primary));
   color: #fff;
+}
+.brief-btn-primary:hover:not(:disabled) {
+  background: var(--color-button-primary-hover, var(--brand-primary-dark));
 }
 .brief-btn-primary:disabled {
   opacity: 0.55;
@@ -1692,4 +1695,654 @@
   font-size: 12px;
   font-weight: 600;
   color: var(--brand-primary);
+}
+
+/* ---------- Brief Central (landing page) ---------- */
+.bc-page {
+  width: 100%;
+}
+
+.bc-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+}
+
+.bc-title {
+  font-family: var(--font-heading);
+  font-size: 34px;
+  font-weight: 600;
+  color: var(--brand-text-primary);
+  line-height: 1.15;
+  margin: 0 0 10px;
+}
+
+.bc-lede {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--brand-text-secondary);
+  max-width: 660px;
+  margin: 0;
+}
+
+.bc-new-btn {
+  margin-top: 26px;
+}
+
+.bc-tabs {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--brand-border);
+  margin: 26px 0 22px;
+  overflow-x: auto;
+}
+
+.bc-tab {
+  padding: 12px 18px;
+  font-family: var(--font-heading);
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--brand-text);
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  cursor: pointer;
+  margin-bottom: -1px;
+  white-space: nowrap;
+}
+
+.bc-tab:hover {
+  color: var(--brand-primary);
+}
+
+.bc-tab-on {
+  color: var(--brand-primary-dark);
+  font-weight: 700;
+  border-bottom-color: var(--brand-primary);
+}
+
+.bc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.bc-card {
+  background: var(--brand-surface);
+  border: 1px solid var(--brand-border);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  display: flex;
+  flex-direction: column;
+}
+
+.bc-card:hover {
+  border-color: var(--brand-primary);
+}
+
+.bc-card-main {
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 18px 18px 12px;
+  cursor: pointer;
+  flex: 1;
+  font-family: var(--font-body);
+}
+
+.bc-card-static {
+  cursor: default;
+}
+
+.bc-card-title {
+  font-family: var(--font-heading);
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--brand-text-primary);
+  line-height: 1.35;
+  margin-bottom: 6px;
+}
+
+.bc-card-query {
+  font-size: 12.5px;
+  color: var(--brand-text-secondary);
+  line-height: 1.5;
+  margin-bottom: 10px;
+}
+
+.bc-card-meta {
+  font-size: 11.5px;
+  color: var(--brand-text-tertiary);
+}
+
+.bc-card-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--brand-border-light);
+}
+
+.bc-card-foot-note {
+  font-size: 11.5px;
+  color: var(--brand-text-tertiary);
+  margin-left: auto;
+}
+
+.bc-chip {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #fff;
+  background: var(--brand-primary);
+  padding: 2px 6px;
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bc-chip-muted {
+  color: var(--brand-text-secondary);
+  background: var(--brand-border-light);
+}
+
+.bc-card-act {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: 1px solid var(--brand-border);
+  color: var(--brand-text-secondary);
+  font-size: 11.5px;
+  font-weight: 600;
+  font-family: var(--font-heading);
+  padding: 4px 9px;
+  cursor: pointer;
+}
+
+.bc-card-act:hover {
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
+}
+
+.bc-card-act-right {
+  margin-left: auto;
+}
+
+.bc-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  height: 26px;
+  background: none;
+  border: none;
+  color: var(--brand-text-tertiary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+}
+
+.bc-icon-btn:hover,
+.bc-icon-danger:hover {
+  color: var(--brand-error);
+}
+
+.bc-add-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: none;
+  border: 1px dashed var(--brand-border);
+  color: var(--brand-text-secondary);
+  font-family: var(--font-heading);
+  font-size: 13.5px;
+  font-weight: 600;
+  padding: 26px;
+  cursor: pointer;
+  min-height: 150px;
+}
+
+.bc-add-card:hover {
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
+}
+
+.bc-empty {
+  padding: 32px 0;
+  color: var(--brand-text-tertiary);
+  font-size: 14px;
+}
+
+.bc-template-headings {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.bc-heading-row {
+  display: flex;
+  gap: 8px;
+  font-size: 12.5px;
+  color: var(--brand-text-secondary);
+  line-height: 1.45;
+}
+
+.bc-heading-sub {
+  margin-left: 22px;
+}
+
+.bc-heading-num {
+  color: var(--brand-text-tertiary);
+  font-weight: 700;
+  min-width: 22px;
+}
+
+/* ---------- Brief Central modals ---------- */
+.bc-modal {
+  max-width: 580px;
+}
+
+.bc-modal-body {
+  padding: 18px 22px 22px;
+}
+
+.bc-mode-toggle {
+  display: flex;
+  border: 1px solid var(--brand-border);
+  margin-bottom: 18px;
+}
+
+.bc-mode-toggle button {
+  flex: 1;
+  padding: 11px;
+  font-family: var(--font-heading);
+  font-size: 13.5px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  background: var(--brand-surface);
+  color: var(--brand-text-secondary);
+}
+
+.bc-mode-toggle button + button {
+  border-left: 1px solid var(--brand-border);
+}
+
+.bc-mode-toggle .bc-mode-on {
+  background: var(--color-button-primary, var(--brand-primary));
+  color: #fff;
+}
+
+.bc-title-input {
+  font-size: 16px;
+}
+
+.bc-field-row {
+  display: flex;
+  gap: 14px;
+}
+
+.bc-field {
+  flex: 1;
+  min-width: 0;
+}
+
+.bc-field-num {
+  flex: 0 0 96px;
+}
+
+.bc-select,
+.bc-input {
+  width: 100%;
+  border: 1px solid var(--brand-border);
+  background: var(--brand-surface);
+  padding: 10px;
+  font-size: 14px;
+  font-family: var(--font-body);
+  color: var(--brand-text-primary);
+  outline: none;
+}
+
+.bc-select:focus,
+.bc-input:focus {
+  border-color: var(--brand-primary);
+}
+
+.bc-hint {
+  font-size: 12.5px;
+  color: var(--brand-text-tertiary);
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
+.bc-kicker {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--brand-text-tertiary);
+  margin-bottom: 8px;
+}
+
+.bc-kicker-spaced {
+  margin-top: 18px;
+}
+
+.bc-template-preview {
+  margin-top: 12px;
+  background: var(--brand-bg);
+  border: 1px solid var(--brand-border-light);
+  padding: 12px 14px;
+}
+
+.bc-modal-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.bc-inline-panel {
+  margin-top: 14px;
+  background: var(--brand-bg);
+  border: 1px solid var(--brand-border-light);
+  padding: 10px 12px;
+}
+
+.bc-inline-panel-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.bc-inline-panel-title {
+  font-family: var(--font-heading);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--brand-text-primary);
+}
+
+.bc-heading-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bc-heading-edit {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.bc-heading-edit .bc-heading-num {
+  font-size: 13px;
+  min-width: 26px;
+}
+
+.bc-heading-edit .bc-input {
+  padding: 9px 10px;
+  font-size: 13.5px;
+}
+
+.bc-add-dashed {
+  margin-top: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: 1px dashed var(--brand-border);
+  color: var(--brand-text-secondary);
+  font-family: var(--font-heading);
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 8px 14px;
+  cursor: pointer;
+}
+
+.bc-add-dashed:hover {
+  border-color: var(--brand-primary);
+  color: var(--brand-primary);
+}
+
+.bc-voice-textarea {
+  resize: vertical;
+}
+
+.bc-delete-btn {
+  margin-left: auto;
+  background: none;
+  border: 1px solid var(--brand-border);
+  color: var(--brand-error);
+  font-family: var(--font-heading);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 9px 14px;
+  cursor: pointer;
+}
+
+.bc-share-row {
+  display: flex;
+  gap: 8px;
+}
+
+.bc-share-row .bc-input {
+  flex: 1;
+  min-width: 0;
+}
+
+.bc-share-url {
+  font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace;
+  font-size: 12.5px;
+  color: var(--brand-text-secondary);
+  background: var(--brand-bg);
+}
+
+.bc-share-list {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bc-share-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border: 1px solid var(--brand-border-light);
+  padding: 10px 12px;
+}
+
+.bc-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--brand-border-light);
+  color: var(--brand-text);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.bc-share-item-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.bc-share-item-name {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--brand-text-primary);
+}
+
+.bc-share-item-kind {
+  font-size: 11.5px;
+  color: var(--brand-text-tertiary);
+}
+
+.bc-viewer-chip {
+  font-size: 11.5px;
+  color: var(--brand-text-secondary);
+  background: var(--brand-bg);
+  padding: 3px 8px;
+}
+
+/* ---------- workspace additions ---------- */
+.brief-back-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.brief-back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--brand-surface);
+  border: 1px solid var(--brand-border);
+  color: var(--brand-text-secondary);
+  font-family: var(--font-heading);
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 13px;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.brief-back-btn:hover {
+  background: var(--brand-border-light);
+  color: var(--brand-text-primary);
+}
+
+.brief-viewer-chip {
+  font-size: 12.5px;
+  font-style: italic;
+  color: var(--brand-text-tertiary);
+}
+
+.brief-regen-voice-label {
+  font-family: var(--font-heading);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--brand-text-secondary);
+  margin: 12px 0 6px;
+}
+
+.brief-regen-voice-select {
+  width: 100%;
+  border: 1px solid var(--brand-border);
+  background: var(--brand-surface);
+  padding: 9px 10px;
+  font-size: 13.5px;
+  font-family: var(--font-body);
+  color: var(--brand-text-primary);
+  outline: none;
+}
+
+.brief-regen-voice-hint {
+  font-size: 12.5px;
+  color: var(--brand-text-secondary);
+  margin-top: 8px;
+  line-height: 1.5;
+}
+
+/* Viewer-only briefs have no history rail — let the document take the row. */
+.brief-builder-solo {
+  grid-template-columns: 1fr;
+}
+
+/* ---------- responsive (matches App.css breakpoints) ---------- */
+@media (max-width: 1024px) {
+  .brief-builder {
+    grid-template-columns: 1fr;
+  }
+
+  .brief-rail {
+    position: static;
+    max-height: none;
+    order: 2;
+  }
+
+  .brief-doc {
+    order: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .brief-tab {
+    padding: 20px 16px 60px;
+  }
+
+  .bc-title {
+    font-size: 26px;
+  }
+
+  .bc-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .bc-header {
+    flex-direction: column;
+  }
+
+  .bc-new-btn {
+    margin-top: 0;
+  }
+
+  .brief-doc {
+    padding: 20px 18px 40px;
+  }
+
+  .brief-doc-header-top {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .brief-doc-header-actions {
+    flex-wrap: wrap;
+  }
+
+  .bc-field-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .bc-field-num {
+    flex: none;
+  }
+
+  .bc-share-row {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .bc-tabs {
+    gap: 0;
+  }
+
+  .bc-tab {
+    padding: 10px 12px;
+    font-size: 13.5px;
+  }
+
+  .brief-modal {
+    margin: 0 8px;
+  }
+
+  .brief-doc-section-tools {
+    flex-wrap: wrap;
+  }
 }

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -2389,3 +2389,84 @@
     flex-wrap: wrap;
   }
 }
+
+/* ---------- floating research status bar ---------- */
+.brief-status-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 20px;
+  transform: translateX(-50%);
+  z-index: 120;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: min(680px, calc(100vw - 32px));
+  padding: 12px 18px;
+  background: var(--brand-primary-dark);
+  color: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.25);
+  border-radius: 8px;
+}
+
+.brief-status-bar-spinner {
+  flex: none;
+  border-color: rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+}
+
+.brief-status-bar-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.brief-status-bar-label {
+  font-family: var(--font-heading);
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1.35;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  overflow: hidden;
+}
+
+.brief-status-bar-count {
+  flex: none;
+  margin-left: auto;
+  font-size: 12px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.brief-status-bar-track {
+  margin-top: 7px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.25);
+  overflow: hidden;
+}
+
+.brief-status-bar-fill {
+  height: 100%;
+  background: #fff;
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+
+.brief-status-bar-stop {
+  flex: none;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  color: #fff;
+  font-family: var(--font-heading);
+  font-size: 12.5px;
+  font-weight: 600;
+  padding: 7px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.brief-status-bar-stop:hover {
+  background: rgba(255, 255, 255, 0.22);
+}

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -2257,9 +2257,20 @@
   line-height: 1.5;
 }
 
-/* Viewer-only briefs have no history rail — let the document take the row. */
-.brief-builder-solo {
-  grid-template-columns: 1fr;
+/* Logged-in workspace: the Contents panel is the sticky side rail (history
+   lives in Brief Central). */
+.brief-toc-rail {
+  position: sticky;
+  top: 16px;
+  align-self: start;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+}
+
+.brief-toc-rail .brief-toc {
+  margin: 0;
+  background: var(--brand-surface);
+  border: 1px solid var(--brand-border);
 }
 
 /* ---------- responsive (matches App.css breakpoints) ---------- */
@@ -2272,6 +2283,12 @@
     position: static;
     max-height: none;
     order: 2;
+  }
+
+  /* Contents stays above the document on small screens for quick navigation. */
+  .brief-toc-rail {
+    position: static;
+    max-height: none;
   }
 
   .brief-doc {

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -2286,6 +2286,19 @@
   border: 1px solid var(--brand-border);
 }
 
+/* Scroll-spy: the section currently in view. (No side accent bars.) The
+   tint bleeds past the text into the panel padding on both sides. */
+.brief-toc-row-active .brief-toc-row-line {
+  background: rgba(91, 143, 168, 0.1);
+  margin: 0 -10px;
+  padding: 2px 10px;
+}
+
+.brief-toc-row-active .brief-toc-text {
+  color: var(--brand-primary-dark);
+  font-weight: 600;
+}
+
 /* ---------- responsive (matches App.css breakpoints) ---------- */
 @media (max-width: 1024px) {
   .brief-builder {

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -1434,7 +1434,8 @@
   flex: 1;
   min-width: 0;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
+  text-align: left;
   gap: 8px;
   background: none;
   border: none;
@@ -1454,9 +1455,11 @@
   color: var(--brand-text-tertiary);
 }
 .brief-toc-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  line-height: 1.35;
 }
 .brief-toc-dot {
   flex: none;

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -2260,6 +2260,16 @@
   line-height: 1.5;
 }
 
+/* An open brief uses the full window width; the document fills the space left
+   of the side rail instead of capping at reading width. */
+.brief-tab-full {
+  max-width: none;
+}
+
+.brief-tab-full .brief-doc {
+  max-width: none;
+}
+
 /* Logged-in workspace: the Contents panel is the sticky side rail (history
    lives in Brief Central). */
 .brief-toc-rail {

--- a/ui/frontend/src/components/brief/briefCentralApi.ts
+++ b/ui/frontend/src/components/brief/briefCentralApi.ts
@@ -1,0 +1,151 @@
+import axios from 'axios';
+import API_BASE_URL from '../../config';
+import {
+  BriefListItem,
+  BriefTemplate,
+  BriefTemplateHeading,
+  RemoteBrief,
+  SavedBrief,
+  VoiceProfile,
+} from './briefTypes';
+
+/**
+ * Axios client for the Brief Central backend (briefs, shares, templates and
+ * voice & tone profiles). All endpoints require the user module: auth rides on
+ * the httpOnly cookie + the global axios CSRF interceptor.
+ */
+
+// List endpoints must return JSON arrays; anything else (an HTML error page, a
+// proxy error object) is a hard failure surfaced to the caller.
+const expectArray = <T>(data: unknown, what: string): T[] => {
+  if (!Array.isArray(data)) throw new Error(`Unexpected ${what} response`);
+  return data as T[];
+};
+
+export const listMyBriefs = async (): Promise<BriefListItem[]> => {
+  const res = await axios.get(`${API_BASE_URL}/briefs/`);
+  return expectArray<BriefListItem>(res.data, 'briefs');
+};
+
+export const listSharedBriefs = async (): Promise<BriefListItem[]> => {
+  const res = await axios.get(`${API_BASE_URL}/briefs/shared`);
+  return expectArray<BriefListItem>(res.data, 'shared briefs');
+};
+
+export const getBrief = async (id: string): Promise<RemoteBrief> => {
+  const res = await axios.get(`${API_BASE_URL}/briefs/${id}`);
+  return res.data as RemoteBrief;
+};
+
+export const createBrief = async (args: {
+  title: string;
+  query: string | null;
+  dataSource: string | null;
+  voiceProfileId: string | null;
+  content: SavedBrief;
+}): Promise<RemoteBrief> => {
+  const res = await axios.post(`${API_BASE_URL}/briefs/`, {
+    title: args.title,
+    query: args.query,
+    data_source: args.dataSource,
+    voice_profile_id: args.voiceProfileId,
+    content: args.content,
+  });
+  return res.data as RemoteBrief;
+};
+
+export const updateBrief = async (
+  id: string,
+  args: {
+    title?: string;
+    query?: string | null;
+    voiceProfileId?: string | null;
+    content?: SavedBrief;
+  },
+): Promise<RemoteBrief> => {
+  const res = await axios.put(`${API_BASE_URL}/briefs/${id}`, {
+    title: args.title,
+    query: args.query,
+    voice_profile_id: args.voiceProfileId,
+    content: args.content,
+  });
+  return res.data as RemoteBrief;
+};
+
+export const deleteBriefRemote = async (id: string): Promise<void> => {
+  await axios.delete(`${API_BASE_URL}/briefs/${id}`);
+};
+
+export const addBriefShare = async (
+  briefId: string,
+  target: string,
+): Promise<RemoteBrief> => {
+  const res = await axios.post(`${API_BASE_URL}/briefs/${briefId}/shares`, { target });
+  return res.data as RemoteBrief;
+};
+
+export const removeBriefShare = async (
+  briefId: string,
+  shareId: string,
+): Promise<void> => {
+  await axios.delete(`${API_BASE_URL}/briefs/${briefId}/shares/${shareId}`);
+};
+
+// ---- templates ----
+
+export const listTemplates = async (): Promise<BriefTemplate[]> => {
+  const res = await axios.get(`${API_BASE_URL}/brief-templates/`);
+  return expectArray<BriefTemplate>(res.data, 'templates');
+};
+
+export const createTemplate = async (args: {
+  name: string;
+  description: string | null;
+  headings: BriefTemplateHeading[];
+  withText: boolean;
+}): Promise<BriefTemplate> => {
+  const res = await axios.post(`${API_BASE_URL}/brief-templates/`, {
+    name: args.name,
+    description: args.description,
+    headings: args.headings,
+    with_text: args.withText,
+  });
+  return res.data as BriefTemplate;
+};
+
+export const deleteTemplate = async (id: string): Promise<void> => {
+  await axios.delete(`${API_BASE_URL}/brief-templates/${id}`);
+};
+
+export const recordTemplateUse = async (id: string): Promise<BriefTemplate> => {
+  const res = await axios.post(`${API_BASE_URL}/brief-templates/${id}/use`);
+  return res.data as BriefTemplate;
+};
+
+// ---- voice profiles ----
+
+export const listVoiceProfiles = async (): Promise<VoiceProfile[]> => {
+  const res = await axios.get(`${API_BASE_URL}/voice-profiles/`);
+  return expectArray<VoiceProfile>(res.data, 'voice profiles');
+};
+
+export const createVoiceProfile = async (args: {
+  name: string;
+  description: string | null;
+  instructions: string;
+}): Promise<VoiceProfile> => {
+  const res = await axios.post(`${API_BASE_URL}/voice-profiles/`, args);
+  return res.data as VoiceProfile;
+};
+
+export const updateVoiceProfile = async (
+  id: string,
+  args: { name: string; description: string | null; instructions: string },
+): Promise<VoiceProfile> => {
+  const res = await axios.put(`${API_BASE_URL}/voice-profiles/${id}`, args);
+  return res.data as VoiceProfile;
+};
+
+export const deleteVoiceProfile = async (id: string): Promise<void> => {
+  await axios.delete(`${API_BASE_URL}/voice-profiles/${id}`);
+};

--- a/ui/frontend/src/components/brief/briefHighlights.ts
+++ b/ui/frontend/src/components/brief/briefHighlights.ts
@@ -41,6 +41,10 @@ export interface HighlightSectionArgs {
   modelConfig?: SummaryModelConfig | null;
   // Abort check — polled between sources so a stale run stops early.
   isStale?: () => boolean;
+  // Called after each source resolves with the full source list (enriched so
+  // far + untouched rest), so the UI can show snippets as they arrive instead
+  // of waiting for the whole section.
+  onPartial?: (sources: SourceReference[]) => void;
 }
 
 /**
@@ -56,6 +60,7 @@ export const highlightSectionSources = async ({
   threshold,
   modelConfig,
   isStale,
+  onPartial,
 }: HighlightSectionArgs): Promise<SourceReference[]> => {
   const cited = new Set(extractCitedNumbers(content));
   const out: SourceReference[] = [];
@@ -79,6 +84,7 @@ export const highlightSectionSources = async ({
     try {
       const matches = await findSemanticMatches(body, claim, threshold, modelConfig);
       out.push(matches.length ? { ...source, semanticMatches: matches } : source);
+      if (matches.length) onPartial?.(out.concat(sources.slice(out.length)));
     } catch {
       // Highlighting is an enhancement — the full excerpt remains the fallback.
       out.push(source);

--- a/ui/frontend/src/components/brief/briefHighlights.ts
+++ b/ui/frontend/src/components/brief/briefHighlights.ts
@@ -1,0 +1,88 @@
+import { SourceReference, SummaryModelConfig } from '../../types/api';
+import { findSemanticMatches } from '../../utils/textHighlighting';
+import { extractCitedNumbers, parseSectionBreadcrumb } from '../citations/CitedContent';
+
+/**
+ * LLM-highlighted citation excerpts for the Brief tab.
+ *
+ * After a section's research completes (references validated), each cited
+ * source's excerpt is run through the existing semantic-highlighting LLM with
+ * the claim it supports — the sentence(s) carrying that `[n]` marker — so the
+ * hover card can emphasise exactly the part of the excerpt backing the claim.
+ * When the LLM returns nothing the excerpt simply renders in full, unmarked.
+ */
+
+// Sentences end at ./!/? followed by whitespace; markdown headings and list
+// items break sentences too. Good enough for claim extraction — the claim only
+// steers the highlighter, it is never shown to the user.
+const SENTENCE_SPLIT_RE = /(?<=[.!?])\s+|\n+/;
+
+/** The sentence(s) of the section that cite source `n`, joined together. */
+export const extractClaimForCitation = (markdown: string, n: number): string => {
+  const marker = new RegExp(`\\[(?:\\d+,\\s*)*${n}(?:,\\s*\\d+)*\\]`);
+  const sentences = markdown
+    .split(SENTENCE_SPLIT_RE)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const claims = sentences.filter((s) => marker.test(s));
+  return claims
+    .join(' ')
+    // Strip citation markers and markdown decoration so the LLM sees prose.
+    .replace(/\[(?:\d+,\s*)*\d+\]/g, '')
+    .replace(/[#*_>`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+};
+
+export interface HighlightSectionArgs {
+  content: string;
+  sources: SourceReference[];
+  threshold: number;
+  modelConfig?: SummaryModelConfig | null;
+  // Abort check — polled between sources so a stale run stops early.
+  isStale?: () => boolean;
+}
+
+/**
+ * Compute LLM highlight matches for every cited source's excerpt, serially
+ * (matching the app's post-search highlighting pattern). Match offsets are
+ * relative to the excerpt *body* (after the heading-breadcrumb line the hover
+ * card splits off). Sources that fail or return nothing keep no matches — the
+ * hover card falls back to the full excerpt.
+ */
+export const highlightSectionSources = async ({
+  content,
+  sources,
+  threshold,
+  modelConfig,
+  isStale,
+}: HighlightSectionArgs): Promise<SourceReference[]> => {
+  const cited = new Set(extractCitedNumbers(content));
+  const out: SourceReference[] = [];
+  for (const source of sources) {
+    if (isStale?.()) return out.concat(sources.slice(out.length));
+    if (
+      source.index == null ||
+      !cited.has(source.index) ||
+      !source.text ||
+      source.semanticMatches?.length
+    ) {
+      out.push(source);
+      continue;
+    }
+    const claim = extractClaimForCitation(content, source.index);
+    if (!claim) {
+      out.push(source);
+      continue;
+    }
+    const { body } = parseSectionBreadcrumb(source.text);
+    try {
+      const matches = await findSemanticMatches(body, claim, threshold, modelConfig);
+      out.push(matches.length ? { ...source, semanticMatches: matches } : source);
+    } catch {
+      // Highlighting is an enhancement — the full excerpt remains the fallback.
+      out.push(source);
+    }
+  }
+  return out;
+};

--- a/ui/frontend/src/components/brief/briefRemote.ts
+++ b/ui/frontend/src/components/brief/briefRemote.ts
@@ -1,0 +1,79 @@
+import {
+  BRIEF_HISTORY_KEY,
+  BRIEF_MIGRATED_KEY,
+  BriefListItem,
+  RemoteBrief,
+  SavedBrief,
+} from './briefTypes';
+import { createBrief } from './briefCentralApi';
+
+/**
+ * Mapping helpers between the server brief models and the local SavedBrief
+ * shape the Brief UI already uses, plus the one-time localStorage migration.
+ */
+
+// A compact server row as a SavedBrief "stub": everything the history rail
+// needs; `sections` stays empty until the full brief is fetched on open.
+export const listItemToStub = (item: BriefListItem): SavedBrief => ({
+  id: item.id,
+  title: item.title,
+  query: item.query || '',
+  date: Date.parse(item.updated_at) || Date.now(),
+  sectionCount: item.section_count,
+  sourceCount: item.source_count,
+  sections: [],
+  voiceId: item.voice_profile_id,
+});
+
+// The server stores the full SavedBrief payload as `content`; re-stamp the
+// server id so local state and server rows stay keyed identically.
+export const remoteToSaved = (remote: RemoteBrief): SavedBrief => ({
+  ...remote.content,
+  id: remote.id,
+  title: remote.title,
+  query: remote.query || remote.content.query || '',
+  voiceId: remote.voice_profile_id,
+});
+
+/**
+ * One-time migration: upload any briefs from the user's localStorage bucket to
+ * the server, then mark the bucket migrated (per user) so this never repeats.
+ * Returns the number of briefs uploaded.
+ */
+export const migrateLocalBriefs = async (
+  userKey: string,
+  dataSource: string | null,
+): Promise<number> => {
+  const migratedKey = `${BRIEF_MIGRATED_KEY}_u_${userKey}`;
+  try {
+    if (localStorage.getItem(migratedKey)) return 0;
+  } catch {
+    return 0;
+  }
+  const bucketKey = `${BRIEF_HISTORY_KEY}_u_${userKey}`;
+  let entries: SavedBrief[] = [];
+  try {
+    const raw = localStorage.getItem(bucketKey);
+    entries = raw ? (JSON.parse(raw) as SavedBrief[]) : [];
+  } catch {
+    entries = [];
+  }
+  let uploaded = 0;
+  for (const entry of entries) {
+    if (!entry.sections?.length) continue;
+    await createBrief({
+      title: entry.title,
+      query: entry.query || null,
+      dataSource,
+      voiceProfileId: entry.voiceId ?? null,
+      content: entry,
+    });
+    uploaded += 1;
+  }
+  try {
+    localStorage.setItem(migratedKey, String(Date.now()));
+  } catch {
+    /* storage may be unavailable; migration simply reruns next session */
+  }
+  return uploaded;
+};

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -57,6 +57,8 @@ export interface BriefSection {
   prevSources?: SourceReference[];
   // The kind of the most recent AI op that changed content, for the changes UI.
   lastChangeKind?: SectionAuditKind;
+  // Voice & tone profile override for this section (null/absent = brief default).
+  voiceId?: string | null;
 }
 
 export interface BriefReference {
@@ -75,6 +77,7 @@ export interface SavedBriefSection {
   sources: SourceReference[];
   audit?: SectionAuditEntry[];
   lastResearchedAt?: number;
+  voiceId?: string | null;
 }
 
 export interface SavedBrief {
@@ -92,6 +95,84 @@ export interface SavedBrief {
   // Stable UUID used as the Activity-log search_id, so each save updates the
   // same activity row instead of creating duplicates.
   activityId?: string;
+  // Brief-level voice & tone profile id (sections may override individually).
+  voiceId?: string | null;
 }
 
 export const BRIEF_HISTORY_KEY = 'evidencelab_brief_history_v1';
+
+// Default title for a brief before the user names it.
+export const DEFAULT_BRIEF_TITLE = 'Evidence Brief';
+
+// Set once the localStorage briefs bucket has been uploaded to the server
+// (per user), so the one-time migration never repeats.
+export const BRIEF_MIGRATED_KEY = 'evidencelab_brief_migrated_v1';
+
+// ---------------------------------------------------------------------------
+// Brief Central: templates, voice & tone profiles, sharing
+// ---------------------------------------------------------------------------
+
+export interface VoiceProfile {
+  id: string;
+  name: string;
+  description: string | null;
+  instructions: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BriefTemplateHeading {
+  title: string;
+  sub: boolean;
+  // Optional saved section text ("include section text" templates).
+  text?: string | null;
+}
+
+export interface BriefTemplate {
+  id: string;
+  name: string;
+  description: string | null;
+  headings: BriefTemplateHeading[];
+  with_text: boolean;
+  use_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BriefShareTarget {
+  id: string;
+  name: string;
+  kind: string; // the user's email, or "Group · N members"
+  is_group: boolean;
+}
+
+// Compact card for the Brief Central grids (no section content).
+export interface BriefListItem {
+  id: string;
+  title: string;
+  query: string | null;
+  data_source: string | null;
+  voice_profile_id: string | null;
+  section_count: number;
+  source_count: number;
+  owner_name: string | null;
+  share_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// Full server brief; `content` is the SavedBrief payload.
+export interface RemoteBrief {
+  id: string;
+  user_id: string;
+  title: string;
+  query: string | null;
+  data_source: string | null;
+  voice_profile_id: string | null;
+  content: SavedBrief;
+  owner_name: string | null;
+  can_edit: boolean;
+  shared_with: BriefShareTarget[];
+  created_at: string;
+  updated_at: string;
+}

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -326,6 +326,11 @@ export const useBrief = ({
         threshold: SEMANTIC_HIGHLIGHT_THRESHOLD,
         modelConfig: semanticModelConfigRef.current,
         isStale,
+        // Apply snippets as each source resolves — a big section takes minutes
+        // to fully enrich and the hover cards should improve as it goes.
+        onPartial: (sources) => {
+          if (!isStale()) updateSection(id, { sources });
+        },
       })
         .then((sources) => {
           if (!isStale()) updateSection(id, { sources });

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -17,9 +17,19 @@ import {
   BriefReference,
   BriefSection,
   BriefStage,
+  DEFAULT_BRIEF_TITLE,
   SavedBrief,
   SectionAuditEntry,
+  VoiceProfile,
 } from './briefTypes';
+import {
+  createBrief as createBriefRemote,
+  deleteBriefRemote,
+  getBrief as getBriefRemote,
+  listMyBriefs,
+  updateBrief as updateBriefRemote,
+} from './briefCentralApi';
+import { listItemToStub, migrateLocalBriefs, remoteToSaved } from './briefRemote';
 
 let _uid = 0;
 const uid = (): string => `b${++_uid}_${Date.now()}`;
@@ -59,6 +69,12 @@ export interface UseBriefOptions {
   // Identifier for the logged-in user; saved briefs are scoped to it. When
   // absent (anonymous), the shared default bucket is used.
   userKey?: string | null;
+  // Server-side persistence (Brief Central). When true, briefs are stored via
+  // the /briefs API instead of localStorage, enabling sharing.
+  remote?: boolean;
+  // The user's voice & tone profiles, used to resolve the instructions applied
+  // when a section is (re)written.
+  voices?: VoiceProfile[] | null;
 }
 
 const loadHistory = (key: string): SavedBrief[] => {
@@ -171,11 +187,13 @@ export const useBrief = ({
   rerankerModel,
   searchSettings,
   userKey,
+  remote = false,
+  voices,
 }: UseBriefOptions) => {
   const historyKey = userKey ? `${BRIEF_HISTORY_KEY}_u_${userKey}` : BRIEF_HISTORY_KEY;
   const { logBrief } = useActivityLogging();
   const [stage, setStage] = useState<BriefStage>('seed');
-  const [briefTitle, setBriefTitle] = useState('Evidence Brief');
+  const [briefTitle, setBriefTitle] = useState(DEFAULT_BRIEF_TITLE);
   const [sections, setSections] = useState<BriefSection[]>([]);
   const [query, setQuery] = useState(''); // the brief topic
   const [instructions, setInstructions] = useState('');
@@ -192,6 +210,11 @@ export const useBrief = ({
   const [numberHeadings, setNumberHeadings] = useState(false);
   // Live activity for the outline-generation deep-research survey.
   const [generatingActivity, setGeneratingActivity] = useState<BriefActivityEvent[]>([]);
+  // Brief-level voice & tone profile (sections may override individually).
+  const [briefVoiceId, setBriefVoiceId] = useState<string | null>(null);
+  // False when the open brief was shared with (not owned by) this user.
+  const [canEdit, setCanEdit] = useState(true);
+  const [ownerName, setOwnerName] = useState<string | null>(null);
 
   const briefIdRef = useRef<string | null>(null);
   // Stable Activity-log id for the current brief (one row per brief).
@@ -218,8 +241,52 @@ export const useBrief = ({
   rerankerModelRef.current = rerankerModel;
   const searchSettingsRef = useRef(searchSettings);
   searchSettingsRef.current = searchSettings;
+  const briefVoiceIdRef = useRef(briefVoiceId);
+  briefVoiceIdRef.current = briefVoiceId;
+  const voicesRef = useRef(voices);
+  voicesRef.current = voices;
+  const canEditRef = useRef(canEdit);
+  canEditRef.current = canEdit;
+  // True once the current brief exists as a server row (remote mode).
+  const remoteSavedRef = useRef(false);
 
-  useEffect(() => setHistory(loadHistory(historyKey)), [historyKey]);
+  // Resolve the style instructions for a section: its own profile wins, else
+  // the brief default; null when neither is set (or the profile was deleted).
+  const voiceInstructionsFor = useCallback((sectionVoiceId?: string | null): string | null => {
+    const id = sectionVoiceId ?? briefVoiceIdRef.current;
+    if (!id) return null;
+    const profile = (voicesRef.current || []).find((v) => v.id === id);
+    return profile ? profile.instructions : null;
+  }, []);
+
+  const refreshRemoteHistory = useCallback(async () => {
+    const items = await listMyBriefs();
+    setHistory(items.map(listItemToStub));
+  }, []);
+
+  useEffect(() => {
+    if (!remote) {
+      setHistory(loadHistory(historyKey));
+      return;
+    }
+    // Remote mode: run the one-time localStorage migration, then load the
+    // server-side history. Errors surface in the brief error banner.
+    let cancelled = false;
+    (async () => {
+      try {
+        if (userKey) await migrateLocalBriefs(userKey, dataSource || null);
+        const items = await listMyBriefs();
+        if (!cancelled) setHistory(items.map(listItemToStub));
+      } catch (e) {
+        if (!cancelled) {
+          setError(e instanceof Error ? e.message : 'Could not load saved briefs.');
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [remote, historyKey, userKey, dataSource]);
   useEffect(() => () => abortRef.current?.abort(), []);
 
   const updateSection = useCallback((id: string, patch: Partial<BriefSection>) => {
@@ -248,14 +315,74 @@ export const useBrief = ({
   );
 
   const deleteBrief = useCallback(
-    (id: string) => persist(history.filter((e) => e.id !== id)),
-    [history, persist],
+    (id: string) => {
+      if (remote) {
+        deleteBriefRemote(id)
+          .then(() => setHistory((prev) => prev.filter((e) => e.id !== id)))
+          .catch((e) =>
+            setError(e instanceof Error ? e.message : 'Could not delete the brief.'),
+          );
+        return;
+      }
+      persist(history.filter((e) => e.id !== id));
+    },
+    [remote, history, persist],
+  );
+
+  // Serialise remote saves: one in flight at a time; a save requested while one
+  // runs re-runs once it finishes (latest state wins — entries are rebuilt).
+  const remoteSaveBusyRef = useRef(false);
+  const remoteSavePendingRef = useRef<SavedBrief | null>(null);
+
+  const pushRemoteSave = useCallback(
+    (entry: SavedBrief) => {
+      if (remoteSaveBusyRef.current) {
+        remoteSavePendingRef.current = entry;
+        return;
+      }
+      remoteSaveBusyRef.current = true;
+      const run = async (current: SavedBrief): Promise<void> => {
+        if (remoteSavedRef.current && briefIdRef.current) {
+          await updateBriefRemote(briefIdRef.current, {
+            title: current.title,
+            query: current.query || null,
+            voiceProfileId: current.voiceId ?? null,
+            content: current,
+          });
+        } else {
+          const created = await createBriefRemote({
+            title: current.title,
+            query: current.query || null,
+            dataSource: dataSource || null,
+            voiceProfileId: current.voiceId ?? null,
+            content: current,
+          });
+          // Adopt the server id so subsequent saves update the same row.
+          briefIdRef.current = created.id;
+          remoteSavedRef.current = true;
+        }
+        const pending = remoteSavePendingRef.current;
+        remoteSavePendingRef.current = null;
+        if (pending) return run({ ...pending, id: briefIdRef.current || pending.id });
+      };
+      run(entry)
+        .then(() => refreshRemoteHistory())
+        .catch((e) =>
+          setError(e instanceof Error ? e.message : 'Could not save the brief.'),
+        )
+        .finally(() => {
+          remoteSaveBusyRef.current = false;
+        });
+    },
+    [dataSource, refreshRemoteHistory],
   );
 
   const saveCurrent = useCallback(() => {
     const id = briefIdRef.current;
     const snap = sectionsRef.current;
     if (!id || !snap.length) return;
+    // Never write back a brief someone else owns (viewer-only).
+    if (remote && !canEditRef.current) return;
     const entry: SavedBrief = {
       id,
       title: briefTitleRef.current,
@@ -278,13 +405,19 @@ export const useBrief = ({
           sources: done ? s.sources : [],
           audit: s.audit && s.audit.length ? s.audit : undefined,
           lastResearchedAt: s.lastResearchedAt,
+          voiceId: s.voiceId ?? undefined,
         };
       }),
       outlineLog: outlineLogRef.current,
       numberHeadings: numberHeadingsRef.current,
       activityId: briefActivityIdRef.current ?? undefined,
+      voiceId: briefVoiceIdRef.current,
     };
-    persist([entry, ...historyRef.current.filter((e) => e.id !== id)].slice(0, 10));
+    if (remote) {
+      pushRemoteSave(entry);
+    } else {
+      persist([entry, ...historyRef.current.filter((e) => e.id !== id)].slice(0, 10));
+    }
 
     // Mirror the brief into the Activity log as a "brief" row, upserted on each
     // save so there's one activity per brief reflecting its latest state.
@@ -307,7 +440,7 @@ export const useBrief = ({
         });
       logBrief(activityId, briefTitleRef.current, markdown, sources);
     }
-  }, [persist, logBrief]);
+  }, [remote, pushRemoteSave, persist, logBrief]);
 
   // Auto-save once a brief exists (outline generated or manual start) so it
   // appears in Saved Briefs right away and keeps tracking title/content edits.
@@ -321,15 +454,21 @@ export const useBrief = ({
   // Generate headings by first running a deep-research survey of the document
   // library for the topic (streaming the same SCAN/READ activity as section
   // research), then asking the model for headings grounded in what it found.
-  const generateOutline = useCallback(async () => {
-    const topic = query.trim();
+  const generateOutline = useCallback(async (overrides?: {
+    topic?: string;
+    instructions?: string;
+    numHeadings?: number;
+  }) => {
+    // Overrides let callers (the New-brief modal) pass values set in the same
+    // tick — the state updates land after this closure captured the old values.
+    const topic = (overrides?.topic ?? query).trim();
     if (!topic) return;
     setError(null);
     setOutlineLoading(true);
     setGeneratingActivity([]);
     const controller = new AbortController();
     abortRef.current = controller;
-    const guidance = instructions.trim();
+    const guidance = (overrides?.instructions ?? instructions).trim();
     let gathered: BriefSourceSample[] = [];
     try {
       const surveyQuery = guidance
@@ -367,13 +506,16 @@ export const useBrief = ({
         dataSource,
         topic,
         instructions: guidance || null,
-        numHeadings,
+        numHeadings: overrides?.numHeadings ?? numHeadings,
         model: assistantModelConfig?.model ?? null,
         sources: gathered,
         signal: controller.signal,
       });
       briefIdRef.current = uid();
       briefActivityIdRef.current = newActivityId();
+      remoteSavedRef.current = false;
+      setCanEdit(true);
+      setOwnerName(null);
       setBriefTitle(toTitleCase(topic));
       setSections(
         outline.headings
@@ -393,7 +535,10 @@ export const useBrief = ({
   const startManual = useCallback(() => {
     briefIdRef.current = uid();
     briefActivityIdRef.current = newActivityId();
-    setBriefTitle('Evidence Brief');
+    remoteSavedRef.current = false;
+    setCanEdit(true);
+    setOwnerName(null);
+    setBriefTitle(DEFAULT_BRIEF_TITLE);
     setSections(
       // Placeholder samples: research stays disabled until the user edits them.
       ['Background & definitions', 'Key findings', 'Recommendations'].map((t) =>
@@ -402,6 +547,32 @@ export const useBrief = ({
     );
     setStage('outline');
   }, []);
+
+  // Start a brief from a template's headings (optionally with saved text).
+  const startFromTemplate = useCallback(
+    (
+      title: string,
+      headings: { title: string; sub: boolean; text?: string | null }[],
+    ) => {
+      briefIdRef.current = uid();
+      briefActivityIdRef.current = newActivityId();
+      remoteSavedRef.current = false;
+      setCanEdit(true);
+      setOwnerName(null);
+      setBriefTitle(title.trim() || DEFAULT_BRIEF_TITLE);
+      setSections(
+        headings.map((h) => {
+          const section = makeSection(h.title, h.sub ? 2 : 1, false);
+          if (h.text) {
+            return { ...section, status: 'done' as const, progress: 100, content: h.text };
+          }
+          return section;
+        }),
+      );
+      setStage('outline');
+    },
+    [],
+  );
 
   // ---- outline editing ----
   const addSection = useCallback(() => {
@@ -519,6 +690,7 @@ export const useBrief = ({
         existingContent: isRevise ? priorContent : null,
         instruction,
         publishedAfterIso,
+        voiceInstructions: voiceInstructionsFor(section.voiceId),
         signal,
         handlers: {
           onActivity: (ev) => pushActivity(id, ev),
@@ -580,7 +752,14 @@ export const useBrief = ({
         ),
       );
     },
-    [apiBaseUrl, dataSource, assistantModelConfig, updateSection, pushActivity],
+    [
+      apiBaseUrl,
+      dataSource,
+      assistantModelConfig,
+      updateSection,
+      pushActivity,
+      voiceInstructionsFor,
+    ],
   );
 
   const startResearch = useCallback(async () => {
@@ -685,6 +864,7 @@ export const useBrief = ({
           dataSource,
           content: priorContent,
           instruction: instruction.trim(),
+          voiceInstructions: voiceInstructionsFor(section.voiceId),
           signal: controller.signal,
         });
         if (controller.signal.aborted) return;
@@ -718,7 +898,7 @@ export const useBrief = ({
         }
       }
     },
-    [apiBaseUrl, dataSource, updateSection],
+    [apiBaseUrl, dataSource, updateSection, voiceInstructionsFor],
   );
 
   // Dispatch the two AI actions on a DONE section: Edit → surgical revise;
@@ -777,32 +957,101 @@ export const useBrief = ({
   );
 
   // ---- history ----
-  const loadBrief = useCallback((entry: SavedBrief) => {
-    abortRef.current?.abort();
-    briefIdRef.current = entry.id;
-    briefActivityIdRef.current = entry.activityId || newActivityId();
-    setBriefTitle(entry.title);
-    setQuery(entry.query);
-    setSections(
-      entry.sections.map((h) => ({
-        ...makeSection(h.title, h.level),
-        status: h.status === 'done' ? 'done' : 'pending',
-        progress: h.status === 'done' ? 100 : 0,
-        content: h.status === 'done' ? h.content : '',
-        sources: h.status === 'done' ? h.sources || [] : [],
-        audit: h.audit || [],
-        lastResearchedAt: h.lastResearchedAt,
-      })),
-    );
-    setGeneratingActivity(entry.outlineLog || []);
-    setNumberHeadings(entry.numberHeadings ?? false);
-    setStage('done');
-    setHistoryOpen(false);
-  }, []);
+  // Materialise a SavedBrief into the working state. `access` marks whether the
+  // user owns it (edit) or views a shared copy (read-only).
+  const applyLoadedBrief = useCallback(
+    (
+      entry: SavedBrief,
+      access: { canEdit: boolean; ownerName: string | null; saved: boolean },
+    ) => {
+      abortRef.current?.abort();
+      briefIdRef.current = entry.id;
+      remoteSavedRef.current = access.saved;
+      briefActivityIdRef.current = entry.activityId || newActivityId();
+      setBriefTitle(entry.title);
+      setQuery(entry.query);
+      setCanEdit(access.canEdit);
+      setOwnerName(access.ownerName);
+      setBriefVoiceId(entry.voiceId ?? null);
+      setSections(
+        entry.sections.map((h) => ({
+          ...makeSection(h.title, h.level),
+          status: h.status === 'done' ? 'done' : 'pending',
+          progress: h.status === 'done' ? 100 : 0,
+          content: h.status === 'done' ? h.content : '',
+          sources: h.status === 'done' ? h.sources || [] : [],
+          audit: h.audit || [],
+          lastResearchedAt: h.lastResearchedAt,
+          voiceId: h.voiceId ?? null,
+        })),
+      );
+      setGeneratingActivity(entry.outlineLog || []);
+      setNumberHeadings(entry.numberHeadings ?? false);
+      setStage('done');
+      setHistoryOpen(false);
+    },
+    [],
+  );
+
+  const loadBrief = useCallback(
+    (entry: SavedBrief) => {
+      if (remote) {
+        // History rows are stubs — fetch the full brief (with access info).
+        getBriefRemote(entry.id)
+          .then((full) =>
+            applyLoadedBrief(remoteToSaved(full), {
+              canEdit: full.can_edit,
+              ownerName: full.owner_name,
+              saved: true,
+            }),
+          )
+          .catch((e) =>
+            setError(e instanceof Error ? e.message : 'Could not open the brief.'),
+          );
+        return;
+      }
+      applyLoadedBrief(entry, { canEdit: true, ownerName: null, saved: false });
+    },
+    [remote, applyLoadedBrief],
+  );
+
+  // Open a server brief by id (Brief Central cards and /brief/<id> URLs).
+  const openBriefById = useCallback(
+    (id: string) => loadBrief({ id } as SavedBrief),
+    [loadBrief],
+  );
 
   // Duplicate a saved brief under a new id and open the copy.
   const cloneBrief = useCallback(
     (entry: SavedBrief) => {
+      if (remote) {
+        getBriefRemote(entry.id)
+          .then(async (full) => {
+            const copyContent: SavedBrief = {
+              ...full.content,
+              title: `${full.title} (copy)`,
+              date: Date.now(),
+              activityId: newActivityId(),
+            };
+            const created = await createBriefRemote({
+              title: copyContent.title,
+              query: full.query,
+              dataSource: full.data_source,
+              voiceProfileId: full.voice_profile_id,
+              content: copyContent,
+            });
+            await refreshRemoteHistory();
+            applyLoadedBrief(remoteToSaved(created), {
+              canEdit: true,
+              ownerName: null,
+              saved: true,
+            });
+          })
+          .catch((e) =>
+            setError(e instanceof Error ? e.message : 'Could not copy the brief.'),
+          );
+        return;
+      }
       const copy: SavedBrief = {
         ...entry,
         id: uid(),
@@ -813,19 +1062,23 @@ export const useBrief = ({
       persist([copy, ...historyRef.current].slice(0, 10));
       loadBrief(copy);
     },
-    [persist, loadBrief],
+    [remote, persist, loadBrief, applyLoadedBrief, refreshRemoteHistory],
   );
 
   const reset = useCallback(() => {
     abortRef.current?.abort();
     briefIdRef.current = null;
     briefActivityIdRef.current = null;
+    remoteSavedRef.current = false;
     setStage('seed');
     setSections([]);
     setRegenFor(null);
     setError(null);
     setQuery('');
     setNumberHeadings(false);
+    setBriefVoiceId(null);
+    setCanEdit(true);
+    setOwnerName(null);
   }, []);
 
   // Persist a title/content edit immediately (any non-seed stage).
@@ -868,6 +1121,11 @@ export const useBrief = ({
     doneCount,
     totalProgress,
     totalSources,
+    briefVoiceId,
+    canEdit,
+    ownerName,
+    remote,
+    voices: voices || [],
     // setters / actions
     setQuery,
     setInstructions,
@@ -878,8 +1136,13 @@ export const useBrief = ({
     setRegenText,
     setError,
     setHistoryOpen,
+    setBriefVoiceId,
+    setSectionVoiceId: (id: string, voiceId: string | null) =>
+      updateSection(id, { voiceId }),
     generateOutline,
     startManual,
+    startFromTemplate,
+    openBriefById,
     addSection,
     addHeading,
     addSubHeading,

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -7,6 +7,7 @@ import {
   BriefActivityEvent,
   BriefSourceSample,
   buildOutlineContext,
+  isLikelyNonAnswer,
   requestBriefOutline,
   requestBriefRevise,
   researchBriefSection,
@@ -763,6 +764,16 @@ export const useBrief = ({
             if (!isRevise) updateSection(id, { sources: s });
           },
           onDone: ({ content, sources }) => {
+            // A run that read sources but answered with process narration
+            // ("I'll go research that…") instead of the section is a failure —
+            // surface it and keep the section pending rather than storing it.
+            if (!isRevise && isLikelyNonAnswer(content, sources.length)) {
+              updateSection(id, { status: 'pending', progress: 0 });
+              setError(
+                `The model did not return researched content for “${section.title}” — please try again.`,
+              );
+              return;
+            }
             const priorKeys = new Set(priorSources.map((s) => s.docId));
             const added = sources.filter((s) => !priorKeys.has(s.docId)).length;
             const entry: SectionAuditEntry = {

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -31,6 +31,11 @@ import {
   updateBrief as updateBriefRemote,
 } from './briefCentralApi';
 import { listItemToStub, migrateLocalBriefs, remoteToSaved } from './briefRemote';
+import { highlightSectionSources } from './briefHighlights';
+import {
+  SEARCH_SEMANTIC_HIGHLIGHTS,
+  SEMANTIC_HIGHLIGHT_THRESHOLD,
+} from '../../config';
 
 let _uid = 0;
 const uid = (): string => `b${++_uid}_${Date.now()}`;
@@ -76,6 +81,9 @@ export interface UseBriefOptions {
   // The user's voice & tone profiles, used to resolve the instructions applied
   // when a section is (re)written.
   voices?: VoiceProfile[] | null;
+  // Model for the LLM semantic highlighter (combo.semantic_highlighting_model),
+  // used to mark the claim-supporting span of each citation's excerpt.
+  semanticModelConfig?: SummaryModelConfig | null;
 }
 
 const loadHistory = (key: string): SavedBrief[] => {
@@ -190,6 +198,7 @@ export const useBrief = ({
   userKey,
   remote = false,
   voices,
+  semanticModelConfig,
 }: UseBriefOptions) => {
   const historyKey = userKey ? `${BRIEF_HISTORY_KEY}_u_${userKey}` : BRIEF_HISTORY_KEY;
   const { logBrief } = useActivityLogging();
@@ -293,6 +302,40 @@ export const useBrief = ({
   const updateSection = useCallback((id: string, patch: Partial<BriefSection>) => {
     setSections((prev) => prev.map((s) => (s.id === id ? { ...s, ...patch } : s)));
   }, []);
+
+  const semanticModelConfigRef = useRef(semanticModelConfig);
+  semanticModelConfigRef.current = semanticModelConfig;
+
+  // After a section's research completes (references validated), run the LLM
+  // semantic highlighter over each cited excerpt in the background — the hover
+  // card then marks the claim-supporting span, falling back to the full
+  // excerpt. `token` (the section's lastResearchedAt) stops a stale run from
+  // clobbering a newer research pass.
+  const enrichSectionHighlights = useCallback(
+    (id: string, token: number) => {
+      if (!SEARCH_SEMANTIC_HIGHLIGHTS) return;
+      const section = sectionsRef.current.find((s) => s.id === id);
+      if (!section || section.status !== 'done' || !section.content) return;
+      const isStale = () => {
+        const cur = sectionsRef.current.find((s) => s.id === id);
+        return !cur || cur.lastResearchedAt !== token;
+      };
+      void highlightSectionSources({
+        content: section.content,
+        sources: section.sources,
+        threshold: SEMANTIC_HIGHLIGHT_THRESHOLD,
+        modelConfig: semanticModelConfigRef.current,
+        isStale,
+      })
+        .then((sources) => {
+          if (!isStale()) updateSection(id, { sources });
+        })
+        .catch(() => {
+          /* highlighting is an enhancement; the plain excerpt remains */
+        });
+    },
+    [updateSection],
+  );
 
   const pushActivity = useCallback((id: string, ev: BriefActivityEvent) => {
     // Retain a deep log; the status box shows ~5 rows and scrolls for the rest.
@@ -731,18 +774,21 @@ export const useBrief = ({
               after: isRevise ? content : undefined,
             };
             const cur = sectionsRef.current.find((s) => s.id === id);
+            const doneAt = Date.now();
             updateSection(id, {
               status: 'done',
               progress: 100,
               content,
               sources,
               audit: [...(cur?.audit || []), entry],
-              lastResearchedAt: Date.now(),
+              lastResearchedAt: doneAt,
               revising: undefined,
               prevContent: isRevise ? priorContent : undefined,
               prevSources: isRevise ? priorSources : undefined,
               lastChangeKind: isRevise ? mode : undefined,
             });
+            // Async: LLM-highlight the cited excerpts once the state lands.
+            setTimeout(() => enrichSectionHighlights(id, doneAt), 0);
           },
           onError: (m) => {
             // A revise keeps its previous good content; a fresh research reverts.
@@ -771,6 +817,7 @@ export const useBrief = ({
       updateSection,
       pushActivity,
       voiceInstructionsFor,
+      enrichSectionHighlights,
     ],
   );
 
@@ -891,18 +938,22 @@ export const useBrief = ({
           before: priorContent,
           after: revised,
         };
+        const doneAt = Date.now();
         updateSection(id, {
           status: 'done',
           progress: 100,
           content: revised,
-          // Sources unchanged — a surgical edit preserves the [n] markers.
+          // Sources unchanged — a surgical edit preserves the [n] markers. The
+          // claims moved though, so drop stale excerpt highlights to recompute.
+          sources: section.sources.map(({ semanticMatches: _sm, ...rest }) => rest),
           audit: [...(cur?.audit || []), entry],
-          lastResearchedAt: Date.now(),
+          lastResearchedAt: doneAt,
           revising: undefined,
           prevContent: priorContent,
           prevSources: section.sources,
           lastChangeKind: 'edit',
         });
+        setTimeout(() => enrichSectionHighlights(id, doneAt), 0);
       } catch (e) {
         if (!controller.signal.aborted) {
           updateSection(id, { status: 'done', progress: 100, revising: undefined });
@@ -910,7 +961,7 @@ export const useBrief = ({
         }
       }
     },
-    [apiBaseUrl, dataSource, updateSection, voiceInstructionsFor],
+    [apiBaseUrl, dataSource, updateSection, voiceInstructionsFor, enrichSectionHighlights],
   );
 
   // Dispatch the two AI actions on a DONE section: Edit → surgical revise;

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -6,6 +6,7 @@ import { extractCitedNumbers } from '../citations/CitedContent';
 import {
   BriefActivityEvent,
   BriefSourceSample,
+  buildOutlineContext,
   requestBriefOutline,
   requestBriefRevise,
   researchBriefSection,
@@ -691,6 +692,17 @@ export const useBrief = ({
         instruction,
         publishedAfterIso,
         voiceInstructions: voiceInstructionsFor(section.voiceId),
+        // The whole document structure (plus a gist of written sections), so
+        // this section stays in scope and doesn't duplicate the others.
+        outlineContext: buildOutlineContext(
+          list.map((s) => ({
+            id: s.id,
+            title: s.title,
+            level: s.level,
+            content: s.status === 'done' ? s.content : undefined,
+          })),
+          id,
+        ),
         signal,
         handlers: {
           onActivity: (ev) => pushActivity(id, ev),

--- a/ui/frontend/src/components/brief/useBriefCentral.ts
+++ b/ui/frontend/src/components/brief/useBriefCentral.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  createTemplate,
+  createVoiceProfile,
+  deleteBriefRemote,
+  deleteTemplate,
+  deleteVoiceProfile,
+  listMyBriefs,
+  listSharedBriefs,
+  listTemplates,
+  listVoiceProfiles,
+  updateVoiceProfile,
+} from './briefCentralApi';
+import {
+  BriefListItem,
+  BriefTemplate,
+  BriefTemplateHeading,
+  VoiceProfile,
+} from './briefTypes';
+
+export type CentralTab = 'mine' | 'shared' | 'templates' | 'voices';
+
+const errMessage = (e: unknown, fallback: string): string =>
+  e instanceof Error ? e.message : fallback;
+
+/**
+ * State for the Brief Central landing page: the user's briefs, briefs shared
+ * with them, their templates and voice & tone profiles — all server-backed.
+ * Only used when the user module is enabled and a user is logged in.
+ */
+export const useBriefCentral = (enabled: boolean) => {
+  const [tab, setTab] = useState<CentralTab>('mine');
+  const [myBriefs, setMyBriefs] = useState<BriefListItem[]>([]);
+  const [sharedBriefs, setSharedBriefs] = useState<BriefListItem[]>([]);
+  const [templates, setTemplates] = useState<BriefTemplate[]>([]);
+  const [voices, setVoices] = useState<VoiceProfile[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const [mine, shared, tpls, vps] = await Promise.all([
+        listMyBriefs(),
+        listSharedBriefs(),
+        listTemplates(),
+        listVoiceProfiles(),
+      ]);
+      setMyBriefs(mine);
+      setSharedBriefs(shared);
+      setTemplates(tpls);
+      setVoices(vps);
+    } catch (e) {
+      setError(errMessage(e, 'Could not load your briefs.'));
+    } finally {
+      setLoading(false);
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const removeBrief = useCallback(async (id: string) => {
+    await deleteBriefRemote(id);
+    setMyBriefs((prev) => prev.filter((b) => b.id !== id));
+  }, []);
+
+  const saveTemplate = useCallback(
+    async (args: {
+      name: string;
+      description: string | null;
+      headings: BriefTemplateHeading[];
+      withText: boolean;
+    }) => {
+      const created = await createTemplate(args);
+      setTemplates((prev) => [created, ...prev]);
+      return created;
+    },
+    [],
+  );
+
+  const removeTemplate = useCallback(async (id: string) => {
+    await deleteTemplate(id);
+    setTemplates((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const saveVoice = useCallback(
+    async (args: {
+      id: string | null;
+      name: string;
+      description: string | null;
+      instructions: string;
+    }) => {
+      if (args.id) {
+        const updated = await updateVoiceProfile(args.id, {
+          name: args.name,
+          description: args.description,
+          instructions: args.instructions,
+        });
+        setVoices((prev) => prev.map((v) => (v.id === updated.id ? updated : v)));
+        return updated;
+      }
+      const created = await createVoiceProfile({
+        name: args.name,
+        description: args.description,
+        instructions: args.instructions,
+      });
+      setVoices((prev) => [...prev, created]);
+      return created;
+    },
+    [],
+  );
+
+  const removeVoice = useCallback(async (id: string) => {
+    await deleteVoiceProfile(id);
+    setVoices((prev) => prev.filter((v) => v.id !== id));
+  }, []);
+
+  const voiceById = useCallback(
+    (id: string | null | undefined): VoiceProfile | null =>
+      (id && voices.find((v) => v.id === id)) || null,
+    [voices],
+  );
+
+  return {
+    tab,
+    setTab,
+    myBriefs,
+    sharedBriefs,
+    templates,
+    voices,
+    loading,
+    error,
+    setError,
+    refresh,
+    removeBrief,
+    saveTemplate,
+    removeTemplate,
+    saveVoice,
+    removeVoice,
+    voiceById,
+  };
+};
+
+export type UseBriefCentralReturn = ReturnType<typeof useBriefCentral>;

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -51,6 +51,21 @@ export const parseSectionBreadcrumb = (
   return { section: null, body: text };
 };
 
+// Expand a match to whole-word boundaries so snippets never start or end
+// mid-word (the phrase matcher is fuzzy and can clip by a few characters).
+export const snapToWordBounds = (
+  text: string,
+  start: number,
+  end: number,
+): { start: number; end: number } => {
+  const isWordChar = (ch: string): boolean => /[\p{L}\p{N}]/u.test(ch);
+  let s = Math.max(0, Math.min(start, text.length));
+  let e = Math.max(s, Math.min(end, text.length));
+  while (s > 0 && isWordChar(text[s - 1]) && s < text.length && isWordChar(text[s])) s--;
+  while (e < text.length && e > 0 && isWordChar(text[e - 1]) && isWordChar(text[e])) e++;
+  return { start: s, end: e };
+};
+
 const renderCitationExcerpt = (
   text: string,
   semanticMatches?: Array<{ start: number; end: number }>,
@@ -61,7 +76,10 @@ const renderCitationExcerpt = (
   // (after the breadcrumb split). Without matches, the full excerpt renders.
   const renderBody = (b: string): React.ReactNode => {
     const snippets = (semanticMatches || [])
-      .map((m) => b.substring(m.start, m.end).trim())
+      .map((m) => {
+        const { start, end } = snapToWordBounds(b, m.start, m.end);
+        return b.substring(start, end).trim();
+      })
       .filter(Boolean);
     if (!snippets.length) return parseAndRenderSuperscripts(b);
     return (

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -51,13 +51,30 @@ export const parseSectionBreadcrumb = (
   return { section: null, body: text };
 };
 
-const renderCitationExcerpt = (text: string): React.ReactNode => {
+const renderCitationExcerpt = (
+  text: string,
+  semanticMatches?: Array<{ start: number; end: number }>,
+): React.ReactNode => {
   const { section, body } = parseSectionBreadcrumb(text);
-  if (!section) return parseAndRenderSuperscripts(text);
+  // LLM-highlighted excerpts show ONLY the claim-supporting span(s), separated
+  // by ellipses — not the whole excerpt. Offsets are relative to the body
+  // (after the breadcrumb split). Without matches, the full excerpt renders.
+  const renderBody = (b: string): React.ReactNode => {
+    const snippets = (semanticMatches || [])
+      .map((m) => b.substring(m.start, m.end).trim())
+      .filter(Boolean);
+    if (!snippets.length) return parseAndRenderSuperscripts(b);
+    return (
+      <span className="citation-hover-snippets">
+        {snippets.map((s) => `“${s}”`).join(' … ')}
+      </span>
+    );
+  };
+  if (!section) return renderBody(text);
   return (
     <>
       <div className="citation-hover-section">{section}</div>
-      {body.trim() && <div>{parseAndRenderSuperscripts(body)}</div>}
+      {body.trim() && <div>{renderBody(body)}</div>}
     </>
   );
 };
@@ -115,7 +132,9 @@ const InlineCitation: React.FC<{
               <div className="citation-hover-meta">Page {source.page}</div>
             )}
             {source.text && (
-              <div className="citation-hover-excerpt">{renderCitationExcerpt(source.text)}</div>
+              <div className="citation-hover-excerpt">
+                {renderCitationExcerpt(source.text, source.semanticMatches)}
+              </div>
             )}
           </div>,
           document.body,

--- a/ui/frontend/src/tests/briefCentral.test.ts
+++ b/ui/frontend/src/tests/briefCentral.test.ts
@@ -1,0 +1,94 @@
+import { numberHeadings } from '../components/brief/BriefCentralModals';
+import { listItemToStub, remoteToSaved } from '../components/brief/briefRemote';
+import { BriefListItem, RemoteBrief, SavedBrief } from '../components/brief/briefTypes';
+
+describe('numberHeadings', () => {
+  it('numbers top-level headings sequentially', () => {
+    const out = numberHeadings([
+      { title: 'A', sub: false },
+      { title: 'B', sub: false },
+    ]);
+    expect(out.map((h) => h.num)).toEqual(['1', '2']);
+  });
+
+  it('numbers sub-headings under their parent', () => {
+    const out = numberHeadings([
+      { title: 'A', sub: false },
+      { title: 'A1', sub: true },
+      { title: 'A2', sub: true },
+      { title: 'B', sub: false },
+      { title: 'B1', sub: true },
+    ]);
+    expect(out.map((h) => h.num)).toEqual(['1', '1.1', '1.2', '2', '2.1']);
+  });
+
+  it('promotes a leading sub-heading to top level', () => {
+    const out = numberHeadings([
+      { title: 'Orphan', sub: true },
+      { title: 'B', sub: false },
+    ]);
+    expect(out[0].num).toBe('1');
+    expect(out[0].sub).toBe(false);
+    expect(out[1].num).toBe('2');
+  });
+});
+
+describe('briefRemote mappings', () => {
+  const listItem: BriefListItem = {
+    id: 'a4f6e6a0-1111-2222-3333-444455556666',
+    title: 'Cash transfers',
+    query: 'Effectiveness of cash',
+    data_source: 'wfp',
+    voice_profile_id: 'v-1',
+    section_count: 5,
+    source_count: 41,
+    owner_name: null,
+    share_count: 2,
+    created_at: '2026-08-01T10:00:00Z',
+    updated_at: '2026-08-06T10:24:00Z',
+  };
+
+  it('listItemToStub keeps counts and parses the updated date', () => {
+    const stub = listItemToStub(listItem);
+    expect(stub.id).toBe(listItem.id);
+    expect(stub.sectionCount).toBe(5);
+    expect(stub.sourceCount).toBe(41);
+    expect(stub.sections).toEqual([]);
+    expect(stub.voiceId).toBe('v-1');
+    expect(stub.date).toBe(Date.parse('2026-08-06T10:24:00Z'));
+  });
+
+  it('remoteToSaved re-stamps the server id and title over the content payload', () => {
+    const content: SavedBrief = {
+      id: 'local-1',
+      title: 'Stale local title',
+      query: 'old query',
+      date: 123,
+      sectionCount: 1,
+      sourceCount: 2,
+      sections: [
+        { title: 'S1', level: 1, status: 'done', content: 'Text', sources: [] },
+      ],
+    };
+    const remote: RemoteBrief = {
+      id: listItem.id,
+      user_id: 'u-1',
+      title: 'Server title',
+      query: 'server query',
+      data_source: 'wfp',
+      voice_profile_id: 'v-2',
+      content,
+      owner_name: 'Priya Raman',
+      can_edit: false,
+      shared_with: [],
+      created_at: listItem.created_at,
+      updated_at: listItem.updated_at,
+    };
+    const saved = remoteToSaved(remote);
+    expect(saved.id).toBe(listItem.id);
+    expect(saved.title).toBe('Server title');
+    expect(saved.query).toBe('server query');
+    expect(saved.voiceId).toBe('v-2');
+    expect(saved.sections).toHaveLength(1);
+  });
+});

--- a/ui/frontend/src/tests/briefGroupSettings.test.tsx
+++ b/ui/frontend/src/tests/briefGroupSettings.test.tsx
@@ -10,6 +10,17 @@ jest.mock('../config', () => ({
 }));
 jest.mock('../hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'u1' } }) }));
 
+// Brief Central (logged-in landing) loads briefs/templates/voices over axios.
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn().mockResolvedValue({ data: [] }),
+    post: jest.fn().mockResolvedValue({ data: {} }),
+    put: jest.fn().mockResolvedValue({ data: {} }),
+    delete: jest.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
 const mockRunDeepResearch = jest.fn();
 const mockRequestOutline = jest.fn();
 const mockResearchSection = jest.fn();
@@ -41,7 +52,10 @@ describe('Brief uses the group search settings when logged in', () => {
         searchSettings={{ denseWeight: 0.7, fieldBoost: true }}
       />,
     );
-    fireEvent.change(screen.getByLabelText('Topic'), { target: { value: 'cash assistance' } });
+    // Logged-in users land on Brief Central: open the New-brief modal, name the
+    // brief and generate the outline from there.
+    fireEvent.click(screen.getByText('New brief'));
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'cash assistance' } });
     fireEvent.click(screen.getByText('Generate outline'));
 
     await waitFor(() => expect(mockRunDeepResearch).toHaveBeenCalled());

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -103,3 +103,31 @@ describe('highlightSectionSources', () => {
     expect(out).toHaveLength(2);
   });
 });
+
+describe('snapToWordBounds', () => {
+  const { snapToWordBounds } = jest.requireActual('../components/citations/CitedContent');
+  const text = 'The Kenya Certificate of Secondary Education results.';
+
+  it('expands a mid-word start back to the word start', () => {
+    const start = text.indexOf('tificate');
+    const out = snapToWordBounds(text, start, text.indexOf('Education') + 9);
+    expect(text.substring(out.start, out.end)).toBe('Certificate of Secondary Education');
+  });
+
+  it('expands a mid-word end forward to the word end', () => {
+    const out = snapToWordBounds(text, text.indexOf('Kenya'), text.indexOf('Cert') + 4);
+    expect(text.substring(out.start, out.end)).toBe('Kenya Certificate');
+  });
+
+  it('leaves boundaries already on word edges untouched', () => {
+    const s = text.indexOf('Kenya');
+    const out = snapToWordBounds(text, s, s + 'Kenya'.length);
+    expect(out).toEqual({ start: s, end: s + 5 });
+  });
+
+  it('clamps out-of-range offsets', () => {
+    const out = snapToWordBounds(text, -5, text.length + 10);
+    expect(out.start).toBe(0);
+    expect(out.end).toBe(text.length);
+  });
+});

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -1,0 +1,105 @@
+import { SourceReference } from '../types/api';
+
+const mockFindSemanticMatches = jest.fn();
+jest.mock('../utils/textHighlighting', () => ({
+  ...jest.requireActual('../utils/textHighlighting'),
+  findSemanticMatches: (...args: unknown[]) => mockFindSemanticMatches(...args),
+}));
+
+import {
+  extractClaimForCitation,
+  highlightSectionSources,
+} from '../components/brief/briefHighlights';
+
+const CONTENT =
+  '# Findings\n\nCash transfers improved food consumption scores [1]. ' +
+  'Effects on dietary diversity were smaller [2], fading within months [2][3]. ' +
+  'Cost efficiency favoured cash in most comparisons [1, 3].';
+
+const source = (index: number, text = `Excerpt for source ${index}.`): SourceReference => ({
+  chunkId: `c${index}`,
+  docId: `d${index}`,
+  title: `Doc ${index}`,
+  text,
+  score: 0.9,
+  index,
+});
+
+describe('extractClaimForCitation', () => {
+  it('returns the sentence carrying the marker, stripped of markers and markdown', () => {
+    const claim = extractClaimForCitation(CONTENT, 1);
+    expect(claim).toContain('Cash transfers improved food consumption scores');
+    expect(claim).toContain('Cost efficiency favoured cash');
+    expect(claim).not.toContain('[1]');
+    expect(claim).not.toContain('#');
+  });
+
+  it('matches a number inside a combined [n, m] marker', () => {
+    const claim = extractClaimForCitation(CONTENT, 3);
+    expect(claim).toContain('fading within months');
+    expect(claim).toContain('Cost efficiency favoured cash');
+    expect(claim).not.toContain('improved food consumption');
+  });
+
+  it('returns empty when the source is not cited', () => {
+    expect(extractClaimForCitation(CONTENT, 9)).toBe('');
+  });
+});
+
+describe('highlightSectionSources', () => {
+  beforeEach(() => mockFindSemanticMatches.mockReset());
+
+  it('attaches matches for cited sources and leaves failures as plain excerpts', async () => {
+    mockFindSemanticMatches
+      .mockResolvedValueOnce([{ start: 0, end: 7, matchedText: 'Excerpt' }])
+      .mockRejectedValueOnce(new Error('LLM down'))
+      .mockResolvedValueOnce([]);
+    const out = await highlightSectionSources({
+      content: CONTENT,
+      sources: [source(1), source(2), source(3)],
+      threshold: 0.6,
+    });
+    expect(out[0].semanticMatches).toEqual([{ start: 0, end: 7, matchedText: 'Excerpt' }]);
+    expect(out[1].semanticMatches).toBeUndefined();
+    expect(out[2].semanticMatches).toBeUndefined();
+  });
+
+  it('skips uncited sources and ones already highlighted', async () => {
+    const already = { ...source(1), semanticMatches: [{ start: 1, end: 2 }] };
+    const out = await highlightSectionSources({
+      content: CONTENT,
+      sources: [already, source(9)],
+      threshold: 0.6,
+    });
+    expect(mockFindSemanticMatches).not.toHaveBeenCalled();
+    expect(out[0].semanticMatches).toEqual([{ start: 1, end: 2 }]);
+    expect(out[1].semanticMatches).toBeUndefined();
+  });
+
+  it('computes matches against the excerpt body after the breadcrumb line', async () => {
+    mockFindSemanticMatches.mockResolvedValue([{ start: 0, end: 4 }]);
+    await highlightSectionSources({
+      content: CONTENT,
+      sources: [source(1, '-- Chapter > Findings --\nBody text here.')],
+      threshold: 0.6,
+    });
+    expect(mockFindSemanticMatches).toHaveBeenCalledWith(
+      'Body text here.',
+      expect.stringContaining('Cash transfers improved'),
+      0.6,
+      undefined,
+    );
+  });
+
+  it('stops early when the run goes stale', async () => {
+    mockFindSemanticMatches.mockResolvedValue([{ start: 0, end: 4 }]);
+    const out = await highlightSectionSources({
+      content: CONTENT,
+      sources: [source(1), source(2)],
+      threshold: 0.6,
+      isStale: () => true,
+    });
+    expect(mockFindSemanticMatches).not.toHaveBeenCalled();
+    expect(out).toHaveLength(2);
+  });
+});

--- a/ui/frontend/src/tests/briefSectionQuery.test.ts
+++ b/ui/frontend/src/tests/briefSectionQuery.test.ts
@@ -1,4 +1,4 @@
-import { buildSectionQuery } from '../utils/briefStream';
+import { buildOutlineContext, buildSectionQuery } from '../utils/briefStream';
 
 describe('buildSectionQuery', () => {
   test('weaves the brief topic into a top-level section query', () => {
@@ -62,5 +62,57 @@ describe('buildSectionQuery', () => {
     const q = buildSectionQuery({ heading: 'Impacts', mode: 'update' });
     expect(q).toContain('Write the "Impacts" section');
     expect(q).not.toContain('Preserve its wording');
+  });
+});
+
+describe('buildOutlineContext', () => {
+  const sections = [
+    { id: 'a', title: 'Context and scope', level: 1 },
+    { id: 'b', title: 'What the evidence shows', level: 1, content: '# What the evidence shows\n\nCash transfers improved food consumption [1].' },
+    { id: 'c', title: 'Effectiveness', level: 1 },
+    { id: 'c1', title: 'Cost efficiency', level: 2 },
+    { id: 'c2', title: 'Outcomes', level: 2 },
+  ];
+
+  test('lists every heading and marks the one being written', () => {
+    const ctx = buildOutlineContext(sections, 'a');
+    expect(ctx).toContain('Context and scope ← the section you are writing');
+    expect(ctx).toContain('- What the evidence shows');
+    expect(ctx).toContain('  - Cost efficiency');
+    expect(ctx).toContain('do NOT repeat or pre-empt material');
+  });
+
+  test('includes a gist of already-written sections without markdown or citation markers', () => {
+    const ctx = buildOutlineContext(sections, 'a');
+    expect(ctx).toContain('already written; covers: What the evidence shows Cash transfers improved food consumption');
+    expect(ctx).not.toContain('[1]');
+    expect(ctx).not.toContain('#');
+  });
+
+  test('tells a parent heading with sub-headings to stay high-level', () => {
+    const ctx = buildOutlineContext(sections, 'c');
+    expect(ctx).toContain('sub-sections (Cost efficiency; Outcomes)');
+    expect(ctx).toContain('high-level introduction');
+  });
+
+  test('a sub-section or a section without children gets no high-level instruction', () => {
+    expect(buildOutlineContext(sections, 'c1')).not.toContain('high-level introduction');
+    expect(buildOutlineContext(sections, 'a')).not.toContain('high-level introduction');
+  });
+
+  test('returns empty for a single-section brief', () => {
+    expect(buildOutlineContext([sections[0]], 'a')).toBe('');
+  });
+});
+
+describe('buildSectionQuery with outline context', () => {
+  test('appends the outline context to the generate query', () => {
+    const q = buildSectionQuery({
+      heading: 'Effectiveness',
+      briefTopic: 'cash transfers',
+      outlineContext: 'For context, the full outline of the brief is:\n- A\n- B',
+    });
+    expect(q).toContain('full outline of the brief');
+    expect(q.indexOf('Write')).toBeLessThan(q.indexOf('full outline'));
   });
 });

--- a/ui/frontend/src/tests/briefSectionQuery.test.ts
+++ b/ui/frontend/src/tests/briefSectionQuery.test.ts
@@ -1,4 +1,4 @@
-import { buildOutlineContext, buildSectionQuery } from '../utils/briefStream';
+import { buildOutlineContext, buildSectionQuery, isLikelyNonAnswer } from '../utils/briefStream';
 
 describe('buildSectionQuery', () => {
   test('weaves the brief topic into a top-level section query', () => {
@@ -35,7 +35,9 @@ describe('buildSectionQuery', () => {
     expect(q).toBe(
       'Write the "Background" section of an evidence brief. ' +
         'Search the document library for evidence relevant to this specific section ' +
-        'and cite a source for every claim.',
+        'and cite a source for every claim. ' +
+        'Your final answer must be the finished section text itself — never a description ' +
+        'of what you are about to do, a promise to research, or narration of your process.',
     );
   });
 
@@ -114,5 +116,31 @@ describe('buildSectionQuery with outline context', () => {
     });
     expect(q).toContain('full outline of the brief');
     expect(q.indexOf('Write')).toBeLessThan(q.indexOf('full outline'));
+  });
+});
+
+describe('isLikelyNonAnswer', () => {
+  const SCOUT =
+    "Alright, partner, I'm sendin' out a scout to rustle up some facts. Once that " +
+    "information comes back, I'll be able to pen that section for ya.";
+
+  test('flags short citationless narration when sources were read', () => {
+    expect(isLikelyNonAnswer(SCOUT, 12)).toBe(true);
+  });
+
+  test('accepts real sections with citations', () => {
+    expect(isLikelyNonAnswer('School meals improved attendance [1]. More [2].', 12)).toBe(false);
+  });
+
+  test('accepts substantial citationless text (e.g. a long intro)', () => {
+    expect(isLikelyNonAnswer('x'.repeat(900), 12)).toBe(false);
+  });
+
+  test('does not flag when few sources were read', () => {
+    expect(isLikelyNonAnswer(SCOUT, 0)).toBe(false);
+  });
+
+  test('flags empty content regardless', () => {
+    expect(isLikelyNonAnswer('', 0)).toBe(true);
   });
 });

--- a/ui/frontend/src/types/api.ts
+++ b/ui/frontend/src/types/api.ts
@@ -162,6 +162,10 @@ export interface SourceReference {
   // the in-app deep link.
   pdfUrl?: string;
   reportUrl?: string;
+  // LLM semantic-highlight matches within the excerpt body (offsets relative
+  // to the text after the heading-breadcrumb line): the part of the excerpt
+  // that supports the citing claim. Absent → render the full excerpt plain.
+  semanticMatches?: Array<{ start: number; end: number; matchedText?: string }>;
 }
 
 export interface AgentState {

--- a/ui/frontend/src/utils/briefStream.ts
+++ b/ui/frontend/src/utils/briefStream.ts
@@ -110,6 +110,7 @@ export const requestBriefRevise = async ({
   content,
   instruction,
   model,
+  voiceInstructions,
   signal,
 }: {
   apiBaseUrl: string;
@@ -117,6 +118,7 @@ export const requestBriefRevise = async ({
   content: string;
   instruction: string;
   model?: string | null;
+  voiceInstructions?: string | null;
   signal?: AbortSignal;
 }): Promise<string> => {
   const response = await fetch(`${apiBaseUrl}/brief/revise`, {
@@ -128,6 +130,7 @@ export const requestBriefRevise = async ({
       instruction,
       data_source: dataSource,
       model: model ?? null,
+      voice_instructions: voiceInstructions ?? null,
     }),
     signal,
   });
@@ -277,6 +280,8 @@ export interface ResearchSectionOptions {
   existingContent?: string | null;
   instruction?: string | null;
   publishedAfterIso?: string | null;
+  // Voice & tone profile instructions applied to the section's writing.
+  voiceInstructions?: string | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -348,6 +353,7 @@ export const buildSectionQuery = ({
   existingContent,
   instruction,
   publishedAfterIso,
+  voiceInstructions,
 }: {
   heading: string;
   briefTopic?: string | null;
@@ -358,29 +364,32 @@ export const buildSectionQuery = ({
   existingContent?: string | null;
   instruction?: string | null;
   publishedAfterIso?: string | null;
+  voiceInstructions?: string | null;
 }): string => {
   const topic = (briefTopic || '').trim();
   const guidance = (briefInstructions || '').trim();
   const draft = (existingContent || '').trim();
+  const voice = (voiceInstructions || '').trim();
   const scope = topic
     ? `the "${heading}" section of an evidence brief on "${topic}"`
     : `the "${heading}" section of an evidence brief`;
 
-  if (mode === 'update' && draft) {
-    return buildReviseQuery({
-      scope,
-      draft,
-      instr: (instruction || '').trim(),
-      guidance,
-      publishedAfterIso,
-    });
-  }
-  return buildGenerateQuery({
-    scope,
-    parent: (parentTitle || '').trim(),
-    guidance,
-    focus: (context || '').trim(),
-  });
+  const base =
+    mode === 'update' && draft
+      ? buildReviseQuery({
+          scope,
+          draft,
+          instr: (instruction || '').trim(),
+          guidance,
+          publishedAfterIso,
+        })
+      : buildGenerateQuery({
+          scope,
+          parent: (parentTitle || '').trim(),
+          guidance,
+          focus: (context || '').trim(),
+        });
+  return voice ? `${base} Voice & tone profile — write the section in this style: ${voice}` : base;
 };
 
 /**
@@ -404,6 +413,7 @@ export const researchBriefSection = ({
   existingContent,
   instruction,
   publishedAfterIso,
+  voiceInstructions,
   handlers,
   signal,
 }: ResearchSectionOptions): Promise<void> => {
@@ -417,6 +427,7 @@ export const researchBriefSection = ({
     existingContent,
     instruction,
     publishedAfterIso,
+    voiceInstructions,
   });
   return runDeepResearch({
     apiBaseUrl,

--- a/ui/frontend/src/utils/briefStream.ts
+++ b/ui/frontend/src/utils/briefStream.ts
@@ -335,10 +335,24 @@ const buildGenerateQuery = (args: {
   }
   parts.push(
     'Search the document library for evidence relevant to this specific section and cite a source for every claim.',
+    'Your final answer must be the finished section text itself — never a description of what you are about to do, a promise to research, or narration of your process.',
   );
   if (args.guidance) parts.push(`Overall brief guidance: ${args.guidance}`);
   if (args.focus) parts.push(`Focus for this section: ${args.focus}`);
   return parts.join(' ');
+};
+
+/**
+ * Heuristic for a deep-research run that returned process narration instead of
+ * the section ("I'll go research that…"): it read sources but produced short
+ * text with no [n] citation markers. Such a result is treated as a failed run
+ * (fail loud, keep the section pending) rather than stored as content.
+ */
+export const isLikelyNonAnswer = (content: string, sourceCount: number): boolean => {
+  const text = (content || '').trim();
+  if (!text) return true;
+  const hasCitations = /\[\d+(?:,\s*\d+)*\]/.test(text);
+  return sourceCount >= 3 && !hasCitations && text.length < 800;
 };
 
 // A minimal shape of the brief's sections for outline context.

--- a/ui/frontend/src/utils/briefStream.ts
+++ b/ui/frontend/src/utils/briefStream.ts
@@ -282,6 +282,9 @@ export interface ResearchSectionOptions {
   publishedAfterIso?: string | null;
   // Voice & tone profile instructions applied to the section's writing.
   voiceInstructions?: string | null;
+  // Rendered outline of the whole brief (see buildOutlineContext), so the
+  // section stays in scope and doesn't duplicate other sections.
+  outlineContext?: string | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -338,6 +341,66 @@ const buildGenerateQuery = (args: {
   return parts.join(' ');
 };
 
+// A minimal shape of the brief's sections for outline context.
+export interface OutlineContextSection {
+  id: string;
+  title: string;
+  level: number; // 1 = section, 2 = sub-section
+  content?: string;
+}
+
+// First ~`max` characters of a section's markdown as plain-ish text, so the
+// model knows what a written section already covers without burning tokens.
+const briefGist = (markdown: string, max = 180): string => {
+  const text = markdown
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/\[(\d+)\]/g, '')
+    .replace(/[#*_>`]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!text) return '';
+  return text.length > max ? `${text.slice(0, max)}…` : text;
+};
+
+/**
+ * Render the brief's outline (with a marker on the section being written and a
+ * one-line gist of each already-written section) plus scope rules, so section
+ * research knows the whole document structure and doesn't duplicate material
+ * that belongs elsewhere. Returns '' when there is no other section.
+ */
+export const buildOutlineContext = (
+  sections: OutlineContextSection[],
+  currentId: string,
+): string => {
+  if (sections.length <= 1) return '';
+  const idx = sections.findIndex((s) => s.id === currentId);
+  const current = idx >= 0 ? sections[idx] : null;
+  const lines = sections.map((s, i) => {
+    const indent = s.level === 2 ? '  - ' : '- ';
+    const marker = s.id === currentId ? ' ← the section you are writing' : '';
+    const gist = s.id !== currentId && s.content ? ` (already written; covers: ${briefGist(s.content)})` : '';
+    return `${indent}${s.title}${marker}${gist}`;
+  });
+  const parts = [
+    `For context, the full outline of the brief is:\n${lines.join('\n')}`,
+    'Keep this section strictly to its own scope: do NOT repeat or pre-empt material that belongs in the other sections listed above.',
+  ];
+  // A top-level heading with sub-headings is an introduction/frame — the
+  // detail belongs to the sub-sections that follow it.
+  if (current && current.level !== 2) {
+    const subs: string[] = [];
+    for (let i = idx + 1; i < sections.length && sections[i].level === 2; i++) {
+      subs.push(sections[i].title);
+    }
+    if (subs.length) {
+      parts.push(
+        `This section has sub-sections (${subs.join('; ')}) — write it as a short high-level introduction to the theme and leave the detail to those sub-sections.`,
+      );
+    }
+  }
+  return parts.join(' ');
+};
+
 /**
  * Build the deep-research instruction for one brief section. For generate it
  * weaves in the brief topic, parent section and author guidance; for edit/update
@@ -354,6 +417,7 @@ export const buildSectionQuery = ({
   instruction,
   publishedAfterIso,
   voiceInstructions,
+  outlineContext,
 }: {
   heading: string;
   briefTopic?: string | null;
@@ -365,11 +429,13 @@ export const buildSectionQuery = ({
   instruction?: string | null;
   publishedAfterIso?: string | null;
   voiceInstructions?: string | null;
+  outlineContext?: string | null;
 }): string => {
   const topic = (briefTopic || '').trim();
   const guidance = (briefInstructions || '').trim();
   const draft = (existingContent || '').trim();
   const voice = (voiceInstructions || '').trim();
+  const outline = (outlineContext || '').trim();
   const scope = topic
     ? `the "${heading}" section of an evidence brief on "${topic}"`
     : `the "${heading}" section of an evidence brief`;
@@ -389,7 +455,10 @@ export const buildSectionQuery = ({
           guidance,
           focus: (context || '').trim(),
         });
-  return voice ? `${base} Voice & tone profile — write the section in this style: ${voice}` : base;
+  const withOutline = outline ? `${base} ${outline}` : base;
+  return voice
+    ? `${withOutline} Voice & tone profile — write the section in this style: ${voice}`
+    : withOutline;
 };
 
 /**
@@ -414,6 +483,7 @@ export const researchBriefSection = ({
   instruction,
   publishedAfterIso,
   voiceInstructions,
+  outlineContext,
   handlers,
   signal,
 }: ResearchSectionOptions): Promise<void> => {
@@ -428,6 +498,7 @@ export const researchBriefSection = ({
     instruction,
     publishedAfterIso,
     voiceInstructions,
+    outlineContext,
   });
   return runDeepResearch({
     apiBaseUrl,


### PR DESCRIPTION
## Summary

Implements the Brief enhancements design handoff:

- **Brief Central landing page** (logged-in users): My briefs, Shared with me, Templates and Voice & tone tabs with card grids
- **Server-side brief persistence**: new `briefs`, `brief_templates`, `voice_profiles`, `brief_shares` tables (migration `0030_add_brief_central`), with a one-time localStorage → server migration per user
- **Viewer-only sharing** by user email or group name; `/brief/<id>` deep links open the shared brief read-only (no edit/AI controls) for people with access
- **Templates**: create from scratch or save from an open brief (optionally including section text); "Use" pre-fills the New-brief modal
- **Voice & tone profiles**: per-user CRUD; applied at outline generation, per-section deep research, regenerate and AI-edit (revise prompt gains an optional voice block)
- **Live outline-generation activity panel** in the logged-in flow (was silent)
- **Responsive styles** for the whole Brief tab (previously had zero media queries) at the app's 1024/768/640 breakpoints
- Anonymous users keep the existing localStorage Brief flow unchanged

## Testing

- 21 new backend unit tests (`tests/unit/test_brief_central.py`); frontend suite green (602 tests, incl. new `briefCentral.test.ts`)
- Sharing/permissions verified end-to-end via API with two accounts (owner edit, viewer read-only, 404 on foreign edit, 401 anonymous)
- UI verified in the running dev stack (desktop + mobile viewports): landing, New-brief AI + manual/template modes, share modal, viewer mode, outline generation with live activity
- Migration applied and verified against the local WFP database

🤖 Generated with [Claude Code](https://claude.com/claude-code)