### PR TITLE
feat(brief): per-section instructions, on-demand citation highlights, and Regenerate All confirmation

### DIFF
--- a/ui/backend/services/assistant_graph.py
+++ b/ui/backend/services/assistant_graph.py
@@ -18,6 +18,7 @@ from deepagents.middleware.subagents import SubAgent
 from jinja2 import Environment, FileSystemLoader
 from langchain_core.tools import tool
 
+from pipeline.utilities.text_cleaning import clean_text
 from ui.backend.services.search import map_field_to_storage, search_chunks
 
 logger = logging.getLogger(__name__)
@@ -383,11 +384,13 @@ class SearchTracker:
         """
         new_sources: List[Dict[str, Any]] = []
         for r in self.all_results:
-            text = r.get("text", "")
+            # Same encoding repair Search applies to chunk text and titles
+            # (routes/search.py), so citation excerpts read identically.
+            text = clean_text(r.get("text", ""))
             entry: Dict[str, Any] = {
                 "chunkId": r.get("chunk_id", ""),
                 "docId": r.get("doc_id", ""),
-                "title": r.get("title", ""),
+                "title": clean_text(r.get("title", "")),
                 # Full chunk text (not truncated): the on-screen citation panels
                 # show title/page only, while the Brief's Word export renders the
                 # complete excerpt for each cited source.

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -12445,3 +12445,18 @@ button.doc-link:hover {
   inset: 0;
   z-index: 999;
 }
+
+/* Hover card: the highlight for this citation is being computed on demand. */
+.citation-hover-pending {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  font-size: 0.75rem;
+  color: var(--gray-500);
+}
+.citation-hover-spinner {
+  width: 11px;
+  height: 11px;
+  border-width: 2px;
+}

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -3834,8 +3834,8 @@ h6,
   z-index: 1000;
   width: 360px;
   max-width: calc(100vw - 24px);
-  max-height: 320px;
-  overflow-y: auto;
+  max-height: 420px;
+  overflow: hidden;
   background: var(--white);
   border: 1px solid var(--gray-200);
   border-radius: 8px;
@@ -12459,4 +12459,38 @@ button.doc-link:hover {
   width: 11px;
   height: 11px;
   border-width: 2px;
+}
+
+/* Excerpt is clipped until "Show more"; expanded it scrolls, so the scrollbar
+   only appears once the reader has asked for the longer text. */
+.citation-hover-excerpt {
+  max-height: 132px;
+  overflow: hidden;
+}
+.citation-hover-excerpt-open {
+  max-height: 300px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+.citation-hover-excerpt-open::-webkit-scrollbar {
+  width: 8px;
+}
+.citation-hover-excerpt-open::-webkit-scrollbar-thumb {
+  background: var(--gray-300);
+  border-radius: 4px;
+}
+.citation-hover-more {
+  display: block;
+  margin-top: 6px;
+  padding: 2px 0;
+  background: none;
+  border: none;
+  color: var(--brand-primary);
+  font-family: var(--font-heading, inherit);
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.citation-hover-more:hover {
+  text-decoration: underline;
 }

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -3853,6 +3853,15 @@ h6,
   font-size: 0.75rem;
   color: var(--gray-500);
 }
+.citation-hover-excerpt {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--gray-100);
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--gray-700);
+}
+
 /* Excerpt body inside the citation hover card: Search's own text formatter
    lays the chunk out, so lists and indentation match a search result. */
 .citation-hover-body .formatted-text-block {

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -3853,30 +3853,22 @@ h6,
   font-size: 0.75rem;
   color: var(--gray-500);
 }
-/* The span(s) the LLM picked out as supporting the hovered claim. */
-.citation-hover-mark {
+/* Excerpt body inside the citation hover card: Search's own text formatter
+   lays the chunk out, so lists and indentation match a search result. */
+.citation-hover-body .formatted-text-block {
+  white-space: pre-wrap;
+}
+
+/* The span(s) the LLM picked out as supporting the hovered claim. Search marks
+   matches with weight alone; a tint reads better in the smaller card. */
+.citation-hover-excerpt mark,
+.citation-hover-excerpt .search-highlight {
   background: rgba(91, 143, 168, 0.22);
   color: inherit;
+  font-weight: inherit;
   padding: 0 1px;
 }
 
-/* Excerpt paragraphs inside the citation hover card. */
-.citation-hover-para {
-  margin: 0 0 8px;
-}
-
-.citation-hover-para:last-child {
-  margin-bottom: 0;
-}
-
-.citation-hover-excerpt {
-  margin-top: 8px;
-  padding-top: 8px;
-  border-top: 1px solid var(--gray-100);
-  font-size: 0.8125rem;
-  line-height: 1.5;
-  color: var(--gray-700);
-}
 /* Heading breadcrumb shown as an italic section path at the top of the excerpt. */
 .citation-hover-section {
   margin-bottom: 6px;

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -12469,15 +12469,25 @@ button.doc-link:hover {
 }
 .citation-hover-excerpt-open {
   max-height: 300px;
-  overflow-y: auto;
+  /* 'scroll', not 'auto': the scrollbar is visible the moment the reader
+     expands, so it is obvious there is more text below. */
+  overflow-y: scroll;
   scrollbar-width: thin;
+  scrollbar-color: var(--gray-400) transparent;
 }
 .citation-hover-excerpt-open::-webkit-scrollbar {
-  width: 8px;
+  width: 9px;
+}
+.citation-hover-excerpt-open::-webkit-scrollbar-track {
+  background: var(--gray-100);
+  border-radius: 5px;
 }
 .citation-hover-excerpt-open::-webkit-scrollbar-thumb {
-  background: var(--gray-300);
-  border-radius: 4px;
+  background: var(--gray-400);
+  border-radius: 5px;
+}
+.citation-hover-excerpt-open::-webkit-scrollbar-thumb:hover {
+  background: var(--gray-500);
 }
 .citation-hover-more {
   display: block;

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -3853,9 +3853,20 @@ h6,
   font-size: 0.75rem;
   color: var(--gray-500);
 }
-/* LLM-selected excerpt snippets render quoted and italic. */
-.citation-hover-snippets {
-  font-style: italic;
+/* The span(s) the LLM picked out as supporting the hovered claim. */
+.citation-hover-mark {
+  background: rgba(91, 143, 168, 0.22);
+  color: inherit;
+  padding: 0 1px;
+}
+
+/* Excerpt paragraphs inside the citation hover card. */
+.citation-hover-para {
+  margin: 0 0 8px;
+}
+
+.citation-hover-para:last-child {
+  margin-bottom: 0;
 }
 
 .citation-hover-excerpt {

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -106,40 +106,55 @@ const AiInstructionPanel: React.FC<{
 // document as a whole.
 const groupReferencesByDoc = (
   refs: Array<{ n: number; title: string; page?: number; source: SourceReference }>,
-  pagesByDoc: Map<string, number[]>,
-): Array<{ key: string; title: string; pages: number[]; entries: typeof refs }> => {
+  pagesByDoc: Map<string, Array<{ page: number; source: SourceReference }>>,
+): Array<{
+  key: string;
+  title: string;
+  cites: Array<{ n: number; page: number; source: SourceReference }>;
+}> => {
   const byDoc = new Map<
     string,
-    { key: string; title: string; pages: number[]; entries: typeof refs }
+    {
+      key: string;
+      title: string;
+      cites: Array<{ n: number; page: number; source: SourceReference }>;
+    }
   >();
   for (const r of refs) {
     const key = r.source.docId || r.title;
-    const found = byDoc.get(key);
-    if (found) found.entries.push(r);
-    else byDoc.set(key, { key, title: r.title, pages: pagesByDoc.get(key) || [], entries: [r] });
+    if (byDoc.has(key)) continue;
+    // Citation numbers are assigned per document, so every chunk of this
+    // document carries this reference's number; the page differs per chunk.
+    const hits = pagesByDoc.get(key) || [];
+    const cites = hits.length
+      ? hits.map((h) => ({ n: r.n, page: h.page, source: h.source }))
+      : [{ n: r.n, page: r.page ?? 0, source: r.source }];
+    byDoc.set(key, { key, title: r.title, cites });
   }
   return Array.from(byDoc.values());
 };
 
 /**
- * Every page cited from each document across the brief. Citation numbers are
- * per document, so the flat list only ever shows the first chunk's page; the
- * grouped view uses this to show the document's full page coverage.
+ * Every cited chunk of each document, as the page and the source behind it.
+ * The grouped references row lists these after the title, each labelled with
+ * the citation number that appears inline in the prose.
  */
-const citedPagesByDoc = (sections: BriefSection[]): Map<string, number[]> => {
-  const map = new Map<string, number[]>();
+const citedPagesByDoc = (
+  sections: BriefSection[],
+): Map<string, Array<{ page: number; source: SourceReference }>> => {
+  const map = new Map<string, Array<{ page: number; source: SourceReference }>>();
   sections.forEach((s) => {
     if (!(s.status === 'done' || s.revising) || !s.content) return;
     const cited = new Set(extractCitedNumbers(s.content));
     s.sources.forEach((src) => {
       if (src.index == null || !cited.has(src.index) || src.page == null) return;
       const key = src.docId || src.title;
-      const pages = map.get(key) || [];
-      if (!pages.includes(src.page)) pages.push(src.page);
-      map.set(key, pages);
+      const hits = map.get(key) || [];
+      if (!hits.some((h) => h.page === src.page)) hits.push({ page: src.page, source: src });
+      map.set(key, hits);
     });
   });
-  map.forEach((pages) => pages.sort((a, b) => a - b));
+  map.forEach((hits) => hits.sort((a, b) => a.page - b.page));
   return map;
 };
 
@@ -874,30 +889,40 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
             {brief.groupReferences
               ? groupReferencesByDoc(references, citedPagesByDoc(sections)).map((g) => (
                   <div className="brief-footnote-group" key={g.key}>
-                    <span className="brief-footnote-group-nums">
-                      {g.entries.map((r) => (
-                        <span className="citation-doc-group" key={r.n}>
+                    <span className="brief-footnote-text">{g.title}</span>
+                    {g.cites.map((c, i) => (
+                      <span className="brief-footnote-cite" key={`${c.n}-${c.page}-${i}`}>
+                        {/* The number is shown once per run of the same
+                            citation, so a document cited from many pages reads
+                            "[1] p. 9, p. 11" rather than repeating "[1]". */}
+                        {(i === 0 || g.cites[i - 1].n !== c.n) && (
+                          <span className="citation-doc-group">
+                            <a
+                              href="#"
+                              className="ai-summary-citation"
+                              onClick={(e) => {
+                                e.preventDefault();
+                                handleSourceClick(c.source);
+                              }}
+                            >
+                              {c.n}
+                            </a>
+                          </span>
+                        )}
+                        {c.page ? (
                           <a
                             href="#"
-                            className="ai-summary-citation"
+                            className="brief-footnote-page-link"
                             onClick={(e) => {
                               e.preventDefault();
-                              handleSourceClick(r.source);
+                              handleSourceClick(c.source);
                             }}
                           >
-                            {r.n}
+                            {` p. ${c.page}`}
                           </a>
-                        </span>
-                      ))}
-                    </span>
-                    <span className="brief-footnote-text">
-                      {g.title}
-                      {g.pages.length > 0 && (
-                        <span className="brief-footnote-pages">
-                          {` — ${g.pages.length > 1 ? 'pp.' : 'p.'} ${g.pages.join(', ')}`}
-                        </span>
-                      )}
-                    </span>
+                        ) : null}
+                      </span>
+                    ))}
                   </div>
                 ))
               : references.map((r) => (

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -106,6 +106,8 @@ interface SectionViewProps {
   display?: SectionDisplay;
   // Viewer-only (shared brief): no editing or AI actions.
   readOnly?: boolean;
+  // Hover on an un-enriched citation asks for that source to be highlighted.
+  onRequestHighlight?: (source: SourceReference) => void;
 }
 
 // A textarea for editing a section's heading guidance / regenerating, shown for
@@ -284,6 +286,7 @@ const SectionDoneBody: React.FC<{
   viewingPending: boolean;
   onSourceClick: (source: SourceReference) => void;
   onCloseDiff: () => void;
+  onRequestHighlight?: (source: SourceReference) => void;
 }> = ({
   section,
   brief,
@@ -293,6 +296,7 @@ const SectionDoneBody: React.FC<{
   viewingPending,
   onSourceClick,
   onCloseDiff,
+  onRequestHighlight,
 }) => {
   const { content, sources } = sectionView(section, display);
   return (
@@ -321,7 +325,12 @@ const SectionDoneBody: React.FC<{
         />
       ) : (
         <div className="brief-doc-content">
-          <CitedMarkdown content={content} sources={sources} onSourceClick={onSourceClick} />
+          <CitedMarkdown
+            content={content}
+            sources={sources}
+            onSourceClick={onSourceClick}
+            onRequestHighlight={onRequestHighlight}
+          />
         </div>
       )}
       <CitedReferences
@@ -358,6 +367,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   onSourceClick,
   display,
   readOnly = false,
+  onRequestHighlight,
 }) => {
   const [editing, setEditing] = useState(false);
   // AI Edit/Update instruction panel + audit modal + changes toggle.
@@ -479,6 +489,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
           viewingPending={viewingPending}
           onSourceClick={onSourceClick}
           onCloseDiff={() => setDiffEntryId(null)}
+          onRequestHighlight={onRequestHighlight}
         />
       )}
     </section>
@@ -817,6 +828,9 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
           onSourceClick={handleSourceClick}
           display={display.get(s.id)}
           readOnly={readOnly}
+          onRequestHighlight={(src) =>
+            src.index != null && brief.requestSourceHighlight(s.id, src.index)
+          }
         />
       ))}
 

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -110,10 +110,12 @@ interface SectionViewProps {
 
 // A textarea for editing a section's heading guidance / regenerating, shown for
 // both pending sections (research with guidance) and done sections (re-research).
-const GuidancePanel: React.FC<{ section: BriefSection; brief: UseBriefReturn }> = ({
-  section,
-  brief,
-}) => {
+const GuidancePanel: React.FC<{
+  section: BriefSection;
+  brief: UseBriefReturn;
+  // The inline panel for an un-researched section has nothing to cancel back to.
+  hideCancel?: boolean;
+}> = ({ section, brief, hideCancel }) => {
   const isPending = section.status === 'pending';
   const briefVoice = brief.voices.find((v) => v.id === brief.briefVoiceId) || null;
   const ownVoice = brief.voices.find((v) => v.id === section.voiceId) || null;
@@ -123,8 +125,8 @@ const GuidancePanel: React.FC<{ section: BriefSection; brief: UseBriefReturn }> 
         {isPending ? 'Research' : 'Regenerate'} “{section.title}”
       </div>
       <textarea
-        value={brief.regenText}
-        onChange={(e) => brief.setRegenText(e.target.value)}
+        value={section.guidance || ''}
+        onChange={(e) => brief.setSectionGuidance(section.id, e.target.value)}
         rows={2}
         placeholder="Optional: add focus or guidance — e.g. ‘emphasise sub-Saharan Africa & 2020 onward’"
       />
@@ -158,13 +160,15 @@ const GuidancePanel: React.FC<{ section: BriefSection; brief: UseBriefReturn }> 
       <div className="brief-regen-actions">
         <button
           className="brief-btn brief-btn-primary"
-          onClick={() => brief.regenerate(section.id, brief.regenText.trim() || null)}
+          onClick={() => brief.regenerate(section.id, (section.guidance || '').trim() || null)}
         >
           {isPending ? 'Research section' : 'Re-research section'}
         </button>
-        <button className="brief-btn brief-btn-secondary" onClick={brief.closeRegen}>
-          Cancel
-        </button>
+        {!hideCancel && (
+          <button className="brief-btn brief-btn-secondary" onClick={brief.closeRegen}>
+            Cancel
+          </button>
+        )}
       </div>
     </div>
   );
@@ -352,6 +356,15 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   const panelOpen = brief.regenFor === section.id;
   const isDone = section.status === 'done';
   const anyResearching = brief.sections.some((s) => s.status === 'researching');
+  // An un-researched section shows its Research panel inline rather than a
+  // button, so instructions can be written for several sections up front and
+  // then applied by "AI Regenerate All". Sample headings must be edited first.
+  const showInlineResearch =
+    section.status === 'pending' &&
+    !panelOpen &&
+    !anyResearching &&
+    !readOnly &&
+    !section.sample;
   const audit = section.audit ?? [];
   const auditCount = audit.length;
   const hasChanges = !!section.prevContent;
@@ -437,11 +450,18 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
         />
       )}
 
-      {panelOpen && <GuidancePanel section={section} brief={brief} />}
-
-      {section.status === 'pending' && !panelOpen && !anyResearching && !readOnly && (
-        <SectionPending sample={section.sample} onResearch={() => brief.openRegen(section.id)} />
+      {(panelOpen || showInlineResearch) && (
+        <GuidancePanel section={section} brief={brief} hideCancel={showInlineResearch} />
       )}
+
+      {/* Sample headings keep the (disabled) button until they are edited. */}
+      {section.status === 'pending' &&
+        section.sample &&
+        !panelOpen &&
+        !anyResearching &&
+        !readOnly && (
+          <SectionPending sample onResearch={() => brief.openRegen(section.id)} />
+        )}
 
       {section.status === 'researching' && (
         <SectionResearching section={section} display={display} onSourceClick={onSourceClick} />

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -336,6 +336,21 @@ const SectionDoneBody: React.FC<{
   );
 };
 
+// How an un-researched section invites research: inline panel (so instructions
+// can be written for several sections before one "Regenerate all" run), the
+// legacy button for un-edited sample headings, or nothing while busy/read-only.
+type PendingMode = 'none' | 'inline' | 'button';
+
+const pendingResearchMode = (
+  section: BriefSection,
+  panelOpen: boolean,
+  anyResearching: boolean,
+  readOnly: boolean,
+): PendingMode => {
+  if (section.status !== 'pending' || panelOpen || anyResearching || readOnly) return 'none';
+  return section.sample ? 'button' : 'inline';
+};
+
 const BriefSectionView: React.FC<SectionViewProps> = ({
   section,
   num,
@@ -356,15 +371,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   const panelOpen = brief.regenFor === section.id;
   const isDone = section.status === 'done';
   const anyResearching = brief.sections.some((s) => s.status === 'researching');
-  // An un-researched section shows its Research panel inline rather than a
-  // button, so instructions can be written for several sections up front and
-  // then applied by "AI Regenerate All". Sample headings must be edited first.
-  const showInlineResearch =
-    section.status === 'pending' &&
-    !panelOpen &&
-    !anyResearching &&
-    !readOnly &&
-    !section.sample;
+  const pendingMode = pendingResearchMode(section, panelOpen, anyResearching, !!readOnly);
   const audit = section.audit ?? [];
   const auditCount = audit.length;
   const hasChanges = !!section.prevContent;
@@ -450,18 +457,13 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
         />
       )}
 
-      {(panelOpen || showInlineResearch) && (
-        <GuidancePanel section={section} brief={brief} hideCancel={showInlineResearch} />
+      {(panelOpen || pendingMode === 'inline') && (
+        <GuidancePanel section={section} brief={brief} hideCancel={pendingMode === 'inline'} />
       )}
 
-      {/* Sample headings keep the (disabled) button until they are edited. */}
-      {section.status === 'pending' &&
-        section.sample &&
-        !panelOpen &&
-        !anyResearching &&
-        !readOnly && (
-          <SectionPending sample onResearch={() => brief.openRegen(section.id)} />
-        )}
+      {pendingMode === 'button' && (
+        <SectionPending sample onResearch={() => brief.openRegen(section.id)} />
+      )}
 
       {section.status === 'researching' && (
         <SectionResearching section={section} display={display} onSourceClick={onSourceClick} />

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -101,12 +101,10 @@ const AiInstructionPanel: React.FC<{
   </div>
 );
 
-// Collapse the reference list to one entry per document, keeping every
-// citation number that points at it. Pages are dropped: the group covers the
-// document as a whole.
+// One row per document: its title, then each citation number pointing into it
+// with that number's page — "Title, [1] p. 32, [2] p. 56". No excerpts.
 const groupReferencesByDoc = (
   refs: Array<{ n: number; title: string; page?: number; source: SourceReference }>,
-  pagesByDoc: Map<string, Array<{ page: number; source: SourceReference }>>,
 ): Array<{
   key: string;
   title: string;
@@ -120,17 +118,16 @@ const groupReferencesByDoc = (
       cites: Array<{ n: number; page: number; source: SourceReference }>;
     }
   >();
+  // Numbers are per cited passage, so a document collects each of its own
+  // numbers with the page that number points at.
   for (const r of refs) {
     const key = r.source.docId || r.title;
-    if (byDoc.has(key)) continue;
-    // Citation numbers are assigned per document, so every chunk of this
-    // document carries this reference's number; the page differs per chunk.
-    const hits = pagesByDoc.get(key) || [];
-    const cites = hits.length
-      ? hits.map((h) => ({ n: r.n, page: h.page, source: h.source }))
-      : [{ n: r.n, page: r.page ?? 0, source: r.source }];
-    byDoc.set(key, { key, title: r.title, cites });
+    const cite = { n: r.n, page: r.page ?? 0, source: r.source };
+    const found = byDoc.get(key);
+    if (found) found.cites.push(cite);
+    else byDoc.set(key, { key, title: r.title, cites: [cite] });
   }
+  byDoc.forEach((g) => g.cites.sort((a, b) => a.page - b.page || a.n - b.n));
   return Array.from(byDoc.values());
 };
 
@@ -887,7 +884,7 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
           </div>
           <div className="brief-footnotes-list">
             {brief.groupReferences
-              ? groupReferencesByDoc(references, citedPagesByDoc(sections)).map((g) => (
+              ? groupReferencesByDoc(references).map((g) => (
                   <div className="brief-footnote-group" key={g.key}>
                     <span className="brief-footnote-text">{g.title}</span>
                     {g.cites.map((c, i) => (

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -1,6 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { SearchResult, SourceReference } from '../../types/api';
-import { CitedMarkdown, CitedReferences } from '../citations/CitedContent';
+import {
+  CitedMarkdown,
+  CitedReferences,
+  extractCitedNumbers,
+} from '../citations/CitedContent';
 import { buildGlobalCitations, SectionDisplay } from './briefCitations';
 import {
   IconClock,
@@ -96,6 +100,48 @@ const AiInstructionPanel: React.FC<{
     </div>
   </div>
 );
+
+// Collapse the reference list to one entry per document, keeping every
+// citation number that points at it. Pages are dropped: the group covers the
+// document as a whole.
+const groupReferencesByDoc = (
+  refs: Array<{ n: number; title: string; page?: number; source: SourceReference }>,
+  pagesByDoc: Map<string, number[]>,
+): Array<{ key: string; title: string; pages: number[]; entries: typeof refs }> => {
+  const byDoc = new Map<
+    string,
+    { key: string; title: string; pages: number[]; entries: typeof refs }
+  >();
+  for (const r of refs) {
+    const key = r.source.docId || r.title;
+    const found = byDoc.get(key);
+    if (found) found.entries.push(r);
+    else byDoc.set(key, { key, title: r.title, pages: pagesByDoc.get(key) || [], entries: [r] });
+  }
+  return Array.from(byDoc.values());
+};
+
+/**
+ * Every page cited from each document across the brief. Citation numbers are
+ * per document, so the flat list only ever shows the first chunk's page; the
+ * grouped view uses this to show the document's full page coverage.
+ */
+const citedPagesByDoc = (sections: BriefSection[]): Map<string, number[]> => {
+  const map = new Map<string, number[]>();
+  sections.forEach((s) => {
+    if (!(s.status === 'done' || s.revising) || !s.content) return;
+    const cited = new Set(extractCitedNumbers(s.content));
+    s.sources.forEach((src) => {
+      if (src.index == null || !cited.has(src.index) || src.page == null) return;
+      const key = src.docId || src.title;
+      const pages = map.get(key) || [];
+      if (!pages.includes(src.page)) pages.push(src.page);
+      map.set(key, pages);
+    });
+  });
+  map.forEach((pages) => pages.sort((a, b) => a - b));
+  return map;
+};
 
 interface SectionViewProps {
   section: BriefSection;
@@ -496,47 +542,21 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
   );
 };
 
-// The dropdown behind "Export to Word": references-list vs footnotes style.
-const ExportMenu: React.FC<{
+// "Export to Word": one button. The document mirrors the on-screen
+// references, so its layout follows the "Group by document" toggle.
+const ExportButton: React.FC<{
   disabled: boolean;
   busy: boolean;
-  open: boolean;
-  setOpen: (fn: (open: boolean) => boolean) => void;
-  onExportWord: (style: 'links' | 'footnotes') => void;
-}> = ({ disabled, busy, open, setOpen, onExportWord }) => (
-  <div className="dropdown-container brief-export-menu">
-    <button
-      className="brief-export-word"
-      onClick={() => setOpen((o) => !o)}
-      onBlur={() => setTimeout(() => setOpen(() => false), 200)}
-      disabled={disabled || busy}
-      aria-haspopup="menu"
-      aria-expanded={open}
-      title="Export this brief to Word, with citations linked to the source documents"
-    >
-      {busy ? 'Exporting…' : <><IconDownload /> Export to Word ▾</>}
-    </button>
-    {open && !busy && (
-      <div className="brief-export-dropdown" role="menu">
-        <button
-          className="brief-export-option"
-          role="menuitem"
-          onClick={() => { setOpen(() => false); onExportWord('links'); }}
-        >
-          References list
-          <span className="brief-export-option-hint">Inline [n] citations + reference excerpts</span>
-        </button>
-        <button
-          className="brief-export-option"
-          role="menuitem"
-          onClick={() => { setOpen(() => false); onExportWord('footnotes'); }}
-        >
-          Footnotes on page
-          <span className="brief-export-option-hint">Each citation as a footnote on the relevant page</span>
-        </button>
-      </div>
-    )}
-  </div>
+  onExportWord: () => void;
+}> = ({ disabled, busy, onExportWord }) => (
+  <button
+    className="brief-export-word"
+    onClick={onExportWord}
+    disabled={disabled || busy}
+    title="Export this brief to Word, with citations linked to the source documents"
+  >
+    {busy ? 'Exporting…' : <><IconDownload /> Export to Word</>}
+  </button>
 );
 
 // The document-level action row: regenerate/update all, share, save-as-template
@@ -548,10 +568,8 @@ const HeaderActions: React.FC<{
   onOpenShare?: () => void;
   onSaveTemplate?: () => void;
   onRegenerateAll?: () => void;
-  onExportWord?: (style: 'links' | 'footnotes') => void;
+  onExportWord?: () => void;
   exportBusy?: boolean;
-  exportMenuOpen: boolean;
-  setExportMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({
   brief,
   readOnly,
@@ -561,8 +579,6 @@ const HeaderActions: React.FC<{
   onRegenerateAll,
   onExportWord,
   exportBusy,
-  exportMenuOpen,
-  setExportMenuOpen,
 }) => {
   const { sections } = brief;
   const hasSections = sections.length > 0;
@@ -607,11 +623,9 @@ const HeaderActions: React.FC<{
         </button>
       )}
       {onExportWord && (
-        <ExportMenu
+        <ExportButton
           disabled={!hasSections}
           busy={!!exportBusy}
-          open={exportMenuOpen}
-          setOpen={setExportMenuOpen}
           onExportWord={onExportWord}
         />
       )}
@@ -624,7 +638,7 @@ interface BriefDocumentProps {
   onResultClick?: (result: SearchResult) => void;
   // Export the brief to Word. 'links' keeps inline [n] citations; 'footnotes'
   // renders each citation as a Word footnote on the relevant page.
-  onExportWord?: (style: 'links' | 'footnotes') => void;
+  onExportWord?: () => void;
   exportBusy?: boolean;
   // Brief Central integrations (remote mode only).
   onOpenShare?: () => void;
@@ -684,7 +698,6 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
 }) => {
   const { sections, numbers } = brief;
   const [logOpen, setLogOpen] = useState(false);
-  const [exportMenuOpen, setExportMenuOpen] = useState(false);
   const titleRef = useRef<HTMLTextAreaElement>(null);
   const hasOutlineLog = brief.generatingActivity.length > 0;
   const { refs: references, display } = useMemo(() => buildGlobalCitations(sections), [sections]);
@@ -727,8 +740,6 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
             onRegenerateAll={onRegenerateAll}
             onExportWord={onExportWord}
             exportBusy={exportBusy}
-            exportMenuOpen={exportMenuOpen}
-            setExportMenuOpen={setExportMenuOpen}
           />
         </div>
         <textarea
@@ -848,28 +859,67 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
 
       {references.length > 0 && (
         <section className="brief-footnotes">
-          <h2 className="brief-footnotes-title">References</h2>
+          <div className="brief-footnotes-head">
+            <h2 className="brief-footnotes-title">References</h2>
+            <label className="brief-footnotes-group-toggle">
+              <input
+                type="checkbox"
+                checked={brief.groupReferences}
+                onChange={(e) => brief.setGroupReferences(e.target.checked)}
+              />
+              Group by document
+            </label>
+          </div>
           <div className="brief-footnotes-list">
-            {references.map((r) => (
-              <div className="brief-footnote-row" key={r.n}>
-                <a
-                  href="#"
-                  className="brief-footnote-link"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    handleSourceClick(r.source);
-                  }}
-                >
-                  <span className="citation-doc-group">
-                    <span className="ai-summary-citation">{r.n}</span>
-                  </span>
-                  <span className="brief-footnote-text">
-                    {r.title}
-                    {r.page ? `, p.${r.page}` : ''}
-                  </span>
-                </a>
-              </div>
-            ))}
+            {brief.groupReferences
+              ? groupReferencesByDoc(references, citedPagesByDoc(sections)).map((g) => (
+                  <div className="brief-footnote-group" key={g.key}>
+                    <span className="brief-footnote-group-nums">
+                      {g.entries.map((r) => (
+                        <span className="citation-doc-group" key={r.n}>
+                          <a
+                            href="#"
+                            className="ai-summary-citation"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              handleSourceClick(r.source);
+                            }}
+                          >
+                            {r.n}
+                          </a>
+                        </span>
+                      ))}
+                    </span>
+                    <span className="brief-footnote-text">
+                      {g.title}
+                      {g.pages.length > 0 && (
+                        <span className="brief-footnote-pages">
+                          {` — ${g.pages.length > 1 ? 'pp.' : 'p.'} ${g.pages.join(', ')}`}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ))
+              : references.map((r) => (
+                  <div className="brief-footnote-row" key={r.n}>
+                    <a
+                      href="#"
+                      className="brief-footnote-link"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handleSourceClick(r.source);
+                      }}
+                    >
+                      <span className="citation-doc-group">
+                        <span className="ai-summary-citation">{r.n}</span>
+                      </span>
+                      <span className="brief-footnote-text">
+                        {r.title}
+                        {r.page ? `, p.${r.page}` : ''}
+                      </span>
+                    </a>
+                  </div>
+                ))}
           </div>
         </section>
       )}

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -852,7 +852,7 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
           display={display.get(s.id)}
           readOnly={readOnly}
           onRequestHighlight={(src) =>
-            src.index != null && brief.requestSourceHighlight(s.id, src.index)
+            src.chunkId && brief.requestSourceHighlight(s.id, src.chunkId)
           }
         />
       ))}

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -100,7 +100,7 @@ const BriefWorkspace: React.FC<{
   loggedIn: boolean;
   onBack: () => void;
   onResultClick?: (result: SearchResult) => void;
-  onExportWord: (style: 'links' | 'footnotes') => void;
+  onExportWord: () => void;
   exportBusy: boolean;
   onOpenModal: (modal: 'share' | 'template' | 'regen-all') => void;
 }> = ({ brief, loggedIn, onBack, onResultClick, onExportWord, exportBusy, onOpenModal }) => {
@@ -264,7 +264,7 @@ export const BriefTab: React.FC<BriefTabProps> = ({
   );
 
   const handleExportWord = useCallback(
-    async (citationStyle: 'links' | 'footnotes' = 'links') => {
+    async () => {
       if (exportBusy) return;
       setExportBusy(true);
       try {
@@ -278,10 +278,12 @@ export const BriefTab: React.FC<BriefTabProps> = ({
           summaryHeading: brief.briefTitle || DEFAULT_BRIEF_TITLE,
           infoBox: BRIEF_DISCLAIMER,
           tableOfContents: true,
-          resultsSectionTitle: 'Reference Excerpts',
-          // 'links' keeps inline [n] citations; 'footnotes' renders each
-          // citation as a Word footnote on the relevant page.
-          citationStyle,
+          resultsSectionTitle: 'References',
+          // The document mirrors the on-screen References section: inline [n]
+          // citations and a compact list, grouped by document when the reader
+          // has that turned on.
+          citationStyle: 'links',
+          referenceList: brief.groupReferences ? 'grouped' : 'flat',
           siteOrigin:
             typeof window !== 'undefined' && window.location ? window.location.origin : undefined,
           // Same API base the on-screen cards use to load table/figure

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -2514,18 +2514,33 @@
   cursor: pointer;
 }
 /* Grouped view: one document per row, with its citation numbers. */
+/* "Title, [1] p. 32, [2] p. 56" — the title then each inline citation with
+   the page it points at. */
 .brief-footnote-group {
-  display: flex;
-  gap: 10px;
-  align-items: baseline;
-  padding: 2px 0;
+  display: block;
+  padding: 3px 0;
+  line-height: 1.6;
 }
-.brief-footnote-group-nums {
-  flex: none;
-  display: inline-flex;
-  gap: 4px;
-  flex-wrap: wrap;
+.brief-footnote-group .brief-footnote-text {
+  margin-right: 2px;
+}
+.brief-footnote-cite {
+  white-space: nowrap;
+  color: var(--brand-text-secondary);
+  font-size: 13px;
+}
+.brief-footnote-cite::before {
+  content: ', ';
+  color: var(--brand-text-tertiary);
 }
 .brief-footnote-pages {
   color: var(--brand-text-tertiary);
+}
+.brief-footnote-page-link {
+  color: var(--brand-text-secondary);
+  text-decoration: none;
+}
+.brief-footnote-page-link:hover {
+  color: var(--brand-primary-dark);
+  text-decoration: underline;
 }

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -489,8 +489,11 @@
   gap: 16px;
 }
 .brief-doc-header-actions {
-  flex-shrink: 0;
-  display: inline-flex;
+  flex-shrink: 1;
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   align-items: center;
   gap: 8px;
 }
@@ -2486,4 +2489,43 @@
 
 .brief-status-bar-stop:hover {
   background: rgba(255, 255, 255, 0.22);
+}
+
+/* References: the grouping toggle sits beside the heading. */
+.brief-footnotes-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+.brief-footnotes-group-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  color: var(--brand-text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+.brief-footnotes-group-toggle input {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+}
+/* Grouped view: one document per row, with its citation numbers. */
+.brief-footnote-group {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  padding: 2px 0;
+}
+.brief-footnote-group-nums {
+  flex: none;
+  display: inline-flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.brief-footnote-pages {
+  color: var(--brand-text-tertiary);
 }

--- a/ui/frontend/src/components/brief/briefCitations.ts
+++ b/ui/frontend/src/components/brief/briefCitations.ts
@@ -89,6 +89,13 @@ export const buildGlobalCitations = (
       if (!seen.has(g)) {
         seen.add(g);
         sources.push({ ...src, index: g });
+        return;
+      }
+      // A document's other chunks ride along as variants: their excerpts carry
+      // the highlights for claims this first chunk does not support.
+      const kept = sources.find((x) => x.index === g);
+      if (kept && kept.chunkId !== src.chunkId) {
+        kept.variants = [...(kept.variants || []), src];
       }
     });
     const content = stripLeadingTitle(s.content, s.title).replace(CITATION_RE, (_m, nums: string) => {

--- a/ui/frontend/src/components/brief/briefCitations.ts
+++ b/ui/frontend/src/components/brief/briefCitations.ts
@@ -57,7 +57,13 @@ export interface SectionDisplay {
 export const buildGlobalCitations = (
   sections: BriefSection[],
 ): { refs: GlobalRef[]; display: Map<string, SectionDisplay> } => {
-  const docToGlobal = new Map<string, number>();
+  // One citation number per cited passage, exactly as the AI summary numbers
+  // its sources (assistant_graph assigns global_index per chunk). A report
+  // cited from p.32 and p.56 therefore gets two numbers, and the reader can
+  // see which page each claim came from.
+  const chunkKey = (src: SourceReference): string =>
+    src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
+  const chunkToGlobal = new Map<string, number>();
   const refs: GlobalRef[] = [];
   // A section mid-Edit/Update (revising) keeps its old content on screen, so
   // it stays in the numbering — otherwise citations would jump twice per run.
@@ -68,9 +74,9 @@ export const buildGlobalCitations = (
     if (!isVisible(s)) return;
     extractCitedNumbers(s.content).forEach((localN) => {
       const src = s.sources.find((x) => x.index === localN);
-      if (!src || docToGlobal.has(src.docId)) return;
+      if (!src || chunkToGlobal.has(chunkKey(src))) return;
       const n = refs.length + 1;
-      docToGlobal.set(src.docId, n);
+      chunkToGlobal.set(chunkKey(src), n);
       refs.push({ n, title: src.title, page: src.page, source: src });
     });
   });
@@ -83,20 +89,13 @@ export const buildGlobalCitations = (
     const seen = new Set<number>();
     s.sources.forEach((src) => {
       if (src.index == null) return;
-      const g = docToGlobal.get(src.docId);
+      const g = chunkToGlobal.get(chunkKey(src));
       if (g == null) return;
       localToGlobal.set(src.index, g);
-      if (!seen.has(g)) {
-        seen.add(g);
-        sources.push({ ...src, index: g });
-        return;
-      }
-      // A document's other chunks ride along as variants: their excerpts carry
-      // the highlights for claims this first chunk does not support.
-      const kept = sources.find((x) => x.index === g);
-      if (kept && kept.chunkId !== src.chunkId) {
-        kept.variants = [...(kept.variants || []), src];
-      }
+      // Each number belongs to one passage, so there is nothing to merge.
+      if (seen.has(g)) return;
+      seen.add(g);
+      sources.push({ ...src, index: g });
     });
     const content = stripLeadingTitle(s.content, s.title).replace(CITATION_RE, (_m, nums: string) => {
       const mapped = Array.from(

--- a/ui/frontend/src/components/brief/briefHighlights.ts
+++ b/ui/frontend/src/components/brief/briefHighlights.ts
@@ -28,6 +28,15 @@ const SENTENCE_SPLIT_RE = /(?<=[.!?])\s+|\n+/;
 // more than they help — drop them.
 const MIN_MATCH_CHARS = 30;
 
+// Excerpts highlighted at once. Each is one LLM call taking ~10-15s, so a
+// serial pass over a heavily-cited section took minutes; a small pool keeps
+// the section usable quickly without flooding the highlight endpoint.
+const HIGHLIGHT_CONCURRENCY = 6;
+
+// Completed excerpts to collect before publishing them to the UI, so cards
+// fill in batches instead of one re-render per source.
+const HIGHLIGHT_BATCH = 3;
+
 /**
  * Every sentence of the section that cites source `n`, individually — cleaned
  * of markers/markdown for the LLM but keyed by `normalizeClaimText` so the
@@ -83,24 +92,59 @@ export const highlightSectionSources = async ({
   onPartial,
 }: HighlightSectionArgs): Promise<SourceReference[]> => {
   const cited = new Set(extractCitedNumbers(content));
-  const out: SourceReference[] = [];
-  for (const source of sources) {
-    if (isStale?.()) return out.concat(sources.slice(out.length));
-    if (
-      source.index == null ||
-      !cited.has(source.index) ||
-      !source.text ||
-      source.claimMatches?.length
-    ) {
-      out.push(source);
-      continue;
+  const out = sources.slice();
+  // Which sources still need a pass: cited, has text, never attempted.
+  const queue = sources
+    .map((source, at) => ({ source, at }))
+    .filter(
+      ({ source }) =>
+        source.index != null &&
+        cited.has(source.index) &&
+        !!source.text &&
+        source.claimMatches === undefined,
+    );
+
+  // Run several at a time. Serially, a section citing 50 sources took ~10
+  // minutes at ~12s per LLM call, so highlights effectively never showed up
+  // for the section the user had just researched.
+  let next = 0;
+  let sinceFlush = 0;
+  const flush = (): void => {
+    if (!sinceFlush) return;
+    sinceFlush = 0;
+    onPartial?.(out.slice());
+  };
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const slot = next++;
+      if (slot >= queue.length || isStale?.()) return;
+      const { source, at } = queue[slot];
+      out[at] = await enrichSource(source, content, threshold, modelConfig, isStale);
+      if (out[at].claimMatches?.length) sinceFlush += 1;
+      // Publish a batch at a time rather than per source: the hover cards fill
+      // in visibly as the pool completes waves, without a re-render each call.
+      if (sinceFlush >= HIGHLIGHT_BATCH) flush();
     }
-    const enriched = await enrichSource(source, content, threshold, modelConfig, isStale);
-    out.push(enriched);
-    if (enriched !== source) onPartial?.(out.concat(sources.slice(out.length)));
-  }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(HIGHLIGHT_CONCURRENCY, queue.length) }, worker),
+  );
+  flush();
   return out;
 };
+
+/**
+ * Highlight a single source on demand — used when a hover card opens on a
+ * citation whose excerpt has not been enriched yet, so the card can fill in
+ * while it is open rather than waiting for the background pass to reach it.
+ */
+export const highlightOneSource = async (args: {
+  source: SourceReference;
+  content: string;
+  threshold: number;
+  modelConfig?: SummaryModelConfig | null;
+}): Promise<SourceReference> =>
+  enrichSource(args.source, args.content, args.threshold, args.modelConfig);
 
 /**
  * Highlight one source's excerpt against each sentence citing it. Returns the
@@ -128,5 +172,7 @@ const enrichSource = async (
   } catch {
     // Highlighting is an enhancement — keep whatever matched before the error.
   }
-  return entries.length ? { ...source, claimMatches: entries } : source;
+  // Always record the attempt (an empty list means "tried, nothing matched"),
+  // so resuming an interrupted run only retries sources never attempted.
+  return { ...source, claimMatches: entries };
 };

--- a/ui/frontend/src/components/brief/briefHighlights.ts
+++ b/ui/frontend/src/components/brief/briefHighlights.ts
@@ -21,11 +21,9 @@ import {
 // steers the highlighter, it is never shown to the user.
 const SENTENCE_SPLIT_RE = /(?<=[.!?])\s+|\n+/;
 
-// A source is often cited from several sentences; highlighting each claim
-// separately keeps every hover card specific. Cap the per-source claim count
-// so one heavily-cited source can't monopolise the (serial) LLM budget.
-const MAX_CLAIMS_PER_SOURCE = 4;
-
+// A source is often cited from several sentences; each claim is highlighted
+// separately so every hover card is specific to the sentence it belongs to.
+// There is no cap — a brief should have highlights everywhere it cites.
 // Matches shorter than this are fragments ("er > Education --") that mislead
 // more than they help — drop them.
 const MIN_MATCH_CHARS = 30;
@@ -52,7 +50,6 @@ export const extractClaimsForCitation = (
     if (!key || seen.has(key)) continue;
     seen.add(key);
     out.push({ key, prose: key });
-    if (out.length >= MAX_CLAIMS_PER_SOURCE) break;
   }
   return out;
 };

--- a/ui/frontend/src/components/brief/briefHighlights.ts
+++ b/ui/frontend/src/components/brief/briefHighlights.ts
@@ -31,7 +31,24 @@ const MIN_MATCH_CHARS = 30;
 // Excerpts highlighted at once. Each is one LLM call taking ~10-15s, so a
 // serial pass over a heavily-cited section took minutes; a small pool keeps
 // the section usable quickly without flooding the highlight endpoint.
-const HIGHLIGHT_CONCURRENCY = 6;
+// Kept below the browser's ~6 connections per origin so a hover-triggered
+// call, plus the brief's own saves, always have a socket free.
+const HIGHLIGHT_CONCURRENCY = 3;
+
+// A hover on an un-highlighted citation must be served at once. Background
+// workers park between calls while any on-demand request is outstanding, and
+// the smaller pool above leaves browser connections free for it — otherwise
+// the hover queues behind a section's worth of calls and takes minutes.
+let priorityInFlight = 0;
+// Bounded: a slow (or stuck) hover request must not stall the whole backfill,
+// so workers yield for at most this long before carrying on regardless.
+const PRIORITY_YIELD_MS = 15000;
+const waitForPriority = async (): Promise<void> => {
+  const until = Date.now() + PRIORITY_YIELD_MS;
+  while (priorityInFlight > 0 && Date.now() < until) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+};
 
 // Completed excerpts to collect before publishing them to the UI, so cards
 // fill in batches instead of one re-render per source.
@@ -116,6 +133,7 @@ export const highlightSectionSources = async ({
   };
   const worker = async (): Promise<void> => {
     for (;;) {
+      await waitForPriority();
       const slot = next++;
       if (slot >= queue.length || isStale?.()) return;
       const { source, at } = queue[slot];
@@ -143,8 +161,25 @@ export const highlightOneSource = async (args: {
   content: string;
   threshold: number;
   modelConfig?: SummaryModelConfig | null;
-}): Promise<SourceReference> =>
-  enrichSource(args.source, args.content, args.threshold, args.modelConfig);
+  // Called as each claim resolves, so an open card shows its first highlight
+  // after one round-trip instead of waiting for every claim in the source.
+  onProgress?: (partial: SourceReference) => void;
+}): Promise<SourceReference> => {
+  // Registered as priority work: background workers pause until this returns.
+  priorityInFlight += 1;
+  try {
+    return await enrichSource(
+      args.source,
+      args.content,
+      args.threshold,
+      args.modelConfig,
+      undefined,
+      args.onProgress,
+    );
+  } finally {
+    priorityInFlight = Math.max(0, priorityInFlight - 1);
+  }
+};
 
 /**
  * Highlight one source's excerpt against each sentence citing it. Returns the
@@ -157,18 +192,37 @@ const enrichSource = async (
   threshold: number,
   modelConfig: SummaryModelConfig | null | undefined,
   isStale?: () => boolean,
+  onProgress?: (partial: SourceReference) => void,
 ): Promise<SourceReference> => {
   const claims = extractClaimsForCitation(content, source.index as number);
   const { body } = parseSectionBreadcrumb(source.text || '');
   const entries: NonNullable<SourceReference['claimMatches']> = [];
   try {
-    for (const { key, prose } of claims) {
-      if (isStale?.()) break;
-      const matches = (await findSemanticMatches(body, prose, threshold, modelConfig)).filter(
-        (m) => m.end - m.start >= MIN_MATCH_CHARS,
-      );
-      if (matches.length) entries.push({ claim: key, matches });
-    }
+    // The claims are independent, so ask for them together: a source cited from
+    // five sentences took five sequential LLM calls (~a minute) before the card
+    // showed anything. One round of parallel calls resolves it in one call's
+    // time. Order is preserved by index.
+    const results = await Promise.all(
+      claims.map(async ({ key, prose }) => {
+        if (isStale?.()) return null;
+        try {
+          const matches = (await findSemanticMatches(body, prose, threshold, modelConfig)).filter(
+            (m) => m.end - m.start >= MIN_MATCH_CHARS,
+          );
+          if (!matches.length) return null;
+          const entry = { claim: key, matches };
+          // Publish immediately: the open card gains this span now rather
+          // than when the slowest claim of the source finishes.
+          onProgress?.({ ...source, claimMatches: [...entries, entry] });
+          entries.push(entry);
+          return entry;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    // entries was filled as each claim resolved (see onProgress above).
+    void results;
   } catch {
     // Highlighting is an enhancement — keep whatever matched before the error.
   }

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -57,6 +57,9 @@ export interface BriefSection {
   prevSources?: SourceReference[];
   // The kind of the most recent AI op that changed content, for the changes UI.
   lastChangeKind?: SectionAuditKind;
+  // Author instructions for researching this section, kept per section so they
+  // survive and are applied by a document-wide "Regenerate all".
+  guidance?: string;
   // Voice & tone profile override for this section (null/absent = brief default).
   voiceId?: string | null;
 }
@@ -78,6 +81,7 @@ export interface SavedBriefSection {
   audit?: SectionAuditEntry[];
   lastResearchedAt?: number;
   voiceId?: string | null;
+  guidance?: string;
 }
 
 export interface SavedBrief {

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -32,7 +32,7 @@ import {
   updateBrief as updateBriefRemote,
 } from './briefCentralApi';
 import { listItemToStub, migrateLocalBriefs, remoteToSaved } from './briefRemote';
-import { highlightSectionSources } from './briefHighlights';
+import { highlightOneSource, highlightSectionSources } from './briefHighlights';
 import {
   SEARCH_SEMANTIC_HIGHLIGHTS,
   SEMANTIC_HIGHLIGHT_THRESHOLD,
@@ -314,6 +314,13 @@ export const useBrief = ({
   // must not start a second pass or overwrite the token of a running one,
   // which would make that run consider itself stale and stop.
   const enrichingRef = useRef<Set<string>>(new Set());
+  // Set when enrichment has updated a section's sources; a post-commit effect
+  // persists them. Without this the highlights lived only in memory and were
+  // lost on reload, since enrichment never triggered a save of its own.
+  const enrichSaveRef = useRef(false);
+  const lastEnrichSaveRef = useRef(0);
+  // Sources with an on-demand (hover-triggered) highlight in flight.
+  const onDemandRef = useRef<Set<string>>(new Set());
   // Brief id awaiting a highlight-enrichment resume after being opened.
   const resumeRef = useRef<string | null>(null);
 
@@ -352,16 +359,56 @@ export const useBrief = ({
         // Apply snippets as each source resolves — a big section takes minutes
         // to fully enrich and the hover cards should improve as it goes.
         onPartial: (sources) => {
-          if (!isStale()) updateSection(id, { sources });
+          if (isStale()) return;
+          updateSection(id, { sources });
+          // Persist progress periodically: a long section takes minutes and a
+          // reload mid-run would otherwise discard everything done so far.
+          if (Date.now() - lastEnrichSaveRef.current > 15000) enrichSaveRef.current = true;
         },
       })
         .then((sources) => {
-          if (!isStale()) updateSection(id, { sources });
+          if (isStale()) return;
+          updateSection(id, { sources });
+          enrichSaveRef.current = true;
         })
         .catch(() => {
           /* highlighting is an enhancement; the plain excerpt remains */
         })
         .finally(() => enrichingRef.current.delete(id));
+    },
+    [updateSection],
+  );
+
+  // Enrich one source now, because a hover card opened on a citation whose
+  // excerpt has no highlights yet. The card re-renders from section state, so
+  // it fills in while the user is still hovering.
+  const requestSourceHighlight = useCallback(
+    (sectionId: string, sourceIndex: number) => {
+      if (!SEARCH_SEMANTIC_HIGHLIGHTS || !semanticModelConfigRef.current?.model) return;
+      const key = `${sectionId}:${sourceIndex}`;
+      if (onDemandRef.current.has(key)) return;
+      const section = sectionsRef.current.find((sec) => sec.id === sectionId);
+      const source = section?.sources.find((src) => src.index === sourceIndex);
+      if (!section || !source || !source.text || source.claimMatches !== undefined) return;
+      onDemandRef.current.add(key);
+      void highlightOneSource({
+        source,
+        content: section.content,
+        threshold: SEMANTIC_HIGHLIGHT_THRESHOLD,
+        modelConfig: semanticModelConfigRef.current,
+      })
+        .then((enriched) => {
+          const cur = sectionsRef.current.find((sec) => sec.id === sectionId);
+          if (!cur) return;
+          updateSection(sectionId, {
+            sources: cur.sources.map((src) => (src.index === sourceIndex ? enriched : src)),
+          });
+          enrichSaveRef.current = true;
+        })
+        .catch(() => {
+          /* the full excerpt remains as the fallback */
+        })
+        .finally(() => onDemandRef.current.delete(key));
     },
     [updateSection],
   );
@@ -1154,7 +1201,12 @@ export const useBrief = ({
     if (!tabVisible) return;
     resumeRef.current = null;
     void (async () => {
-      for (const { id } of sectionsRef.current) {
+      // Most recently researched first: that is the section the user is
+      // looking at, and enriching in document order left it until last.
+      const order = sectionsRef.current
+        .map((sec) => ({ id: sec.id, at: sec.lastResearchedAt ?? 0 }))
+        .sort((a, b) => b.at - a.at);
+      for (const { id } of order) {
         if (briefIdRef.current !== briefId) return;
         // A pass started by research owns this section; starting a second one
         // here would overwrite its token and make it stop mid-run.
@@ -1321,6 +1373,7 @@ export const useBrief = ({
     setError,
     setHistoryOpen,
     setBriefVoiceId,
+    requestSourceHighlight,
     setSectionGuidance: (id: string, guidance: string) => updateSection(id, { guidance }),
     setSectionVoiceId: (id: string, voiceId: string | null) =>
       updateSection(id, { voiceId }),

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -209,6 +209,9 @@ export const useBrief = ({
   const [query, setQuery] = useState(''); // the brief topic
   const [instructions, setInstructions] = useState('');
   const [numHeadings, setNumHeadings] = useState(6);
+  // References list: one row per document (off) vs grouped by document (on).
+  // Also chooses how the Word export lays its references out.
+  const [groupReferences, setGroupReferences] = useState(false);
   const [newHeading, setNewHeading] = useState('');
   const [regenFor, setRegenFor] = useState<string | null>(null);
   const [regenText, setRegenText] = useState('');
@@ -1373,6 +1376,8 @@ export const useBrief = ({
     setError,
     setHistoryOpen,
     setBriefVoiceId,
+    groupReferences,
+    setGroupReferences,
     requestSourceHighlight,
     setSectionGuidance: (id: string, guidance: string) => updateSection(id, { guidance }),
     setSectionVoiceId: (id: string, voiceId: string | null) =>

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -310,6 +310,10 @@ export const useBrief = ({
   // Latest research-completion token per section id, written synchronously so
   // highlight enrichment can detect a superseded run without waiting on state.
   const researchTokenRef = useRef<Record<string, number>>({});
+  // Sections with an enrichment pass in flight. The backfill skips these: it
+  // must not start a second pass or overwrite the token of a running one,
+  // which would make that run consider itself stale and stop.
+  const enrichingRef = useRef<Set<string>>(new Set());
   // Brief id awaiting a highlight-enrichment resume after being opened.
   const resumeRef = useRef<string | null>(null);
 
@@ -338,6 +342,7 @@ export const useBrief = ({
       // runs from a timeout that can fire before the re-render lands.
       const isStale = () => researchTokenRef.current[id] !== token;
       if (isStale()) return Promise.resolve();
+      enrichingRef.current.add(id);
       return highlightSectionSources({
         content,
         sources,
@@ -355,7 +360,8 @@ export const useBrief = ({
         })
         .catch(() => {
           /* highlighting is an enhancement; the plain excerpt remains */
-        });
+        })
+        .finally(() => enrichingRef.current.delete(id));
     },
     [updateSection],
   );
@@ -1148,17 +1154,25 @@ export const useBrief = ({
     if (!tabVisible) return;
     resumeRef.current = null;
     void (async () => {
-      for (const section of sectionsRef.current) {
+      for (const { id } of sectionsRef.current) {
         if (briefIdRef.current !== briefId) return;
-        if (section.status !== 'done' || !section.content) continue;
+        // A pass started by research owns this section; starting a second one
+        // here would overwrite its token and make it stop mid-run.
+        if (enrichingRef.current.has(id)) continue;
+        // Re-read: research finishing during the backfill replaces a section's
+        // content and sources, and the snapshot would enrich the old set.
+        const section = sectionsRef.current.find((s) => s.id === id);
+        if (!section || section.status !== 'done' || !section.content) continue;
         const cited = new Set(extractCitedNumbers(section.content));
         const pending = section.sources.some(
           (src) => src.index != null && cited.has(src.index) && src.claimMatches === undefined,
         );
         if (!pending) continue;
-        const token = section.lastResearchedAt ?? Date.now();
-        researchTokenRef.current[section.id] = token;
-        await enrichSectionHighlights(section.id, token, section.content, section.sources);
+        // Keep any token already recorded so a run started by research retains
+        // ownership; only invent one when the section has none.
+        const token = researchTokenRef.current[id] ?? section.lastResearchedAt ?? Date.now();
+        researchTokenRef.current[id] = token;
+        await enrichSectionHighlights(id, token, section.content, section.sources);
       }
     })();
   });

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -175,7 +175,9 @@ const computeReferences = (sections: BriefSection[]): BriefReference[] => {
     const cited = new Set(extractCitedNumbers(s.content));
     s.sources.forEach((src: SourceReference) => {
       if (src.index == null || !cited.has(src.index)) return;
-      const key = src.docId || src.title;
+      // One entry per cited passage, matching the numbering in
+      // buildGlobalCitations (and the AI summary), not one per document.
+      const key = src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
       if (seen.has(key)) return;
       seen.add(key);
       refs.push({

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -459,6 +459,7 @@ export const useBrief = ({
           audit: s.audit && s.audit.length ? s.audit : undefined,
           lastResearchedAt: s.lastResearchedAt,
           voiceId: s.voiceId ?? undefined,
+          guidance: s.guidance || undefined,
         };
       }),
       outlineLog: outlineLogRef.current,
@@ -863,7 +864,10 @@ export const useBrief = ({
       setStage('research');
       for (const id of ids) {
         if (controller.signal.aborted) return;
-        await researchOne(id, null, controller.signal);
+        // Each section carries its own author instructions (set in its Research
+        // panel), so a document-wide run honours what the user typed per section.
+        const guidance = sectionsRef.current.find((s) => s.id === id)?.guidance?.trim() || null;
+        await researchOne(id, guidance, controller.signal);
       }
       if (!controller.signal.aborted) {
         setStage('done');
@@ -1091,6 +1095,7 @@ export const useBrief = ({
           audit: h.audit || [],
           lastResearchedAt: h.lastResearchedAt,
           voiceId: h.voiceId ?? null,
+          guidance: h.guidance || '',
         })),
       );
       setGeneratingActivity(entry.outlineLog || []);
@@ -1245,6 +1250,7 @@ export const useBrief = ({
     setError,
     setHistoryOpen,
     setBriefVoiceId,
+    setSectionGuidance: (id: string, guidance: string) => updateSection(id, { guidance }),
     setSectionVoiceId: (id: string, voiceId: string | null) =>
       updateSection(id, { voiceId }),
     generateOutline,

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -388,12 +388,16 @@ export const useBrief = ({
   // excerpt has no highlights yet. The card re-renders from section state, so
   // it fills in while the user is still hovering.
   const requestSourceHighlight = useCallback(
-    (sectionId: string, sourceIndex: number) => {
+    (sectionId: string, chunkId: string) => {
       if (!SEARCH_SEMANTIC_HIGHLIGHTS || !semanticModelConfigRef.current?.model) return;
-      const key = `${sectionId}:${sourceIndex}`;
+      const key = `${sectionId}:${chunkId}`;
       if (onDemandRef.current.has(key)) return;
       const section = sectionsRef.current.find((sec) => sec.id === sectionId);
-      const source = section?.sources.find((src) => src.index === sourceIndex);
+      // Matched by chunk, not index: the card shows the *display* source, whose
+      // index is the global citation number, while section state keeps the
+      // local research indices. Matching on index found nothing, so the card
+      // sat on "Highlighting…" for ever.
+      const source = section?.sources.find((src) => src.chunkId === chunkId);
       if (!section || !source || !source.text || source.claimMatches !== undefined) return;
       onDemandRef.current.add(key);
       void highlightOneSource({
@@ -406,7 +410,7 @@ export const useBrief = ({
           const cur = sectionsRef.current.find((sec) => sec.id === sectionId);
           if (!cur) return;
           updateSection(sectionId, {
-            sources: cur.sources.map((src) => (src.index === sourceIndex ? enriched : src)),
+            sources: cur.sources.map((src) => (src.chunkId === chunkId ? enriched : src)),
           });
           enrichSaveRef.current = true;
         })

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -400,20 +400,24 @@ export const useBrief = ({
       const source = section?.sources.find((src) => src.chunkId === chunkId);
       if (!section || !source || !source.text || source.claimMatches !== undefined) return;
       onDemandRef.current.add(key);
+      const applyToSection = (enriched: SourceReference): void => {
+        const cur = sectionsRef.current.find((sec) => sec.id === sectionId);
+        if (!cur) return;
+        updateSection(sectionId, {
+          sources: cur.sources.map((src) => (src.chunkId === chunkId ? enriched : src)),
+        });
+        enrichSaveRef.current = true;
+      };
       void highlightOneSource({
         source,
         content: section.content,
         threshold: SEMANTIC_HIGHLIGHT_THRESHOLD,
         modelConfig: semanticModelConfigRef.current,
+        // Paint each claim as it lands so the open card stops saying
+        // "Highlighting…" after the first result, not the last.
+        onProgress: applyToSection,
       })
-        .then((enriched) => {
-          const cur = sectionsRef.current.find((sec) => sec.id === sectionId);
-          if (!cur) return;
-          updateSection(sectionId, {
-            sources: cur.sources.map((src) => (src.chunkId === chunkId ? enriched : src)),
-          });
-          enrichSaveRef.current = true;
-        })
+        .then(applyToSection)
         .catch(() => {
           /* the full excerpt remains as the fallback */
         })

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -310,6 +310,8 @@ export const useBrief = ({
   // Latest research-completion token per section id, written synchronously so
   // highlight enrichment can detect a superseded run without waiting on state.
   const researchTokenRef = useRef<Record<string, number>>({});
+  // Brief id awaiting a highlight-enrichment resume after being opened.
+  const resumeRef = useRef<string | null>(null);
 
   // After a section's research completes (references validated), run the LLM
   // semantic highlighter over each cited excerpt in the background — the hover
@@ -317,14 +319,26 @@ export const useBrief = ({
   // excerpt. `token` (the section's lastResearchedAt) stops a stale run from
   // clobbering a newer research pass.
   const enrichSectionHighlights = useCallback(
-    (id: string, token: number, content: string, sources: SourceReference[]) => {
-      if (!SEARCH_SEMANTIC_HIGHLIGHTS || !content || !sources.length) return;
+    (
+      id: string,
+      token: number,
+      content: string,
+      sources: SourceReference[],
+    ): Promise<void> => {
+      if (!SEARCH_SEMANTIC_HIGHLIGHTS || !content || !sources.length) {
+        return Promise.resolve();
+      }
+      // No highlight model yet (the combo config is applied after mount) —
+      // leave the section un-enriched so the resume pass retries once it lands.
+      if (!semanticModelConfigRef.current?.model) {
+        return Promise.resolve();
+      }
       // Staleness is tracked in a ref written synchronously at completion —
       // reading it from section state would race React's commit, since this
       // runs from a timeout that can fire before the re-render lands.
       const isStale = () => researchTokenRef.current[id] !== token;
-      if (isStale()) return;
-      void highlightSectionSources({
+      if (isStale()) return Promise.resolve();
+      return highlightSectionSources({
         content,
         sources,
         threshold: SEMANTIC_HIGHLIGHT_THRESHOLD,
@@ -1102,9 +1116,52 @@ export const useBrief = ({
       setNumberHeadings(entry.numberHeadings ?? false);
       setStage('done');
       setHistoryOpen(false);
+      resumeRef.current = entry.id;
     },
     [],
   );
+
+  // Whether this tab is in the foreground; the opportunistic highlight backfill
+  // only runs here (see below).
+  const [tabVisible, setTabVisible] = useState(
+    () => typeof document === 'undefined' || document.visibilityState !== 'hidden',
+  );
+  useEffect(() => {
+    const onVisibility = (): void => setTabVisible(document.visibilityState !== 'hidden');
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, []);
+
+  // Highlight enrichment runs in the browser after a section completes, so
+  // reloading or navigating away mid-run leaves cited sources unenriched for
+  // good. Opening a brief resumes those gaps, one section at a time.
+  useEffect(() => {
+    const briefId = resumeRef.current;
+    if (!briefId || !SEARCH_SEMANTIC_HIGHLIGHTS) return;
+    // The highlight model comes from the model combo, which App applies after
+    // mount. Starting first sends model=null and every call fails, so wait —
+    // this effect re-runs on the render that delivers the config.
+    if (!semanticModelConfigRef.current?.model) return;
+    // Backfill only from the visible tab. Every open tab showing a brief would
+    // otherwise run the same backfill, multiplying API load and exhausting the
+    // browser's per-origin connections (which stalls page loads).
+    if (!tabVisible) return;
+    resumeRef.current = null;
+    void (async () => {
+      for (const section of sectionsRef.current) {
+        if (briefIdRef.current !== briefId) return;
+        if (section.status !== 'done' || !section.content) continue;
+        const cited = new Set(extractCitedNumbers(section.content));
+        const pending = section.sources.some(
+          (src) => src.index != null && cited.has(src.index) && src.claimMatches === undefined,
+        );
+        if (!pending) continue;
+        const token = section.lastResearchedAt ?? Date.now();
+        researchTokenRef.current[section.id] = token;
+        await enrichSectionHighlights(section.id, token, section.content, section.sources);
+      }
+    })();
+  });
 
   const loadBrief = useCallback(
     (entry: SavedBrief) => {

--- a/ui/frontend/src/components/citations/CitationExcerpt.tsx
+++ b/ui/frontend/src/components/citations/CitationExcerpt.tsx
@@ -1,0 +1,49 @@
+// The excerpt shown in a citation hover card. Chunk text is tidied, then laid
+// out by the same renderer Search uses for result snippets (superscripts,
+// bullet/number indentation) with the LLM-selected span(s) supporting the
+// hovered claim highlighted in place.
+
+import React from 'react';
+import { renderTextWithInlineReferences } from '../../utils/textHighlighting';
+
+/**
+ * Tidy a raw chunk for reading: PDF extraction leaves runs of spaces
+ * mid-sentence and inline footnote markers ("[^56]"), and lines arrive hard-
+ * wrapped with stray leading whitespace. Line and paragraph breaks are kept so
+ * the formatter can indent lists.
+ */
+export const formatExcerpt = (text: string): string =>
+  text
+    .replace(/\[\^\d+\]/g, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/[ \t]+([.,;:!?])/g, '$1')
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+export const CitationExcerpt: React.FC<{
+  text: string;
+  // The claim being supported; used as the highlighter's query context.
+  claim?: string;
+  // Spans the LLM picked out for that claim. Search's renderer re-finds them
+  // by text, so formatting shifting the original offsets does not matter.
+  matches?: Array<{ start: number; end: number; matchedText?: string }>;
+}> = ({ text, claim, matches }) => {
+  const spans = (matches || []).filter((m) => m.matchedText);
+  return (
+    <div className="citation-hover-body">
+      {renderTextWithInlineReferences(
+        formatExcerpt(text),
+        // renderHighlightedText short-circuits on an empty query; the claim is
+        // the meaningful context here and semantic matches take precedence.
+        claim || 'excerpt',
+        undefined,
+        spans.length
+          ? (spans as Array<{ start: number; end: number; matchedText: string }>)
+          : undefined,
+      )}
+    </div>
+  );
+};

--- a/ui/frontend/src/components/citations/CitationExcerpt.tsx
+++ b/ui/frontend/src/components/citations/CitationExcerpt.tsx
@@ -8,13 +8,14 @@ import { renderTextWithInlineReferences } from '../../utils/textHighlighting';
 
 /**
  * Tidy a raw chunk for reading: PDF extraction leaves runs of spaces
- * mid-sentence and inline footnote markers ("[^56]"), and lines arrive hard-
- * wrapped with stray leading whitespace. Line and paragraph breaks are kept so
- * the formatter can indent lists.
+ * mid-sentence, and lines arrive hard-wrapped with stray leading whitespace.
+ * Line and paragraph breaks are kept so the formatter can indent lists.
+ *
+ * Footnote markers ("[^56]") are left in place: Search's renderer turns them
+ * into superscripts, so the card shows them the same way a result does.
  */
 export const formatExcerpt = (text: string): string =>
   text
-    .replace(/\[\^\d+\]/g, '')
     .replace(/[ \t]{2,}/g, ' ')
     .replace(/[ \t]+([.,;:!?])/g, '$1')
     .split('\n')

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -216,7 +216,7 @@ const InlineCitation: React.FC<{
                 {!shown.matches?.length && shown.source.claimMatches === undefined && (
                   <div className="citation-hover-pending">
                     <span className="brief-spinner citation-hover-spinner" />
-                    Finding the supporting passage…
+                    Highlighting relevant text …
                   </div>
                 )}
                 <CitationExcerpt text={excerptBody} claim={claim} matches={shown.matches} />

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -3,7 +3,7 @@
 // references list grouped by document. Used by the Research Assistant
 // (ChatMessage) and the Brief tab so both render citations identically.
 
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -129,6 +129,11 @@ const InlineCitation: React.FC<{
   const ref = useRef<HTMLAnchorElement>(null);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [card, setCard] = useState<{ top: number; left: number } | null>(null);
+  // The excerpt is clipped until the reader asks for the rest; expanding turns
+  // the body into a scroll area (with its scrollbar) rather than a long card.
+  const [expanded, setExpanded] = useState(false);
+  const [clipped, setClipped] = useState(false);
+  const bodyRef = useRef<HTMLDivElement>(null);
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -152,8 +157,19 @@ const InlineCitation: React.FC<{
     setCard({ top: r.bottom + 6, left: Math.min(r.left, window.innerWidth - CARD_W - 12) });
   };
   const scheduleHide = () => {
-    hideTimer.current = setTimeout(() => setCard(null), 120);
+    hideTimer.current = setTimeout(() => {
+      setCard(null);
+      setExpanded(false);
+    }, 120);
   };
+
+  // Is there more text than the collapsed height shows? Measured after the
+  // card renders, so "Show more" only appears when it would do something.
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!card || !el) return;
+    setClipped(el.scrollHeight > el.clientHeight + 4);
+  }, [card, excerptBody, expanded]);
 
   return (
     <>
@@ -162,8 +178,17 @@ const InlineCitation: React.FC<{
         href="#"
         className="ai-summary-citation"
         onClick={handleClick}
-        onMouseEnter={show}
+        // mouseover (not mouseenter) so the card also opens when the badge is
+        // re-rendered under a stationary cursor — enrichment re-renders these
+        // constantly, and mouseenter would not fire again until you left and
+        // returned. mousemove is the safety net for that same case.
+        onMouseOver={show}
+        onMouseMove={() => {
+          if (!card) show();
+        }}
+        onFocus={show}
         onMouseLeave={scheduleHide}
+        onBlur={scheduleHide}
       >
         {num}
       </a>
@@ -181,7 +206,12 @@ const InlineCitation: React.FC<{
               <div className="citation-hover-meta">Page {shown.source.page}</div>
             )}
             {shown.source.text && (
-              <div className="citation-hover-excerpt">
+              <div
+                ref={bodyRef}
+                className={`citation-hover-excerpt${
+                  expanded ? ' citation-hover-excerpt-open' : ''
+                }`}
+              >
                 {breadcrumb && <div className="citation-hover-section">{breadcrumb}</div>}
                 {!shown.matches?.length && shown.source.claimMatches === undefined && (
                   <div className="citation-hover-pending">
@@ -191,6 +221,15 @@ const InlineCitation: React.FC<{
                 )}
                 <CitationExcerpt text={excerptBody} claim={claim} matches={shown.matches} />
               </div>
+            )}
+            {shown.source.text && (clipped || expanded) && (
+              <button
+                type="button"
+                className="citation-hover-more"
+                onClick={() => setExpanded((v) => !v)}
+              >
+                {expanded ? 'Show less' : 'Show more'}
+              </button>
             )}
           </div>,
           document.body,

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -98,27 +98,100 @@ export const snapToWordBounds = (
   return { start: s, end: e };
 };
 
+/**
+ * Tidy a raw chunk for reading: PDF extraction leaves runs of spaces mid-
+ * sentence and inline footnote markers ("[^56]"), and paragraphs arrive as
+ * single newlines. Paragraph breaks are preserved for rendering.
+ */
+export const formatExcerpt = (text: string): string =>
+  text
+    .replace(/\[\^\d+\]/g, '')
+    .replace(/[ \t]{2,}/g, ' ')
+    .replace(/[ \t]+([.,;:!?])/g, '$1')
+    .split('\n')
+    .map((line) => line.trim())
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+/**
+ * Locate each LLM-selected span inside the formatted excerpt. Offsets from the
+ * matcher refer to the raw text, so the span is re-found by its text after
+ * formatting — then snapped to whole words and merged where spans overlap.
+ */
+export const locateMatchRanges = (
+  formatted: string,
+  snippets: string[],
+): Array<{ start: number; end: number }> => {
+  const haystack = formatted.toLowerCase();
+  const found: Array<{ start: number; end: number }> = [];
+  for (const raw of snippets) {
+    const needle = formatExcerpt(raw).toLowerCase().trim();
+    if (needle.length < 12) continue;
+    const at = haystack.indexOf(needle);
+    if (at < 0) continue;
+    found.push(snapToWordBounds(formatted, at, at + needle.length));
+  }
+  found.sort((a, b) => a.start - b.start);
+  const merged: Array<{ start: number; end: number }> = [];
+  for (const r of found) {
+    const last = merged[merged.length - 1];
+    if (last && r.start <= last.end) last.end = Math.max(last.end, r.end);
+    else merged.push({ ...r });
+  }
+  return merged;
+};
+
+// One paragraph of the excerpt with the claim-supporting spans marked.
+const ExcerptParagraph: React.FC<{
+  text: string;
+  ranges: Array<{ start: number; end: number }>;
+  offset: number;
+}> = ({ text, ranges, offset }) => {
+  const parts: React.ReactNode[] = [];
+  let cursor = 0;
+  ranges.forEach((r, i) => {
+    const start = r.start - offset;
+    const end = r.end - offset;
+    if (end <= 0 || start >= text.length) return;
+    const from = Math.max(0, start);
+    const to = Math.min(text.length, end);
+    if (from > cursor) parts.push(text.slice(cursor, from));
+    parts.push(
+      <mark key={`hl-${i}`} className="citation-hover-mark">
+        {text.slice(from, to)}
+      </mark>,
+    );
+    cursor = to;
+  });
+  if (cursor < text.length) parts.push(text.slice(cursor));
+  return <p className="citation-hover-para">{parts.length ? parts : text}</p>;
+};
+
 const renderCitationExcerpt = (
   text: string,
-  semanticMatches?: Array<{ start: number; end: number }>,
+  semanticMatches?: Array<{ start: number; end: number; matchedText?: string }>,
 ): React.ReactNode => {
   const { section, body } = parseSectionBreadcrumb(text);
-  // LLM-highlighted excerpts show ONLY the claim-supporting span(s), separated
-  // by ellipses — not the whole excerpt. Offsets are relative to the body
-  // (after the breadcrumb split). Without matches, the full excerpt renders.
-  const renderBody = (b: string): React.ReactNode => {
+  // The whole excerpt is shown, formatted for reading, with the span(s) the
+  // LLM picked out for the hovered claim highlighted in place.
+  const renderBody = (raw: string): React.ReactNode => {
+    const formatted = formatExcerpt(raw);
     const snippets = (semanticMatches || [])
-      .map((m) => {
-        const { start, end } = snapToWordBounds(b, m.start, m.end);
-        return b.substring(start, end).trim();
-      })
+      .map((m) => m.matchedText ?? raw.slice(m.start, m.end))
       .filter(Boolean);
-    if (!snippets.length) return parseAndRenderSuperscripts(b);
-    return (
-      <span className="citation-hover-snippets">
-        {snippets.map((s) => `“${s}”`).join(' … ')}
-      </span>
-    );
+    const ranges = snippets.length ? locateMatchRanges(formatted, snippets) : [];
+    if (!ranges.length) return parseAndRenderSuperscripts(formatted);
+    // Paragraphs are rendered separately, so each needs its offset into the
+    // formatted text to know which ranges fall inside it.
+    let offset = 0;
+    return formatted.split(/\n{2,}/).map((para, i) => {
+      const node = (
+        <ExcerptParagraph key={`p-${i}`} text={para} ranges={ranges} offset={offset} />
+      );
+      offset += para.length + 2;
+      return node;
+    });
   };
   if (!section) return renderBody(text);
   return (
@@ -138,12 +211,19 @@ const renderCitationExcerpt = (
 const matchesForClaim = (
   source: SourceReference,
   claim: string | undefined,
-): Array<{ start: number; end: number }> | undefined => {
+): Array<{ start: number; end: number; matchedText?: string }> | undefined => {
   const entries = source.claimMatches;
   if (entries?.length) {
     if (claim) {
       const key = normalizeClaimText(claim);
-      const hit = entries.find((e) => e.claim === key);
+      // Enrichment splits sentences in the markdown, where a soft line-wrap
+      // ends a "sentence"; the rendered text the card sees has those wraps
+      // collapsed. Containment matches the two forms of the same sentence.
+      const hit =
+        entries.find((e) => e.claim === key) ||
+        entries.find(
+          (e) => e.claim.length > 24 && (key.includes(e.claim) || e.claim.includes(key)),
+        );
       if (hit) return hit.matches;
     }
     return entries.length === 1 ? entries[0].matches : undefined;

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -122,7 +122,10 @@ const InlineCitation: React.FC<{
   source?: SourceReference;
   onClick?: (source: SourceReference) => void;
   claim?: string;
-}> = ({ num, source, onClick, claim }) => {
+  // Ask the owner to highlight this source now (hover on an un-enriched
+  // excerpt). The card re-renders from state, so it fills in while open.
+  onRequestHighlight?: (source: SourceReference) => void;
+}> = ({ num, source, onClick, claim, onRequestHighlight }) => {
   const ref = useRef<HTMLAnchorElement>(null);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [card, setCard] = useState<{ top: number; left: number } | null>(null);
@@ -140,6 +143,8 @@ const InlineCitation: React.FC<{
   const show = () => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
     if (!source) return;
+    // Nothing highlighted for this claim yet — kick off a pass for it.
+    if (!shown?.matches?.length && onRequestHighlight) onRequestHighlight(source);
     const r = ref.current?.getBoundingClientRect();
     if (!r) return;
     // Position below the badge, clamped so the card stays in the viewport.
@@ -178,6 +183,12 @@ const InlineCitation: React.FC<{
             {shown.source.text && (
               <div className="citation-hover-excerpt">
                 {breadcrumb && <div className="citation-hover-section">{breadcrumb}</div>}
+                {!shown.matches?.length && shown.source.claimMatches === undefined && (
+                  <div className="citation-hover-pending">
+                    <span className="brief-spinner citation-hover-spinner" />
+                    Finding the supporting passage…
+                  </div>
+                )}
                 <CitationExcerpt text={excerptBody} claim={claim} matches={shown.matches} />
               </div>
             )}
@@ -193,6 +204,7 @@ function replaceCitations(
   text: string,
   sourceByIndex: Map<number, SourceReference>,
   onSourceClick?: (source: SourceReference) => void,
+  onRequestHighlight?: (source: SourceReference) => void,
 ): React.ReactNode {
   const parts: React.ReactNode[] = [];
   const re = new RegExp(CITATION_REGEX.source, 'g');
@@ -229,6 +241,7 @@ function replaceCitations(
                     source={sourceByIndex.get(n)}
                     onClick={onSourceClick}
                     claim={claim}
+                    onRequestHighlight={onRequestHighlight}
                   />
                 </React.Fragment>
               ))}
@@ -249,10 +262,11 @@ function transformChildren(
   children: React.ReactNode,
   sourceByIndex: Map<number, SourceReference>,
   onSourceClick?: (source: SourceReference) => void,
+  onRequestHighlight?: (source: SourceReference) => void,
 ): React.ReactNode {
   return React.Children.map(children, (child) => {
     if (typeof child !== 'string') return child;
-    return replaceCitations(child, sourceByIndex, onSourceClick);
+    return replaceCitations(child, sourceByIndex, onSourceClick, onRequestHighlight);
   });
 }
 
@@ -260,7 +274,9 @@ export const CitedMarkdown: React.FC<{
   content: string;
   sources: SourceReference[];
   onSourceClick?: (source: SourceReference) => void;
-}> = ({ content, sources, onSourceClick }) => {
+  // Called when a hover card opens on a citation with no highlights yet.
+  onRequestHighlight?: (source: SourceReference) => void;
+}> = ({ content, sources, onSourceClick, onRequestHighlight }) => {
   const sourceByIndex = useMemo(() => {
     const map = new Map<number, SourceReference>();
     sources.forEach((s) => {
@@ -272,19 +288,19 @@ export const CitedMarkdown: React.FC<{
   const components = useMemo(
     () => ({
       p: ({ children, ...props }: any) => (
-        <p {...props}>{transformChildren(children, sourceByIndex, onSourceClick)}</p>
+        <p {...props}>{transformChildren(children, sourceByIndex, onSourceClick, onRequestHighlight)}</p>
       ),
       li: ({ children, ...props }: any) => (
-        <li {...props}>{transformChildren(children, sourceByIndex, onSourceClick)}</li>
+        <li {...props}>{transformChildren(children, sourceByIndex, onSourceClick, onRequestHighlight)}</li>
       ),
       strong: ({ children, ...props }: any) => (
-        <strong {...props}>{transformChildren(children, sourceByIndex, onSourceClick)}</strong>
+        <strong {...props}>{transformChildren(children, sourceByIndex, onSourceClick, onRequestHighlight)}</strong>
       ),
       em: ({ children, ...props }: any) => (
-        <em {...props}>{transformChildren(children, sourceByIndex, onSourceClick)}</em>
+        <em {...props}>{transformChildren(children, sourceByIndex, onSourceClick, onRequestHighlight)}</em>
       ),
     }),
-    [sourceByIndex, onSourceClick],
+    [sourceByIndex, onSourceClick, onRequestHighlight],
   );
 
   return (

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -8,7 +8,7 @@ import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { SourceReference } from '../../types/api';
-import { parseAndRenderSuperscripts } from '../../utils/textHighlighting';
+import { CitationExcerpt } from './CitationExcerpt';
 
 const CITATION_REGEX = /\[(\d+(?:,\s*\d+)*)\]/g;
 
@@ -73,7 +73,9 @@ export const parseSectionBreadcrumb = (
   let i = 0;
   while (i < lines.length && lines[i].trim() === '') i++;
   const match = i < lines.length ? SECTION_BREADCRUMB_RE.exec(lines[i].trim()) : null;
-  if (match && match[1].includes(' > ')) {
+  // Any leading "-- … --" line is the chunk's heading breadcrumb, whether it is
+  // a full path ("Chapter > Section") or a single heading.
+  if (match) {
     const body = lines
       .slice(i + 1)
       .join('\n')
@@ -83,152 +85,36 @@ export const parseSectionBreadcrumb = (
   return { section: null, body: text };
 };
 
-// Expand a match to whole-word boundaries so snippets never start or end
-// mid-word (the phrase matcher is fuzzy and can clip by a few characters).
-export const snapToWordBounds = (
-  text: string,
-  start: number,
-  end: number,
-): { start: number; end: number } => {
-  const isWordChar = (ch: string): boolean => /[\p{L}\p{N}]/u.test(ch);
-  let s = Math.max(0, Math.min(start, text.length));
-  let e = Math.max(s, Math.min(end, text.length));
-  while (s > 0 && isWordChar(text[s - 1]) && s < text.length && isWordChar(text[s])) s--;
-  while (e < text.length && e > 0 && isWordChar(text[e - 1]) && isWordChar(text[e])) e++;
-  return { start: s, end: e };
-};
-
 /**
- * Tidy a raw chunk for reading: PDF extraction leaves runs of spaces mid-
- * sentence and inline footnote markers ("[^56]"), and paragraphs arrive as
- * single newlines. Paragraph breaks are preserved for rendering.
+ * The chunk and spans to show for the sentence being hovered. A document's
+ * chunks are combined under one citation number, so the variants are searched
+ * too and whichever chunk supports this claim is the one displayed.
  */
-export const formatExcerpt = (text: string): string =>
-  text
-    .replace(/\[\^\d+\]/g, '')
-    .replace(/[ \t]{2,}/g, ' ')
-    .replace(/[ \t]+([.,;:!?])/g, '$1')
-    .split('\n')
-    .map((line) => line.trim())
-    .join('\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-
-/**
- * Locate each LLM-selected span inside the formatted excerpt. Offsets from the
- * matcher refer to the raw text, so the span is re-found by its text after
- * formatting — then snapped to whole words and merged where spans overlap.
- */
-export const locateMatchRanges = (
-  formatted: string,
-  snippets: string[],
-): Array<{ start: number; end: number }> => {
-  const haystack = formatted.toLowerCase();
-  const found: Array<{ start: number; end: number }> = [];
-  for (const raw of snippets) {
-    const needle = formatExcerpt(raw).toLowerCase().trim();
-    if (needle.length < 12) continue;
-    const at = haystack.indexOf(needle);
-    if (at < 0) continue;
-    found.push(snapToWordBounds(formatted, at, at + needle.length));
-  }
-  found.sort((a, b) => a.start - b.start);
-  const merged: Array<{ start: number; end: number }> = [];
-  for (const r of found) {
-    const last = merged[merged.length - 1];
-    if (last && r.start <= last.end) last.end = Math.max(last.end, r.end);
-    else merged.push({ ...r });
-  }
-  return merged;
-};
-
-// One paragraph of the excerpt with the claim-supporting spans marked.
-const ExcerptParagraph: React.FC<{
-  text: string;
-  ranges: Array<{ start: number; end: number }>;
-  offset: number;
-}> = ({ text, ranges, offset }) => {
-  const parts: React.ReactNode[] = [];
-  let cursor = 0;
-  ranges.forEach((r, i) => {
-    const start = r.start - offset;
-    const end = r.end - offset;
-    if (end <= 0 || start >= text.length) return;
-    const from = Math.max(0, start);
-    const to = Math.min(text.length, end);
-    if (from > cursor) parts.push(text.slice(cursor, from));
-    parts.push(
-      <mark key={`hl-${i}`} className="citation-hover-mark">
-        {text.slice(from, to)}
-      </mark>,
-    );
-    cursor = to;
-  });
-  if (cursor < text.length) parts.push(text.slice(cursor));
-  return <p className="citation-hover-para">{parts.length ? parts : text}</p>;
-};
-
-const renderCitationExcerpt = (
-  text: string,
-  semanticMatches?: Array<{ start: number; end: number; matchedText?: string }>,
-): React.ReactNode => {
-  const { section, body } = parseSectionBreadcrumb(text);
-  // The whole excerpt is shown, formatted for reading, with the span(s) the
-  // LLM picked out for the hovered claim highlighted in place.
-  const renderBody = (raw: string): React.ReactNode => {
-    const formatted = formatExcerpt(raw);
-    const snippets = (semanticMatches || [])
-      .map((m) => m.matchedText ?? raw.slice(m.start, m.end))
-      .filter(Boolean);
-    const ranges = snippets.length ? locateMatchRanges(formatted, snippets) : [];
-    if (!ranges.length) return parseAndRenderSuperscripts(formatted);
-    // Paragraphs are rendered separately, so each needs its offset into the
-    // formatted text to know which ranges fall inside it.
-    let offset = 0;
-    return formatted.split(/\n{2,}/).map((para, i) => {
-      const node = (
-        <ExcerptParagraph key={`p-${i}`} text={para} ranges={ranges} offset={offset} />
-      );
-      offset += para.length + 2;
-      return node;
-    });
-  };
-  if (!section) return renderBody(text);
-  return (
-    <>
-      <div className="citation-hover-section">{section}</div>
-      {body.trim() && <div>{renderBody(body)}</div>}
-    </>
-  );
-};
-
-/**
- * Highlight matches for the specific citing sentence being hovered. Falls back
- * to the source-level matches (older briefs) when per-claim data is absent —
- * but only if there is a single claim entry, since source-level matches for a
- * multiply-cited source mix claims and mislead.
- */
-const matchesForClaim = (
+const resolveForClaim = (
   source: SourceReference,
   claim: string | undefined,
-): Array<{ start: number; end: number; matchedText?: string }> | undefined => {
-  const entries = source.claimMatches;
-  if (entries?.length) {
-    if (claim) {
-      const key = normalizeClaimText(claim);
+): {
+  source: SourceReference;
+  matches?: Array<{ start: number; end: number; matchedText?: string }>;
+} => {
+  const candidates = [source, ...(source.variants || [])];
+  const key = claim ? normalizeClaimText(claim) : '';
+  if (key) {
+    for (const candidate of candidates) {
       // Enrichment splits sentences in the markdown, where a soft line-wrap
       // ends a "sentence"; the rendered text the card sees has those wraps
       // collapsed. Containment matches the two forms of the same sentence.
-      const hit =
-        entries.find((e) => e.claim === key) ||
-        entries.find(
-          (e) => e.claim.length > 24 && (key.includes(e.claim) || e.claim.includes(key)),
-        );
-      if (hit) return hit.matches;
+      const hit = (candidate.claimMatches || []).find(
+        (e) =>
+          e.claim === key ||
+          (e.claim.length > 24 && (key.includes(e.claim) || e.claim.includes(key))),
+      );
+      if (hit) return { source: candidate, matches: hit.matches };
     }
-    return entries.length === 1 ? entries[0].matches : undefined;
   }
-  return source.semanticMatches;
+  // A source cited once has no ambiguity about which claim its spans support.
+  const only = source.claimMatches?.length === 1 ? source.claimMatches[0].matches : undefined;
+  return { source, matches: only ?? source.semanticMatches };
 };
 
 const InlineCitation: React.FC<{
@@ -245,6 +131,11 @@ const InlineCitation: React.FC<{
     e.preventDefault();
     if (source && onClick) onClick(source);
   };
+
+  const shown = source ? resolveForClaim(source, claim) : null;
+  const { section: breadcrumb, body: excerptBody } = parseSectionBreadcrumb(
+    shown?.source.text || '',
+  );
 
   const show = () => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
@@ -272,7 +163,7 @@ const InlineCitation: React.FC<{
         {num}
       </a>
       {card &&
-        source &&
+        shown &&
         createPortal(
           <div
             className="citation-hover-card"
@@ -280,13 +171,14 @@ const InlineCitation: React.FC<{
             onMouseEnter={show}
             onMouseLeave={scheduleHide}
           >
-            <div className="citation-hover-title">{source.title || `Source ${num}`}</div>
-            {typeof source.page === 'number' && (
-              <div className="citation-hover-meta">Page {source.page}</div>
+            <div className="citation-hover-title">{shown.source.title || `Source ${num}`}</div>
+            {typeof shown.source.page === 'number' && (
+              <div className="citation-hover-meta">Page {shown.source.page}</div>
             )}
-            {source.text && (
+            {shown.source.text && (
               <div className="citation-hover-excerpt">
-                {renderCitationExcerpt(source.text, matchesForClaim(source, claim))}
+                {breadcrumb && <div className="citation-hover-section">{breadcrumb}</div>}
+                <CitationExcerpt text={excerptBody} claim={claim} matches={shown.matches} />
               </div>
             )}
           </div>,

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -3,7 +3,7 @@
 // references list grouped by document. Used by the Research Assistant
 // (ChatMessage) and the Brief tab so both render citations identically.
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -134,6 +134,9 @@ const InlineCitation: React.FC<{
   const [expanded, setExpanded] = useState(false);
   const [clipped, setClipped] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
+  // Whether this card's on-screen placement has been settled for this open.
+  const placedRef = useRef(false);
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -152,14 +155,17 @@ const InlineCitation: React.FC<{
     if (!shown?.matches?.length && onRequestHighlight) onRequestHighlight(source);
     const r = ref.current?.getBoundingClientRect();
     if (!r) return;
-    // Position below the badge, clamped so the card stays in the viewport.
+    // Provisional spot below the badge; the layout effect below flips it above
+    // once the real height is known and there is not room underneath.
     const CARD_W = 360;
+    placedRef.current = false;
     setCard({ top: r.bottom + 6, left: Math.min(r.left, window.innerWidth - CARD_W - 12) });
   };
   const scheduleHide = () => {
     hideTimer.current = setTimeout(() => {
       setCard(null);
       setExpanded(false);
+      placedRef.current = false;
     }, 120);
   };
 
@@ -170,6 +176,30 @@ const InlineCitation: React.FC<{
     if (!card || !el) return;
     setClipped(el.scrollHeight > el.clientHeight + 4);
   }, [card, excerptBody, expanded]);
+
+  // Highlight enrichment re-renders these badges constantly. If the pointer is
+  // already resting on one, no pointer event fires for the new node, so the
+  // card would only appear after the user moved (or clicked). Re-open it here.
+  useEffect(() => {
+    if (card || !ref.current) return;
+    if (ref.current.matches(':hover')) show();
+  });
+
+  // Keep the card on screen: flip above the citation when it would overflow
+  // the bottom. Runs once per open (placedRef), never in a setCard→effect→
+  // setCard loop, which froze the page.
+  useLayoutEffect(() => {
+    const el = cardRef.current;
+    const anchor = ref.current;
+    if (!card || !el || !anchor || placedRef.current) return;
+    placedRef.current = true;
+    const height = el.offsetHeight;
+    const a = anchor.getBoundingClientRect();
+    const room = window.innerHeight - a.bottom - 12;
+    if (height > room && a.top > room) {
+      setCard({ top: Math.max(8, a.top - height - 6), left: card.left });
+    }
+  }, [card]);
 
   return (
     <>
@@ -196,6 +226,7 @@ const InlineCitation: React.FC<{
         shown &&
         createPortal(
           <div
+            ref={cardRef}
             className="citation-hover-card"
             style={{ top: card.top, left: card.left }}
             onMouseEnter={show}

--- a/ui/frontend/src/tests/briefCitations.test.ts
+++ b/ui/frontend/src/tests/briefCitations.test.ts
@@ -49,24 +49,32 @@ describe('buildGlobalCitations', () => {
 
     const { refs, display } = buildGlobalCitations(sections);
 
-    // Three distinct documents → consecutive global numbers 1, 2, 3.
-    expect(refs.map((r) => r.n)).toEqual([1, 2, 3]);
-    expect(refs.map((r) => r.title)).toEqual(['Doc One', 'Doc Two', 'Doc Three']);
+    // One number per cited passage (as the AI summary numbers its sources), so
+    // Doc One's two pages are [1] and [4], not one combined number.
+    expect(refs.map((r) => r.n)).toEqual([1, 2, 3, 4]);
+    expect(refs.map((r) => r.title)).toEqual([
+      'Doc One',
+      'Doc Two',
+      'Doc Three',
+      'Doc One',
+    ]);
+    expect(refs.map((r) => r.page)).toEqual([5, 3, 1, 9]);
 
     // Section A keeps 1, 2.
     expect(display.get('a')?.content).toBe('Intro [1] and more [2].');
-    // Section B: local [7] → global [3] (new doc, consecutive); local [21] → [1]
-    // (same document as section A's [1], so combined to the same number).
-    expect(display.get('b')?.content).toBe('New finding [3] and a repeat of doc one [1].');
+    // Section B: local [7] → [3]; local [21] is a different passage of Doc One
+    // (p.9, not p.5) so it gets its own number rather than reusing [1].
+    expect(display.get('b')?.content).toBe('New finding [3] and a repeat of doc one [4].');
   });
 
-  test('combines multiple citations to the same document within a marker group', () => {
+  test('keeps separate numbers for different passages of one document', () => {
     const sections: BriefSection[] = [
       section({
         id: 'a',
         content: 'Claim [3, 4].',
         sources: [
-          // Both local indices point at the same document → one global number.
+          // Two passages of the same document, on different pages: each keeps
+          // its own number so the reader can tell which page backs the claim.
           src({ index: 3, docId: 'dX', title: 'Same Doc', page: 2 }),
           src({ index: 4, docId: 'dX', title: 'Same Doc', page: 8 }),
         ],
@@ -75,8 +83,27 @@ describe('buildGlobalCitations', () => {
 
     const { refs, display } = buildGlobalCitations(sections);
 
+    expect(refs).toHaveLength(2);
+    expect(refs.map((r) => r.page)).toEqual([2, 8]);
+    expect(display.get('a')?.content).toBe('Claim [1, 2].');
+  });
+
+  test('one number per passage, shared by chunks of the same page', () => {
+    const sections: BriefSection[] = [
+      section({
+        id: 'a',
+        content: 'Claim [1] and [2].',
+        sources: [
+          src({ index: 1, chunkId: 'same-chunk', docId: 'dY', title: 'Doc', page: 4 }),
+          src({ index: 2, chunkId: 'same-chunk', docId: 'dY', title: 'Doc', page: 4 }),
+        ],
+      }),
+    ];
+
+    const { refs, display } = buildGlobalCitations(sections);
+
     expect(refs).toHaveLength(1);
-    expect(display.get('a')?.content).toBe('Claim [1].');
+    expect(display.get('a')?.content).toBe('Claim [1] and [1].');
   });
 
   test('ignores sections that are not done', () => {

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -154,6 +154,46 @@ describe('snapToWordBounds', () => {
   });
 });
 
+describe('excerpt formatting and highlight location', () => {
+  const { formatExcerpt, locateMatchRanges } = jest.requireActual(
+    '../components/citations/CitedContent',
+  );
+  const RAW =
+    '211. WFP has launched a new  country  strategy for the period 2018 -2023 [^56] .\n\n' +
+    '212. The launching of  Kenya\'s first School Feeding strategy in 2018 .';
+
+  it('drops footnote markers and PDF double-spacing but keeps paragraphs', () => {
+    const out = formatExcerpt(RAW);
+    expect(out).toContain('a new country strategy');
+    expect(out).not.toContain('[^56]');
+    expect(out).not.toMatch(/ {2,}/);
+    expect(out).toContain('2018 -2023.');
+    expect(out.split(/\n{2,}/)).toHaveLength(2);
+  });
+
+  it('locates a snippet in the formatted text despite raw-text spacing', () => {
+    const formatted = formatExcerpt(RAW);
+    const ranges = locateMatchRanges(formatted, ['a new  country  strategy for the period']);
+    expect(ranges).toHaveLength(1);
+    expect(formatted.slice(ranges[0].start, ranges[0].end)).toContain(
+      'a new country strategy for the period',
+    );
+  });
+
+  it('merges overlapping spans and ignores ones that are not present', () => {
+    const formatted = formatExcerpt(RAW);
+    const ranges = locateMatchRanges(formatted, [
+      'WFP has launched a new country',
+      'launched a new country strategy',
+      'text that does not appear anywhere',
+    ]);
+    expect(ranges).toHaveLength(1);
+    expect(formatted.slice(ranges[0].start, ranges[0].end)).toBe(
+      'WFP has launched a new country strategy',
+    );
+  });
+});
+
 describe('claim selection in the hover card (matchesForClaim via normalize/sentence)', () => {
   const { normalizeClaimText, sentenceAround } = jest.requireActual(
     '../components/citations/CitedContent',

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -55,12 +55,16 @@ describe('highlightSectionSources', () => {
   beforeEach(() => mockFindSemanticMatches.mockReset());
 
   it('attaches per-claim matches for cited sources; failures keep plain excerpts', async () => {
-    // Source 1 is cited from two sentences → two claim entries.
-    mockFindSemanticMatches
-      .mockResolvedValueOnce([LONG_MATCH])
-      .mockResolvedValueOnce([{ ...LONG_MATCH, start: 5, end: 45 }])
-      .mockRejectedValueOnce(new Error('LLM down'))
-      .mockResolvedValue([]);
+    // Keyed by claim, not call order: sources are highlighted concurrently, so
+    // a fixed mock sequence would be consumed in a non-deterministic order.
+    mockFindSemanticMatches.mockImplementation((_body: string, claim: string) => {
+      if (claim.includes('cash transfers improved')) return Promise.resolve([LONG_MATCH]);
+      if (claim.includes('cost efficiency favoured')) {
+        return Promise.resolve([{ ...LONG_MATCH, start: 5, end: 45 }]);
+      }
+      if (claim.includes('dietary diversity')) return Promise.reject(new Error('LLM down'));
+      return Promise.resolve([]);
+    });
     const out = await highlightSectionSources({
       content: CONTENT,
       sources: [source(1), source(2), source(3)],

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -126,38 +126,8 @@ describe('highlightSectionSources', () => {
   });
 });
 
-describe('snapToWordBounds', () => {
-  const { snapToWordBounds } = jest.requireActual('../components/citations/CitedContent');
-  const text = 'The Kenya Certificate of Secondary Education results.';
-
-  it('expands a mid-word start back to the word start', () => {
-    const start = text.indexOf('tificate');
-    const out = snapToWordBounds(text, start, text.indexOf('Education') + 9);
-    expect(text.substring(out.start, out.end)).toBe('Certificate of Secondary Education');
-  });
-
-  it('expands a mid-word end forward to the word end', () => {
-    const out = snapToWordBounds(text, text.indexOf('Kenya'), text.indexOf('Cert') + 4);
-    expect(text.substring(out.start, out.end)).toBe('Kenya Certificate');
-  });
-
-  it('leaves boundaries already on word edges untouched', () => {
-    const s = text.indexOf('Kenya');
-    const out = snapToWordBounds(text, s, s + 'Kenya'.length);
-    expect(out).toEqual({ start: s, end: s + 5 });
-  });
-
-  it('clamps out-of-range offsets', () => {
-    const out = snapToWordBounds(text, -5, text.length + 10);
-    expect(out.start).toBe(0);
-    expect(out.end).toBe(text.length);
-  });
-});
-
 describe('excerpt formatting and highlight location', () => {
-  const { formatExcerpt, locateMatchRanges } = jest.requireActual(
-    '../components/citations/CitedContent',
-  );
+  const { formatExcerpt } = jest.requireActual('../components/citations/CitationExcerpt');
   const RAW =
     '211. WFP has launched a new  country  strategy for the period 2018 -2023 [^56] .\n\n' +
     '212. The launching of  Kenya\'s first School Feeding strategy in 2018 .';
@@ -171,27 +141,6 @@ describe('excerpt formatting and highlight location', () => {
     expect(out.split(/\n{2,}/)).toHaveLength(2);
   });
 
-  it('locates a snippet in the formatted text despite raw-text spacing', () => {
-    const formatted = formatExcerpt(RAW);
-    const ranges = locateMatchRanges(formatted, ['a new  country  strategy for the period']);
-    expect(ranges).toHaveLength(1);
-    expect(formatted.slice(ranges[0].start, ranges[0].end)).toContain(
-      'a new country strategy for the period',
-    );
-  });
-
-  it('merges overlapping spans and ignores ones that are not present', () => {
-    const formatted = formatExcerpt(RAW);
-    const ranges = locateMatchRanges(formatted, [
-      'WFP has launched a new country',
-      'launched a new country strategy',
-      'text that does not appear anywhere',
-    ]);
-    expect(ranges).toHaveLength(1);
-    expect(formatted.slice(ranges[0].start, ranges[0].end)).toBe(
-      'WFP has launched a new country strategy',
-    );
-  });
 });
 
 describe('claim selection in the hover card (matchesForClaim via normalize/sentence)', () => {

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -76,7 +76,10 @@ describe('highlightSectionSources', () => {
     // An empty list records "attempted, nothing matched" so a resumed run
     // does not retry these; only never-attempted sources are picked up.
     expect(out[1].claimMatches).toEqual([]);
-    expect(out[2].claimMatches).toEqual([]);
+    // Source 3 is cited from two sentences: the 'dietary diversity' one fails,
+    // but claims are highlighted independently, so the other still lands.
+    expect(out[2].claimMatches).toHaveLength(1);
+    expect(out[2].claimMatches?.[0].claim).toContain('cost efficiency');
   });
 
   it('drops fragment matches below the minimum length', async () => {

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -69,8 +69,10 @@ describe('highlightSectionSources', () => {
     expect(out[0].claimMatches).toHaveLength(2);
     expect(out[0].claimMatches?.[0].claim).toContain('cash transfers improved');
     expect(out[0].claimMatches?.[0].matches).toEqual([LONG_MATCH]);
-    expect(out[1].claimMatches).toBeUndefined();
-    expect(out[2].claimMatches).toBeUndefined();
+    // An empty list records "attempted, nothing matched" so a resumed run
+    // does not retry these; only never-attempted sources are picked up.
+    expect(out[1].claimMatches).toEqual([]);
+    expect(out[2].claimMatches).toEqual([]);
   });
 
   it('drops fragment matches below the minimum length', async () => {
@@ -80,7 +82,7 @@ describe('highlightSectionSources', () => {
       sources: [source(2)],
       threshold: 0.6,
     });
-    expect(out[0].claimMatches).toBeUndefined();
+    expect(out[0].claimMatches).toEqual([]);
   });
 
   it('skips uncited sources and ones already highlighted', async () => {
@@ -132,13 +134,17 @@ describe('excerpt formatting and highlight location', () => {
     '211. WFP has launched a new  country  strategy for the period 2018 -2023 [^56] .\n\n' +
     '212. The launching of  Kenya\'s first School Feeding strategy in 2018 .';
 
-  it('drops footnote markers and PDF double-spacing but keeps paragraphs', () => {
+  it('collapses PDF double-spacing and keeps paragraphs', () => {
     const out = formatExcerpt(RAW);
     expect(out).toContain('a new country strategy');
-    expect(out).not.toContain('[^56]');
     expect(out).not.toMatch(/ {2,}/);
-    expect(out).toContain('2018 -2023.');
     expect(out.split(/\n{2,}/)).toHaveLength(2);
+  });
+
+  it('keeps footnote markers so they render as superscripts, as Search does', () => {
+    const out = formatExcerpt(RAW);
+    expect(out).toContain('[^56]');
+    expect(out).toContain('2018 -2023 [^56].');
   });
 
 });
@@ -160,5 +166,24 @@ describe('claim selection in the hover card (matchesForClaim via normalize/sente
   it('sentenceAround isolates the sentence containing the marker position', () => {
     const text = 'First sentence here. Second one cites [3]. Third sentence.';
     expect(sentenceAround(text, text.indexOf('[3]'))).toBe('Second one cites [3].');
+  });
+});
+
+describe('resuming an interrupted enrichment', () => {
+  beforeEach(() => mockFindSemanticMatches.mockReset());
+
+  it('retries sources never attempted but leaves attempted ones alone', async () => {
+    mockFindSemanticMatches.mockResolvedValue([LONG_MATCH]);
+    const attempted = { ...source(1), claimMatches: [] };
+    const neverTried = source(2);
+    const out = await highlightSectionSources({
+      content: CONTENT,
+      sources: [attempted, neverTried],
+      threshold: 0.6,
+    });
+    // Only the never-attempted source is sent to the highlighter.
+    expect(mockFindSemanticMatches).toHaveBeenCalledTimes(1);
+    expect(out[0].claimMatches).toEqual([]);
+    expect(out[1].claimMatches).toHaveLength(1);
   });
 });

--- a/ui/frontend/src/tests/citationBreadcrumb.test.ts
+++ b/ui/frontend/src/tests/citationBreadcrumb.test.ts
@@ -21,9 +21,11 @@ describe('parseSectionBreadcrumb', () => {
     expect(body).toBe('Just an ordinary excerpt with no heading line.');
   });
 
-  test('a "-- … --" line without a " > " separator is not treated as a breadcrumb', () => {
-    const text = '-- not a path --\nbody';
-    const { section } = parseSectionBreadcrumb(text);
-    expect(section).toBeNull();
+  test('a single-heading "-- … --" line is a breadcrumb too, not body text', () => {
+    // Chunks from a document with flat headings carry one heading rather than
+    // a path; showing it as the section keeps the "--" markers out of the body.
+    const { section, body } = parseSectionBreadcrumb('-- Summary EQ 1 --\nbody');
+    expect(section).toBe('Summary EQ 1');
+    expect(body).toBe('body');
   });
 });

--- a/ui/frontend/src/tests/citationHoverCard.test.tsx
+++ b/ui/frontend/src/tests/citationHoverCard.test.tsx
@@ -14,6 +14,19 @@ const source: SourceReference = {
   headings: [],
 };
 
+const claimSource: SourceReference = {
+  ...source,
+  text: 'The GoK  commitment to  education is articulated in the Constitution [^56] .',
+  claimMatches: [
+    {
+      claim: 'a key finding',
+      matches: [
+        { start: 0, end: 31, matchedText: 'The GoK commitment to education' },
+      ],
+    },
+  ],
+};
+
 describe('inline citation hover card', () => {
   test('renders the excerpt with the same formatter Search uses', () => {
     const { container } = render(<CitedMarkdown content="A key finding [1]." sources={[source]} />);
@@ -31,5 +44,20 @@ describe('inline citation hover card', () => {
     const excerpt = document.querySelector('.citation-hover-excerpt');
     expect(excerpt).not.toBeNull();
     expect(excerpt!.querySelector('.formatted-text-block')).not.toBeNull();
+  });
+
+  test('marks the span supporting the hovered claim and tidies the chunk', () => {
+    const { container } = render(
+      <CitedMarkdown content="A key finding [1]." sources={[claimSource]} />,
+    );
+    fireEvent.mouseEnter(container.querySelector('.ai-summary-citation') as HTMLElement);
+
+    const excerpt = document.querySelector('.citation-hover-excerpt') as HTMLElement;
+    const mark = excerpt.querySelector('mark');
+    expect(mark).not.toBeNull();
+    expect(mark!.textContent).toContain('commitment to education');
+    // Footnote markers and PDF double-spacing are cleaned up for reading.
+    expect(excerpt.textContent).not.toContain('[^56]');
+    expect(excerpt.textContent).not.toMatch(/ {2,}/);
   });
 });

--- a/ui/frontend/src/types/api.ts
+++ b/ui/frontend/src/types/api.ts
@@ -173,6 +173,10 @@ export interface SourceReference {
     claim: string;
     matches: Array<{ start: number; end: number; matchedText?: string }>;
   }>;
+  // Other chunks of the same document cited in the same section. Display
+  // combines a document's chunks under one number, so the hover card looks
+  // across these to show the chunk that actually supports the hovered claim.
+  variants?: SourceReference[];
 }
 
 export interface AgentState {

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -999,13 +999,10 @@ const buildReferenceList = (
       rows.push({ label: nums.join(', '), title: titleOf(result), result }),
     );
   } else {
-    results.forEach((r, idx) =>
-      rows.push({
-        label: String(idx + 1),
-        title: `${titleOf(r)}${r.page_num ? `, p.${r.page_num}` : ''}`,
-        result: r,
-      }),
-    );
+    results.forEach((r, idx) => {
+      const page = r.page_num ? `, p.${r.page_num}` : '';
+      rows.push({ label: String(idx + 1), title: `${titleOf(r)}${page}`, result: r });
+    });
   }
 
   const out: Paragraph[] = [

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -63,6 +63,10 @@ export interface ExportOptions {
   /** Heading for the per-result excerpts section (default "Search Results").
    *  The Brief export passes "Reference Excerpts". */
   resultsSectionTitle?: string;
+  // Render a compact references list (no excerpts) instead of full result
+  // cards, mirroring the Brief's on-screen References section. 'grouped'
+  // collapses to one row per document.
+  referenceList?: 'flat' | 'grouped';
   /** Cover-page document title (default "Evidence Lab — Search Export").
    *  The Brief export passes "AI-generated Research Brief". */
   documentTitle?: string;
@@ -965,6 +969,69 @@ const buildResultCard = (
   return out;
 };
 
+/**
+ * A compact references list: one line per citation (flat) or per document
+ * (grouped), title hyperlinked to the source, no excerpt text. Mirrors what
+ * the Brief shows on screen so the export matches the reader's view.
+ */
+const buildReferenceList = (
+  results: SearchResult[],
+  siteOrigin: string,
+  dataSource: string | undefined,
+  grouped: boolean,
+  sectionTitle = 'References',
+): Paragraph[] => {
+  const titleOf = (r: SearchResult): string =>
+    (r.title && r.title.trim()) ||
+    (typeof r.document_title === 'string' && r.document_title.trim()) ||
+    '(untitled document)';
+
+  const rows: Array<{ label: string; title: string; result: SearchResult }> = [];
+  if (grouped) {
+    const byDoc = new Map<string, { nums: number[]; result: SearchResult }>();
+    results.forEach((r, idx) => {
+      const key = r.doc_id || titleOf(r);
+      const found = byDoc.get(key);
+      if (found) found.nums.push(idx + 1);
+      else byDoc.set(key, { nums: [idx + 1], result: r });
+    });
+    byDoc.forEach(({ nums, result }) =>
+      rows.push({ label: nums.join(', '), title: titleOf(result), result }),
+    );
+  } else {
+    results.forEach((r, idx) =>
+      rows.push({
+        label: String(idx + 1),
+        title: `${titleOf(r)}${r.page_num ? `, p.${r.page_num}` : ''}`,
+        result: r,
+      }),
+    );
+  }
+
+  const out: Paragraph[] = [
+    new Paragraph({
+      heading: HeadingLevel.HEADING_1,
+      children: [new TextRun({ text: sectionTitle })],
+      spacing: { before: 360, after: 120 },
+    }),
+  ];
+  rows.forEach(({ label, title, result }) => {
+    out.push(
+      new Paragraph({
+        spacing: { after: 60 },
+        children: [
+          new TextRun({ text: `${label}. `, bold: true }),
+          new ExternalHyperlink({
+            link: resolveResultLink(result, siteOrigin, dataSource),
+            children: [new TextRun({ text: title, style: 'Hyperlink' })],
+          }),
+        ],
+      }),
+    );
+  });
+  return out;
+};
+
 const buildResultsSection = (
   results: SearchResult[],
   siteOrigin: string,
@@ -1018,13 +1085,21 @@ export const buildExportDocument = (
       opts.tableOfContents ? tocBookmarkPrefix : undefined,
       footnotes,
     ),
-    ...buildResultsSection(
-      opts.results,
-      siteOrigin,
-      opts.dataSource,
-      opts.resultsSectionTitle,
-      images,
-    ),
+    ...(opts.referenceList
+      ? buildReferenceList(
+          opts.results,
+          siteOrigin,
+          opts.dataSource,
+          opts.referenceList === 'grouped',
+          opts.resultsSectionTitle,
+        )
+      : buildResultsSection(
+          opts.results,
+          siteOrigin,
+          opts.dataSource,
+          opts.resultsSectionTitle,
+          images,
+        )),
   ];
 
   return new Document({


### PR DESCRIPTION
## Summary

Follow-on work to Brief Central (#422, #423), covering per-section research instructions and making LLM citation highlights actually visible to the reader.

### Research instructions
- **Per-section instructions.** Guidance lived in a single shared field tied to whichever panel was open, so notes written for one section overwrote another's and a document-wide run ignored them. Guidance now lives on the section (`BriefSection.guidance`), saves with the brief, and `startResearch` passes each section its own.
- **Inline Research panel** for an un-researched section, instead of a `Research this section` button, so instructions can be written across several sections and then run with **AI Regenerate All**. Sample placeholder headings keep the (disabled) button until edited.
- **Regenerate All asks first** — it re-researches every section, so it now opens a confirmation with optional instructions, a voice & tone profile, and an *Apply this profile to every section* toggle.

### Citation highlights
The highlighting pipeline worked but was effectively invisible, and several defects hid it entirely:

- **Never started.** The backfill ran before the model combo was applied, sending `model=null` — 128 failures on a single page load — and cleared its resume flag before bailing, so it never retried. It now waits for the model and retries on the render that delivers it.
- **Killed mid-run.** The backfill and the research-triggered pass shared one token map; the backfill overwrote the token of an in-flight pass, which then judged itself stale and stopped. Sections researched during a backfill ended up with no highlights at all.
- **Too slow to see.** One excerpt at a time at ~12s per call meant ~10 minutes for a heavily-cited section. Now 6 run concurrently, published in batches of 3.
- **Wrong order.** The backfill walked sections in document order, so the section just researched was enriched last. Now ordered by most recently researched.
- **Hover on demand.** Hovering a citation with no highlight requests one for that source; the card shows *Finding the supporting passage…* and updates in place.
- **Multi-tab starvation.** Every open tab ran the same backfill, saturating the browser's per-origin connections and leaving `bundle.js` hanging (blank page). The backfill now runs only in the visible tab and resumes on `visibilitychange`.

### Presentation
- Footnote markers (`[^56]`) render as superscripts, matching search results, instead of being stripped
- Assistant source excerpts and titles get Search's `clean_text()` repair, so tooltips read like results
- Restored the excerpt's smaller text size (regressed by an earlier CSS edit)
- `/brief/<id>` URLs survive tab navigation

## Testing

- 100 brief/citation unit tests pass; TypeScript clean; complexity gate satisfied
- Verified in the running dev stack: per-section instructions reach the wire (the second section's request carried its own `Focus for this section: …`); enrichment confirmed running and persisting against Postgres
- **Not verified by me:** the hover-to-highlight interaction end-to-end in a real foreground browser — my automation pane reports itself hidden (which suppresses the backfill by design) and became unresponsive during the final check. Worth a manual pass before merge: regenerate a section, hover a citation immediately, and confirm the pending indicator resolves to a highlight within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)