### PR TITLE
fix(build): pin docx to 9.6.1 so the production build compiles

### DIFF
--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "ajv": "^8.20.0",
         "ajv-keywords": "^5.1.0",
         "axios": "^1.19.0",
-        "docx": "9.7.1",
+        "docx": "9.6.1",
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
         "pdfjs-dist": "^3.11.174",
@@ -8275,9 +8275,9 @@
       }
     },
     "node_modules/docx": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
-      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -9,7 +9,7 @@
     "ajv": "^8.20.0",
     "ajv-keywords": "^5.1.0",
     "axios": "^1.19.0",
-    "docx": "9.7.1",
+    "docx": "9.6.1",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
     "pdfjs-dist": "^3.11.174",


### PR DESCRIPTION
## Problem

The production image fails to build:

```
SyntaxError: /app/node_modules/docx/dist/index.mjs: When using
'@babel/plugin-transform-parameters', it's not possible to compile `super()`
in an arrow function with default or rest parameters without compiling classes.
Please add '@babel/plugin-transform-classes' to your Babel configuration.
```

docx 9.7.1 (from #429) ships an ESM bundle whose `ImageRun` constructor calls `super()` inside an arrow function with rest parameters. `react-scripts` transpiles `node_modules` with `babel-preset-react-app/dependencies`, which applies `@babel/plugin-transform-parameters` without `transform-classes` — and that combination is a hard error rather than a warning.

## Fix

Pin `docx` back to **9.6.1** and update the lockfile.

## How this was verified

Ran the `Dockerfile.prod` builder stage directly (`npm ci --legacy-peer-deps` + `npm run build` on `node:18-alpine`, with `config.json` staged as the Dockerfile does):

| | |
|---|---|
| `rc/v1.6.1` (docx 9.7.1) | **fails** with the SyntaxError above |
| this branch (docx 9.6.1) | **compiles** — "The build folder is ready to be deployed" |

## Why CI missed it

Nothing in the pipeline builds the production frontend:
- `ui-tests` runs Jest, which resolves docx's CommonJS entry, so the ESM bundle is never transpiled
- `container-scan` does not build `Dockerfile.prod`

Only a real production build resolves `dist/index.mjs`. **Recommend adding a prod-build job** so a dependency bump cannot break the release image unnoticed — happy to do that in a follow-up.

## Note on upgrading later

Moving to 9.7.x will need one of: a webpack alias to docx's CJS build (via craco/react-app-rewired), a browserslist target modern enough that babel skips the parameters transform, or an upstream fix. Dependabot will re-propose the bump, so this pin should be revisited deliberately rather than auto-merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)