### PR TITLE
feat(toc-validator): show human approval and source the included-section list from config

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,7 +24,16 @@
       "highlight_threshold": 0.6,
       "page_size": 50,
       "rerank_model": "jinaai/jina-reranker-v2-base-multilingual",
-      "default_dense_model": "e5_large"
+      "default_dense_model": "e5_large",
+      "default_included_section_types": [
+        "executive_summary",
+        "context",
+        "methodology",
+        "findings",
+        "conclusions",
+        "recommendations",
+        "other"
+      ]
     }
   },
   "supported_embedding_models": {

--- a/docs/admin/toc-validator.md
+++ b/docs/admin/toc-validator.md
@@ -15,6 +15,14 @@ executive_summary, context, methodology, findings, conclusions, recommendations,
 Every other section type — `front_matter`, `acronyms`, `annexes`, `appendix`,
 `bibliography`, `introduction` — is **excluded by default**.
 
+This default-included list is **not hardcoded in the validator**. It is read from
+`application.search.default_included_section_types` in `config.json` — the *same*
+list Search uses — so the two can never drift. Changing that one config value
+re-points both Search's default and the validator (rebuild the frontend for the
+Search side, since `config.json` is baked into the build). If, for example, you
+decide `introduction` should count as body content, add it there and the
+validator stops flagging it everywhere at once.
+
 Section tagging is automatic (done at upload by the TOC classifier). If a section
 that is really part of the report body is mis-tagged as, say, `annexes`, that content
 silently disappears from default search results. Users never see it and never know
@@ -78,7 +86,9 @@ Two patterns are worth separating:
 * **`introduction` flagged across most documents.** This is systemic, not per-document
   mis-tagging: the body range starts at the introduction, and `introduction` is not in
   the default-included set (nor is it offered as a filter option in Search settings).
-  The fix is a decision about the defaults, not about individual documents.
+  The fix is a decision about the defaults, not about individual documents — add
+  `introduction` to `application.search.default_included_section_types` in `config.json`
+  and both Search and the validator will treat it as included.
 * **`annexes` / `acronyms` / `bibliography` / `front_matter` inside the body range.**
   These are genuine mis-tags worth investigating per document — for example a report
   whose *Findings* and *Recommendations* chapters were labelled `annexes` because their
@@ -88,6 +98,24 @@ Two patterns are worth separating:
 
 From a flagged row, open **Contents**, correct the section type, and save. Editing the
 classification automatically re-validates that document so the verdict updates.
+
+## Human approval
+
+A reviewer can mark a document's section tagging as **Approved** — a human sign-off that
+the classification has been checked. Approval is set from the **Contents** modal (its
+**Approved** checkbox), reachable both from the Documents Library and from the TOC
+Validator's own **Contents** link.
+
+Approved documents are called out in the review column with a green **✓ Human-approved**
+badge, and the row is tinted. The badge shows independently of the automated verdict: an
+approved document may still read **Fail** (for example a document dominated by a correctly
+tagged `introduction`) or **Not tested** — approval records human judgement, not the
+result of the check. This lets an admin tell at a glance which flagged rows have already
+been reviewed and accepted from those that still need attention.
+
+Approval is a live property of the document (stored as `sys_toc_approved`), read fresh
+from the document list — it is **not** frozen into the stored validation snapshot, so it
+stays current even between validation runs.
 
 ## Where results are stored
 

--- a/pipeline/db/config.py
+++ b/pipeline/db/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from dotenv import load_dotenv
 from qdrant_client.http.models import Distance
@@ -322,6 +322,23 @@ def get_application_config() -> Dict[str, Any]:
     """Get application config from datasources config."""
     config = load_datasources_config()
     return config.get("application", {})
+
+
+def get_default_included_section_types() -> List[str]:
+    """Return the section types Search includes by default (config-driven).
+
+    Reads ``application.search.default_included_section_types`` from config.json
+    so Search and the admin TOC Validator share one definition and cannot drift.
+    Falls back to ``section_inclusion.DEFAULT_INCLUDED_SECTION_TYPES`` only when
+    the key is absent. Labels are normalised to lowercase to match stored tags.
+    """
+    from pipeline.validation.section_inclusion import DEFAULT_INCLUDED_SECTION_TYPES
+
+    search_config = get_application_config().get("search") or {}
+    configured = search_config.get("default_included_section_types")
+    if isinstance(configured, list) and configured:
+        return [str(item).strip().lower() for item in configured if str(item).strip()]
+    return list(DEFAULT_INCLUDED_SECTION_TYPES)
 
 
 VALID_METRICS = {

--- a/pipeline/db/postgres_client_docs.py
+++ b/pipeline/db/postgres_client_docs.py
@@ -1069,10 +1069,12 @@ class PostgresDocMixin:
 
                     sys_toc = None
                     sys_toc_classified = None
+                    sys_toc_approved = None
                     sys_filepath = None
                     if isinstance(sys_data, dict):
                         sys_toc = sys_data.get("sys_toc")
                         sys_toc_classified = sys_data.get("sys_toc_classified")
+                        sys_toc_approved = sys_data.get("sys_toc_approved")
                         sys_filepath = sys_data.get("sys_filepath")
 
                     documents.append(
@@ -1095,6 +1097,7 @@ class PostgresDocMixin:
                             "sys_error_message": sys_error_message,
                             "sys_toc": sys_toc,
                             "sys_toc_classified": sys_toc_classified,
+                            "sys_toc_approved": sys_toc_approved,
                             "sys_filepath": sys_filepath,
                             "map_title": map_title,
                             "map_organization": map_organization,

--- a/pipeline/validation/section_inclusion.py
+++ b/pipeline/validation/section_inclusion.py
@@ -20,8 +20,13 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-# Mirrors DEFAULT_SECTION_TYPES in ui/frontend/src/utils/searchUrl.ts — the
-# section types that Search includes by default. Everything else is excluded.
+# Fallback default for the section types Search includes by default (everything
+# else is excluded). The authoritative source is
+# ``config.application.search.default_included_section_types`` in config.json —
+# the same list Search uses (ui/frontend/src/utils/searchUrl.ts reads it too).
+# The backend TOC-validator service resolves that config value and passes it in
+# as ``included``; this tuple is only used when no list is supplied (the offline
+# script and unit tests), so the two stay in sync via config, never by hand.
 DEFAULT_INCLUDED_SECTION_TYPES: Tuple[str, ...] = (
     "executive_summary",
     "context",

--- a/tests/evaluation/section_inclusion/check_included_section_types.py
+++ b/tests/evaluation/section_inclusion/check_included_section_types.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(PROJECT_ROOT))  # noqa: E402
 
+from pipeline.db.config import get_default_included_section_types  # noqa: E402
 from pipeline.validation.section_inclusion import (  # noqa: E402
     describe_excluded_sections,
     evaluate_document,
@@ -92,9 +93,11 @@ def select_documents(
     return eligible[:limit] if limit else eligible
 
 
-def build_report_row(doc: Dict[str, Any], data_source: str) -> Dict[str, Any]:
+def build_report_row(
+    doc: Dict[str, Any], data_source: str, included: List[str]
+) -> Dict[str, Any]:
     """Evaluate one doc and flatten the result into a report row."""
-    result = evaluate_document(doc)
+    result = evaluate_document(doc, included=included)
     return {
         "doc_id": str(doc.get("id")),
         "title": get_document_title(doc),
@@ -178,9 +181,10 @@ def main() -> None:
 
     counts = {"pass": 0, "fail": 0, "skipped": 0}
     excluded_tally: Dict[str, int] = {}
+    included = get_default_included_section_types()
 
     for doc in select_documents(pg.fetch_all_docs(), args.records, args.file_id):
-        row = build_report_row(doc, args.data_source)
+        row = build_report_row(doc, args.data_source, included)
         counts[row["status"]] += 1
         _tally_excluded(row, excluded_tally)
         ws.append([row[key] for key in REPORT_HEADERS])

--- a/tests/unit/test_check_included_section_types.py
+++ b/tests/unit/test_check_included_section_types.py
@@ -30,6 +30,18 @@ INTRO_FIELD = (
     "Introduction - before beginning of Annexes (start_page_number, end_page_number)"
 )
 
+# The default-included set the script now receives from config (see
+# pipeline.db.config.get_default_included_section_types).
+INCLUDED = [
+    "executive_summary",
+    "context",
+    "methodology",
+    "findings",
+    "conclusions",
+    "recommendations",
+    "other",
+]
+
 
 class TestSelectDocuments:
     def _docs(self):
@@ -68,7 +80,7 @@ class TestBuildReportRow:
 
     def test_build_report_row_when_body_annex_then_fail_row(self):
         toc = "[H1] Intro | context | page 13\n[H1] Misfiled | annexes | page 40\n"
-        row = mod.build_report_row(self._doc(toc, "(13, 67)"), "wfp")
+        row = mod.build_report_row(self._doc(toc, "(13, 67)"), "wfp", INCLUDED)
         assert row["status"] == "fail"
         assert row["doc_id"] == "doc-1"
         assert row["title"] == "Test Doc"
@@ -79,13 +91,13 @@ class TestBuildReportRow:
 
     def test_build_report_row_has_all_report_headers(self):
         row = mod.build_report_row(
-            self._doc("[H1] F | findings | page 30", "(13, 67)"), "wfp"
+            self._doc("[H1] F | findings | page 30", "(13, 67)"), "wfp", INCLUDED
         )
         assert set(row.keys()) == set(mod.REPORT_HEADERS)
 
     def test_build_report_row_when_no_range_then_skipped(self):
         row = mod.build_report_row(
-            self._doc("[H1] F | findings | page 30", None), "wfp"
+            self._doc("[H1] F | findings | page 30", None), "wfp", INCLUDED
         )
         assert row["status"] == "skipped"
         assert "missing_metadata_range" in row["reasons"]

--- a/tests/unit/test_included_section_types_config.py
+++ b/tests/unit/test_included_section_types_config.py
@@ -1,0 +1,44 @@
+"""The default-included section types come from config.json, shared with Search.
+
+``get_default_included_section_types`` is the single resolver both the admin TOC
+Validator service and the offline bulk script use, so their notion of "included"
+tracks Search's ``config.application.search.default_included_section_types`` and
+cannot drift from it.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from pipeline.db import config as cfg
+from pipeline.validation.section_inclusion import DEFAULT_INCLUDED_SECTION_TYPES
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetDefaultIncludedSectionTypes:
+    def test_reads_and_normalizes_configured_list(self):
+        app_cfg = {
+            "search": {"default_included_section_types": [" Findings ", "CONTEXT"]}
+        }
+        with patch.object(cfg, "get_application_config", return_value=app_cfg):
+            assert cfg.get_default_included_section_types() == ["findings", "context"]
+
+    def test_falls_back_when_key_absent(self):
+        with patch.object(cfg, "get_application_config", return_value={"search": {}}):
+            assert cfg.get_default_included_section_types() == list(
+                DEFAULT_INCLUDED_SECTION_TYPES
+            )
+
+    def test_falls_back_when_list_empty(self):
+        app_cfg = {"search": {"default_included_section_types": []}}
+        with patch.object(cfg, "get_application_config", return_value=app_cfg):
+            assert cfg.get_default_included_section_types() == list(
+                DEFAULT_INCLUDED_SECTION_TYPES
+            )
+
+    def test_falls_back_when_no_search_section(self):
+        with patch.object(cfg, "get_application_config", return_value={}):
+            assert cfg.get_default_included_section_types() == list(
+                DEFAULT_INCLUDED_SECTION_TYPES
+            )

--- a/tests/unit/test_paginated_documents_toc_approved.py
+++ b/tests/unit/test_paginated_documents_toc_approved.py
@@ -1,0 +1,101 @@
+"""The paginated documents payload must surface the human-approval flag.
+
+The TOC Validator (and the Documents Library approval checkbox) read
+``toc_approved`` off each listed document. That field is derived from
+``sys_data['sys_toc_approved']`` by ``_get_paginated_documents_impl`` and then
+normalised to ``toc_approved`` by ``normalize_document_payload``. These tests
+guard that contract so the approval indicator cannot silently regress.
+"""
+
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipeline.db.postgres_client_docs import PostgresDocMixin
+from ui.backend.utils.document_utils import normalize_document_payload
+
+
+@pytest.fixture()
+def client():
+    """A PostgresDocMixin whose DB connection is fully mocked."""
+    with patch.object(PostgresDocMixin, "__init__", lambda self: None):
+        c = PostgresDocMixin.__new__(PostgresDocMixin)
+        c.docs_table = "docs_test"
+        c.data_source = "test"
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = (1,)  # count query
+        mock_cursor.fetchall.return_value = []
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        c._get_conn = MagicMock(return_value=mock_conn)
+        c._mock_cursor = mock_cursor
+        return c
+
+
+def _row(sys_data: Optional[Dict[str, Any]]) -> tuple:
+    """Build one result row in the exact column order the impl SELECTs."""
+    return (
+        "d1",  # doc_id
+        {},  # src_doc_raw_metadata
+        None,  # sys_summary
+        None,  # sys_full_summary
+        None,  # sys_taxonomies
+        "indexed",  # sys_status
+        None,  # sys_status_timestamp
+        sys_data,  # sys_data
+        None,  # sys_file_format
+        None,  # sys_file_size_mb
+        None,  # sys_page_count
+        None,  # sys_language
+        None,  # sys_stages
+        None,  # sys_last_updated
+        None,  # sys_error_message
+        "Doc",  # map_title
+        None,  # map_organization
+        None,  # map_published_year
+        None,  # map_document_type
+        None,  # map_country
+        None,  # map_language
+        None,  # map_region
+        None,  # map_theme
+        None,  # map_pdf_url
+        None,  # map_report_url
+        None,  # sys_ocr_applied
+    )
+
+
+def _first_doc(client, sys_data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    client._mock_cursor.fetchall.return_value = [_row(sys_data)]
+    result = client._get_paginated_documents_impl(
+        page=1,
+        page_size=10,
+        filters={},
+        filter_map={},
+        sort_by="year",
+        sort_order="asc",
+    )
+    return result["documents"][0]
+
+
+class TestPaginatedTocApproved:
+    @pytest.mark.unit
+    def test_approved_document_exposes_toc_approved_true(self, client):
+        doc = _first_doc(client, {"sys_toc_approved": True})
+        assert doc["sys_toc_approved"] is True
+        assert normalize_document_payload(doc)["toc_approved"] is True
+
+    @pytest.mark.unit
+    def test_unapproved_document_reports_falsy_toc_approved(self, client):
+        doc = _first_doc(client, {"sys_toc_classified": "x"})
+        assert doc["sys_toc_approved"] is None
+        assert normalize_document_payload(doc).get("toc_approved") is None
+
+    @pytest.mark.unit
+    def test_missing_sys_data_does_not_crash(self, client):
+        doc = _first_doc(client, None)
+        assert doc["sys_toc_approved"] is None

--- a/tests/unit/test_toc_validator_service.py
+++ b/tests/unit/test_toc_validator_service.py
@@ -1,6 +1,6 @@
 """Unit tests for the TOC validator backend service."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -66,6 +66,24 @@ class TestRunValidation:
         }
         results = service.run_validation(pg, ["b", "a"])
         assert [r["doc_id"] for r in results] == ["b", "a"]
+
+    def test_run_validation_honours_configured_included_set(self):
+        """The validator uses Search's configured list, not a hardcoded copy.
+
+        With ``introduction`` in the included set, an in-body introduction (the
+        classic false positive) passes instead of failing.
+        """
+        pg = MagicMock()
+        pg.fetch_docs.return_value = {
+            "d1": _doc("[H1] Introduction | introduction | page 30", "(13, 67)")
+        }
+        with patch.object(
+            service,
+            "get_default_included_section_types",
+            return_value=["introduction", "findings"],
+        ):
+            results = service.run_validation(pg, ["d1"])
+        assert results[0]["status"] == "pass"
 
 
 class TestGetStoredResults:

--- a/ui/backend/services/toc_validator.py
+++ b/ui/backend/services/toc_validator.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from pipeline.db import PostgresClient
+from pipeline.db.config import get_default_included_section_types
 from pipeline.validation.section_inclusion import evaluate_document
 
 # Field name stored on each document row (in sys_data + its own column).
@@ -29,9 +30,10 @@ def build_result(
     doc_id: str,
     validated_by: Optional[str],
     validated_at: str,
+    included: List[str],
 ) -> Dict[str, Any]:
     """Evaluate a document row and shape the persisted/returned result."""
-    evaluation = evaluate_document(doc)
+    evaluation = evaluate_document(doc, included=included)
     return {
         "doc_id": str(doc_id),
         "status": evaluation["status"],
@@ -58,13 +60,14 @@ def run_validation(
     Unknown ``doc_ids`` (not present in the table) are skipped silently.
     """
     stamp = validated_at or _now_iso()
+    included = get_default_included_section_types()
     docs = pg.fetch_docs(doc_ids)
     results: List[Dict[str, Any]] = []
     for doc_id in doc_ids:
         doc = docs.get(str(doc_id))
         if doc is None:
             continue
-        result = build_result(doc, str(doc_id), validated_by, stamp)
+        result = build_result(doc, str(doc_id), validated_by, stamp, included)
         pg.merge_doc_sys_fields(doc_id=str(doc_id), sys_fields={SYS_FIELD: result})
         results.append(result)
     return results

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -12399,6 +12399,34 @@ a.admin-citation-clickable:hover {
   border: 1px dashed var(--gray-300);
 }
 
+/* Status chip + approval badge sit on one row above the detail lines. */
+.toc-validation-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Human-approval marker: deliberately high-contrast so an approved document is
+   obvious at a glance, independent of the pass/fail verdict beside it. */
+.toc-approved-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  white-space: nowrap;
+  background: var(--color-success);
+  color: white;
+}
+
+/* Subtle full-row tint reinforcing approval (no side accent bar, per UI rules). */
+.toc-validator-row-approved td {
+  background: #ecfdf5;
+}
+
 .toc-validation-detail {
   font-size: 0.78rem;
   color: var(--gray-600);

--- a/ui/frontend/src/components/admin/TocValidationResultCell.tsx
+++ b/ui/frontend/src/components/admin/TocValidationResultCell.tsx
@@ -5,7 +5,23 @@ interface TocValidationResultCellProps {
   result?: TocValidationResult;
   /** True when this row's result was added or changed by the most recent run. */
   changed?: boolean;
+  /** True when a human reviewer has approved this document's section tagging. */
+  approved?: boolean;
 }
+
+/**
+ * Prominent, self-contained marker that a human signed off on the tagging.
+ * Shown independently of the automated verdict (an approved document may still
+ * be "Fail" or "Not tested" — approval records human judgement, not the check).
+ */
+const ApprovedBadge: React.FC = () => (
+  <span
+    className="toc-approved-badge"
+    title="A human reviewer approved this document's section classifications"
+  >
+    <span aria-hidden="true">✓</span> Human-approved
+  </span>
+);
 
 const STATUS_LABEL = new Map<string, string>([
   ['pass', 'Pass'],
@@ -34,21 +50,28 @@ const describeReasons = (reasons: string[]): string =>
 export const TocValidationResultCell: React.FC<TocValidationResultCellProps> = ({
   result,
   changed,
+  approved,
 }) => {
   if (!result) {
     return (
       <td className="toc-validation-cell">
-        <span className="status-badge status-untested">Not tested</span>
+        <div className="toc-validation-chips">
+          <span className="status-badge status-untested">Not tested</span>
+          {approved && <ApprovedBadge />}
+        </div>
       </td>
     );
   }
 
   return (
     <td className="toc-validation-cell">
-      <span className={`status-badge status-${result.status}`}>
-        {STATUS_LABEL.get(result.status) || result.status}
-      </span>
-      {changed && <span className="badge badge-default">updated</span>}
+      <div className="toc-validation-chips">
+        <span className={`status-badge status-${result.status}`}>
+          {STATUS_LABEL.get(result.status) || result.status}
+        </span>
+        {approved && <ApprovedBadge />}
+        {changed && <span className="badge badge-default">updated</span>}
+      </div>
       {result.status === 'fail' && (
         <div className="toc-validation-detail" title={
           result.excluded_sections

--- a/ui/frontend/src/components/admin/TocValidatorManager.tsx
+++ b/ui/frontend/src/components/admin/TocValidatorManager.tsx
@@ -4,7 +4,7 @@ import API_BASE_URL from '../../config';
 import { MetadataModal } from '../documents/MetadataModal';
 import TocModal from '../TocModal';
 import TocValidatorTable from './TocValidatorTable';
-import { docKey, useTocValidator } from './useTocValidator';
+import { docApproved, docKey, useTocValidator } from './useTocValidator';
 
 interface TocValidatorManagerProps {
   dataSource?: string;
@@ -16,6 +16,7 @@ interface TocModalState {
   docId: string;
   toc: string;
   loading: boolean;
+  approved: boolean;
 }
 
 const EMPTY_TOC_STATE: TocModalState = {
@@ -23,6 +24,7 @@ const EMPTY_TOC_STATE: TocModalState = {
   docId: '',
   toc: '',
   loading: false,
+  approved: false,
 };
 
 /**
@@ -48,7 +50,8 @@ export const TocValidatorManager: React.FC<TocValidatorManagerProps> = ({
     async (doc: any) => {
       const docId = docKey(doc);
       const seeded = doc.toc_classified || doc.sys_toc_classified || doc.toc || '';
-      setTocState({ open: true, docId, toc: seeded, loading: true });
+      const approved = docApproved(doc);
+      setTocState({ open: true, docId, toc: seeded, loading: true, approved });
       try {
         const response = await axios.get<any>(`${API_BASE_URL}/document/${docId}`, {
           params: { data_source: dataSource || undefined },
@@ -59,6 +62,7 @@ export const TocValidatorManager: React.FC<TocValidatorManagerProps> = ({
           docId,
           toc: data.toc_classified || data.sys_toc_classified || seeded,
           loading: false,
+          approved: docApproved(data),
         });
       } catch (err) {
         setTocState((prev) => ({ ...prev, loading: false }));
@@ -74,6 +78,15 @@ export const TocValidatorManager: React.FC<TocValidatorManagerProps> = ({
     (newToc: string) => {
       setTocState((prev) => ({ ...prev, toc: newToc }));
       if (tocState.docId) state.revalidate(tocState.docId);
+    },
+    [state, tocState.docId]
+  );
+
+  // The modal already persisted the approval flag; reflect it in the table.
+  const handleTocApprovedChange = useCallback(
+    (approved: boolean) => {
+      setTocState((prev) => ({ ...prev, approved }));
+      if (tocState.docId) state.setApproval(tocState.docId, approved);
     },
     [state, tocState.docId]
   );
@@ -143,6 +156,7 @@ export const TocValidatorManager: React.FC<TocValidatorManagerProps> = ({
         results={resultsByDocId}
         changedIds={state.changedIds}
         selectedIds={state.selectedIds}
+        approvedIds={state.approvedIds}
         onToggle={state.toggle}
         onTogglePage={state.togglePage}
         allOnPageSelected={allOnPageSelected}
@@ -195,6 +209,8 @@ export const TocValidatorManager: React.FC<TocValidatorManagerProps> = ({
         dataSource={dataSource}
         loading={tocState.loading}
         onTocUpdated={handleTocUpdated}
+        tocApproved={tocState.approved}
+        onTocApprovedChange={handleTocApprovedChange}
       />
     </div>
   );

--- a/ui/frontend/src/components/admin/TocValidatorTable.tsx
+++ b/ui/frontend/src/components/admin/TocValidatorTable.tsx
@@ -9,6 +9,7 @@ interface TocValidatorTableProps {
   results: Map<string, TocValidationResult>;
   changedIds: Set<string>;
   selectedIds: Set<string>;
+  approvedIds: Set<string>;
   onToggle: (docId: string) => void;
   onTogglePage: () => void;
   allOnPageSelected: boolean;
@@ -95,6 +96,7 @@ export const TocValidatorTable: React.FC<TocValidatorTableProps> = ({
   results,
   changedIds,
   selectedIds,
+  approvedIds,
   onToggle,
   onTogglePage,
   allOnPageSelected,
@@ -153,9 +155,11 @@ export const TocValidatorTable: React.FC<TocValidatorTableProps> = ({
         {documents.map((doc) => {
           const key = docKey(doc);
           const status = doc.status || doc.sys_status || 'downloaded';
+          const approved = approvedIds.has(key);
           const rowClass = [
             selectedIds.has(key) ? 'admin-row-selected' : '',
             changedIds.has(key) ? 'toc-validator-row-changed' : '',
+            approved ? 'toc-validator-row-approved' : '',
           ]
             .filter(Boolean)
             .join(' ');
@@ -183,6 +187,7 @@ export const TocValidatorTable: React.FC<TocValidatorTableProps> = ({
               <TocValidationResultCell
                 result={results.get(key)}
                 changed={changedIds.has(key)}
+                approved={approved}
               />
               <DocumentLinksCell
                 doc={doc}

--- a/ui/frontend/src/components/admin/useTocValidator.ts
+++ b/ui/frontend/src/components/admin/useTocValidator.ts
@@ -16,6 +16,14 @@ export const docOrg = (doc: any): string =>
 export const docStatus = (doc: any): string =>
   doc.status || doc.sys_status || 'downloaded';
 
+/**
+ * True when a human reviewer has approved this document's section tagging.
+ * Reads the normalized `toc_approved` field, falling back to the raw sys_data
+ * shape so it works whether the row came from the list or a single-doc fetch.
+ */
+export const docApproved = (doc: any): boolean =>
+  doc?.toc_approved === true || doc?.sys_data?.sys_toc_approved === true;
+
 /** The four filterable columns; drives header rendering and options. */
 export type FilterColumn = 'title' | 'organization' | 'status' | 'review';
 
@@ -82,6 +90,7 @@ export const useTocValidator = (dataSource: string) => {
   const [results, setResults] = useState<Record<string, TocValidationResult>>({});
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [changedIds, setChangedIds] = useState<Set<string>>(new Set());
+  const [approvedIds, setApprovedIds] = useState<Set<string>>(new Set());
   const [running, setRunning] = useState(false);
 
   const loadDocuments = useCallback(async () => {
@@ -105,6 +114,7 @@ export const useTocValidator = (dataSource: string) => {
         current += 1;
       } while (current <= pages);
       setAllDocuments(collected);
+      setApprovedIds(new Set(collected.filter(docApproved).map(docKey)));
     } catch (err) {
       setError('Could not load documents.');
     } finally {
@@ -137,10 +147,21 @@ export const useTocValidator = (dataSource: string) => {
   useEffect(() => {
     setSelectedIds(new Set());
     setChangedIds(new Set());
+    setApprovedIds(new Set());
     setColumnFilters({});
     setSearch('');
     setPage(1);
   }, [dataSource]);
+
+  /** Reflect an approval toggle (made in the Contents modal) in the table. */
+  const setApproval = useCallback((docId: string, approved: boolean) => {
+    setApprovedIds((prev) => {
+      const next = new Set(prev);
+      if (approved) next.add(docId);
+      else next.delete(docId);
+      return next;
+    });
+  }, []);
 
   // Filtered set (search box + every active column filter), in load order.
   const filtered = useMemo(() => {
@@ -299,6 +320,7 @@ export const useTocValidator = (dataSource: string) => {
     results,
     selectedIds,
     changedIds,
+    approvedIds,
     running,
     columnFilters,
     activeFilterColumn,
@@ -317,6 +339,7 @@ export const useTocValidator = (dataSource: string) => {
     selectAllMatching,
     runValidation,
     revalidate,
+    setApproval,
     reloadDocuments: loadDocuments,
   };
 };

--- a/ui/frontend/src/tests/tocValidator.test.tsx
+++ b/ui/frontend/src/tests/tocValidator.test.tsx
@@ -19,8 +19,14 @@ jest.mock('../components/documents/MetadataModal', () => ({
 
 jest.mock('../components/TocModal', () => ({
   __esModule: true,
-  default: ({ isOpen, docId }: any) =>
-    isOpen ? <div data-testid="toc-modal">{docId}</div> : null,
+  default: ({ isOpen, docId, tocApproved, onTocApprovedChange }: any) =>
+    isOpen ? (
+      <div data-testid="toc-modal">
+        <span>{docId}</span>
+        <span data-testid="toc-modal-approved">{String(Boolean(tocApproved))}</span>
+        <button onClick={() => onTocApprovedChange(!tocApproved)}>toggle-approve</button>
+      </div>
+    ) : null,
 }));
 
 const mockGet = jest.fn();
@@ -55,12 +61,12 @@ const failResult: TocValidationResult = {
   validated_by: 'admin@wfp.org',
 };
 
-const renderCell = (result?: TocValidationResult, changed?: boolean) =>
+const renderCell = (result?: TocValidationResult, changed?: boolean, approved?: boolean) =>
   render(
     <table>
       <tbody>
         <tr>
-          <TocValidationResultCell result={result} changed={changed} />
+          <TocValidationResultCell result={result} changed={changed} approved={approved} />
         </tr>
       </tbody>
     </table>
@@ -94,6 +100,23 @@ describe('TocValidationResultCell', () => {
   test('shows updated badge when result changed in the last run', () => {
     renderCell(failResult, true);
     expect(screen.getByText('updated')).toBeInTheDocument();
+  });
+
+  test('shows the human-approved badge alongside the verdict when approved', () => {
+    renderCell(failResult, false, true);
+    expect(screen.getByText('Fail')).toBeInTheDocument();
+    expect(screen.getByText('Human-approved')).toBeInTheDocument();
+  });
+
+  test('shows the human-approved badge even when the document is not tested', () => {
+    renderCell(undefined, false, true);
+    expect(screen.getByText('Not tested')).toBeInTheDocument();
+    expect(screen.getByText('Human-approved')).toBeInTheDocument();
+  });
+
+  test('omits the human-approved badge when the document is not approved', () => {
+    renderCell(failResult, false, false);
+    expect(screen.queryByText('Human-approved')).not.toBeInTheDocument();
   });
 });
 
@@ -232,6 +255,46 @@ describe('TocValidatorManager', () => {
     expect(within(withoutToc).queryByText('Contents')).not.toBeInTheDocument();
     fireEvent.click(within(withToc).getByText('Contents'));
     expect(await screen.findByTestId('toc-modal')).toHaveTextContent('d1');
+  });
+
+  test('marks rows a human has approved with the approved badge', async () => {
+    mockGet.mockImplementation((url: string) => {
+      if (url.includes('/toc-validator/results')) {
+        return Promise.resolve({ data: { results: {} } });
+      }
+      if (url.includes('/documents')) {
+        return Promise.resolve({
+          data: {
+            documents: [
+              { ...DOCS[0], toc_approved: true },
+              DOCS[1],
+            ],
+            total_pages: 1,
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    render(<TocValidatorManager dataSource="wfp" />);
+    const approvedRow = (await screen.findByText('Zambia Country Programme')).closest(
+      'tr'
+    ) as HTMLElement;
+    const plainRow = screen.getByText('Yemen Emergency Response').closest('tr') as HTMLElement;
+    expect(within(approvedRow).getByText('Human-approved')).toBeInTheDocument();
+    expect(within(plainRow).queryByText('Human-approved')).not.toBeInTheDocument();
+  });
+
+  test('approving from the contents modal marks the row approved live', async () => {
+    render(<TocValidatorManager dataSource="wfp" />);
+    const row = (await screen.findByText('Zambia Country Programme')).closest('tr') as HTMLElement;
+    expect(within(row).queryByText('Human-approved')).not.toBeInTheDocument();
+
+    fireEvent.click(within(row).getByText('Contents'));
+    fireEvent.click(await screen.findByText('toggle-approve'));
+
+    await waitFor(() =>
+      expect(within(row).getByText('Human-approved')).toBeInTheDocument()
+    );
   });
 
   test('shows an error when the validation run fails', async () => {

--- a/ui/frontend/src/utils/searchUrl.ts
+++ b/ui/frontend/src/utils/searchUrl.ts
@@ -1,3 +1,4 @@
+import config from '../config.json';
 import { SearchFilters } from '../types/api';
 import type { SearchSettings } from '../types/auth';
 
@@ -26,15 +27,20 @@ export interface SearchStateFromURL {
 
 export const DEFAULT_FIELD_BOOST_FIELDS: Record<string, number> = { country: 1, organization: 0.5 };
 
-export const DEFAULT_SECTION_TYPES = [
-  'executive_summary',
-  'context',
-  'methodology',
-  'findings',
-  'conclusions',
-  'recommendations',
-  'other',
-];
+// The section types Search includes by default. Sourced from
+// `config.application.search.default_included_section_types` in config.json so
+// Search and the admin TOC Validator share one definition and cannot drift.
+// The literal here is only a safety net for a config.json missing the key.
+export const DEFAULT_SECTION_TYPES: string[] =
+  (config.application as any).search?.default_included_section_types ?? [
+    'executive_summary',
+    'context',
+    'methodology',
+    'findings',
+    'conclusions',
+    'recommendations',
+    'other',
+  ];
 
 /** Hardcoded system defaults for all search/content settings. */
 export const SYSTEM_DEFAULTS: Required<SearchSettings> = {


### PR DESCRIPTION
## Description

Two related improvements to the **admin TOC Validator**.

### 1. Human-approval indicator
Admins couldn't tell, from the validator, which flagged documents a human had already reviewed and accepted.

- Documents a reviewer has approved (`sys_toc_approved`) now show a green **✓ Human-approved** badge in the *Table of Contents review* column, plus a tinted row.
- The badge shows **independently of the automated verdict** — an approved document may still read **Fail** (e.g. one dominated by a correctly-tagged `introduction`) or **Not tested**. Approval records human judgement, not the check result.
- Approval is settable from the validator's **own Contents modal** (previously only the Documents Library wired this up), and the table updates **live** on toggle.
- Approval is read **live** from the document list — not frozen into the stored validation snapshot — so it stays current between runs.
- The paginated `/documents` payload now surfaces `sys_toc_approved` → `normalize_document_payload` exposes `toc_approved`. This also fixes a latent bug where the **Documents Library** approval checkbox opened unchecked for already-approved documents.

### 2. Config-driven included-section list (removes drift)
The list of section types Search includes by default was hardcoded **twice** — `DEFAULT_SECTION_TYPES` in `searchUrl.ts` and `DEFAULT_INCLUDED_SECTION_TYPES` in `section_inclusion.py` — kept in sync only by a comment. They could silently diverge, and the validator's verdicts depend on that list.

- The list now lives in **`config.json`** at `application.search.default_included_section_types`, read by **both** Search (`searchUrl.ts`) and the validator (`pipeline.db.config.get_default_included_section_types`) — so they can no longer drift.
- The offline `check_included_section_types.py` bulk script uses the same resolver.
- The built-in literals remain **only as a fallback** when the key is absent, so behavior is unchanged everywhere.

> ⚠️ **Deployment config note**
> The default-included section types now come from `application.search.default_included_section_types` in `config.json` (shared by Search and the TOC Validator). This PR adds the key — with the seven current defaults — to the canonical `config.json`.
>
> **Deployments that maintain their own `config.json`** (e.g. skip-worktree or externally managed) should add this key there to keep it config-driven, or to customize the set — e.g. add `introduction` to stop it being flagged across every document. **If the key is omitted, the code falls back to the same seven built-in defaults, so behavior is unchanged** — no deployment is required to act unless it wants to customize. Because `config.json` is baked into the frontend build, rebuild the frontend for the Search side to pick up a change.

## Type of Change
- [x] Bug fix (Documents Library approval checkbox initial state)
- [x] New feature (approval indicator; config-driven section list)
- [x] Documentation update

## Testing
- [x] Tests pass locally — backend `114 passed` (validator/config/section/paginated/api/sql suites), frontend `56 passed` (validator/search/group tests)
- [x] New tests added: config resolver + config-driven validation (`test_included_section_types_config.py`, `test_toc_validator_service.py`), approval payload (`test_paginated_documents_toc_approved.py`), approval badge + live toggle (`tocValidator.test.tsx`)
- [x] Manual verification via component tests (real `TocValidatorManager`/hook/table/cell against mocked network); TypeScript `tsc --noEmit` clean; black/isort/flake8/mypy/bandit/detect-secrets/gitleaks/code-metrics all pass in pre-commit

> Note: the validator is `current_superuser`-gated; verification was via the component/unit suite + type-check rather than an authenticated browser click-through.

## Checklist
- [x] Code follows project style guidelines (pre-commit clean, no suppressions)
- [x] Self-review completed
- [x] Documentation updated (`docs/admin/toc-validator.md`)
- [x] No breaking changes (config key is optional; safe fallback preserved)
