### PR TITLE
fix(eval): drive dataset/experiment case filters from the datasource config

### DIFF
--- a/docs/admin/evaluation.md
+++ b/docs/admin/evaluation.md
@@ -86,28 +86,32 @@ The CSV columns are:
 
 #### Filtering a case
 
-Filters restrict which documents a case searches, reproducing the app's search
-facets. With **+ Add case** you can set the common ones with UI controls — a
-**document picker** (type to search real document titles), **country** and
-**region** pickers (populated from the data source's values), and a
-**publication year** range — and use the collapsible **Advanced filters /
-params (JSON)** box for anything else. In a CSV `filters` cell (and in the
-Advanced box) you provide a JSON object:
+Filters restrict which documents a case searches, using the **same filter
+fields the search page offers** for the dataset's data source — they come from
+the data source's configuration (`config.json`), not from a fixed list. With
+**+ Add case** the editor shows one control per configured field: a **document
+picker** (type to search real document titles) when the source declares a
+title filter, a **value picker** for each facet field (populated from the data
+source's values, e.g. country, region, document type, language), and **min /
+max inputs** for each numeric range field (e.g. publication year). Anything a
+case carries beyond those fields (e.g. `params` from an import) is shown
+read-only and kept unchanged when saving. In a CSV `filters` cell you provide
+a JSON object:
 
 | Filter | Format | Example |
 |--------|--------|---------|
 | Specific documents | `doc_titles`: a list of **exact document titles as they appear in the UI** (matched case-insensitively) | `{"doc_titles": ["Evaluation of X", "Annual Report 2021"]}` |
-| Publication year | `published_year_min` / `published_year_max` (numbers) | `{"published_year_min": 2018, "published_year_max": 2022}` |
-| Country / region | `country` / `region`: lists of values | `{"country": ["Kenya"], "region": ["Asia and the Pacific"]}` |
-| Other fields | e.g. `organization`, `document_type` (strings) | `{"organization": "WFP"}` |
+| Facet fields | the configured field name with a list of values | `{"country": ["Kenya"], "region": ["Asia and the Pacific"]}` |
+| Range fields | `<field>_min` / `<field>_max` (numbers) | `{"published_year_min": 2018, "published_year_max": 2022}` |
 
-`doc_titles` and `region` are resolved to the matching document IDs at run time,
-so you filter by the human-readable title/region rather than an internal ID
-(region also matches documents whose region field is not stamped on individual
-chunks). A `doc_titles` or `region` value that matches no document yields
+Document-level fields — `doc_titles`, `region`, `language` and the source's
+`src_*` fields — are resolved to the matching document IDs at run time, exactly
+as the search page does, so you filter by the human-readable value rather than
+an internal ID (this also matches documents whose value is not stamped on
+individual chunks). A document-level value that matches no document yields
 **zero** results for that case (it is never silently ignored), so prefer the
-pickers to avoid typos. Use a separate `params` key for search behaviour (e.g.
-`rerank`, `limit`), not for document filtering.
+pickers to avoid typos. Search behaviour (e.g. `rerank`, `limit`) belongs in a
+case's separate `params` key — set via the API or an import, not a filter.
 
 ---
 

--- a/tests/unit/test_harness_doc_filters.py
+++ b/tests/unit/test_harness_doc_filters.py
@@ -1,20 +1,34 @@
 """Unit tests for the eval-harness document-level filter resolver.
 
-The evaluation harness lets a test case filter by exact document title (``doc_titles``)
-and by ``region`` — both document-level fields not stored on chunks. Because the
-harness calls chunk search directly (bypassing the ``/search`` route's own
-resolvers), these must be resolved to a ``doc_id`` filter at run time. These tests
-cover that resolution, its AND-intersection with a pre-existing ``doc_id`` filter,
-region OR-union, and the no-match sentinel behaviour.
+The evaluation harness lets a test case use any of the data source's
+config-declared filter fields. Fields whose values live on documents rather
+than chunks — ``doc_titles`` (exact UI titles), ``region``, ``language`` and
+the config-declared ``src_*`` fields — must be resolved to a ``doc_id`` filter
+at run time because the harness calls chunk search directly (bypassing the
+``/search`` route's own resolvers). These tests cover that resolution, its
+AND-intersection with a pre-existing ``doc_id`` filter, the OR-union of values
+within a field, and the no-match sentinel behaviour.
 """
 
 from unittest.mock import MagicMock
 
 import pytest
 
+import ui.backend.utils.filter_helpers as filter_helpers
 from ui.backend.utils.filter_helpers import NO_MATCH_DOC_ID, resolve_doc_level_filters
 
 pytestmark = pytest.mark.unit
+
+SOURCE = "test-source"
+
+
+@pytest.fixture(autouse=True)
+def _no_src_fields(monkeypatch):
+    """Default the data source's ``src_field_mapping`` to empty for every test.
+
+    Tests exercising ``src_*`` resolution override this with a real mapping.
+    """
+    monkeypatch.setattr(filter_helpers, "get_src_field_mapping", lambda source: {})
 
 
 def _pg_titles(doc_ids):
@@ -27,7 +41,7 @@ class TestResolveDocTitles:
     def test_no_doc_level_keys_when_absent_then_filters_returned_unchanged(self):
         filters = {"published_year_max": 2020, "country": "Kenya"}
         pg = MagicMock()
-        assert resolve_doc_level_filters(filters, pg) == {
+        assert resolve_doc_level_filters(filters, pg, SOURCE) == {
             "published_year_max": 2020,
             "country": "Kenya",
         }
@@ -37,20 +51,20 @@ class TestResolveDocTitles:
     def test_single_title_when_set_then_replaced_by_doc_id_filter(self):
         filters = {"doc_titles": ["Report A"]}
         pg = _pg_titles(["d1"])
-        result = resolve_doc_level_filters(filters, pg)
+        result = resolve_doc_level_filters(filters, pg, SOURCE)
         assert "doc_titles" not in result
         assert result["doc_id"] == ["d1"]
         pg.fetch_doc_ids_by_exact_titles.assert_called_once_with(["Report A"])
 
     def test_multiple_titles_when_set_then_all_doc_ids_returned(self):
         filters = {"doc_titles": ["Report A", "Report B"]}
-        result = resolve_doc_level_filters(filters, _pg_titles(["d2", "d1"]))
+        result = resolve_doc_level_filters(filters, _pg_titles(["d2", "d1"]), SOURCE)
         assert result["doc_id"] == ["d1", "d2"]  # sorted, deterministic
 
     def test_comma_string_when_given_then_split_into_titles(self):
         filters = {"doc_titles": "Report A, Report B"}
         pg = _pg_titles(["d1"])
-        resolve_doc_level_filters(filters, pg)
+        resolve_doc_level_filters(filters, pg, SOURCE)
         pg.fetch_doc_ids_by_exact_titles.assert_called_once_with(
             ["Report A", "Report B"]
         )
@@ -58,42 +72,44 @@ class TestResolveDocTitles:
     def test_blank_titles_when_only_whitespace_then_no_lookup_and_no_doc_id(self):
         filters = {"doc_titles": ["  ", ""]}
         pg = MagicMock()
-        result = resolve_doc_level_filters(filters, pg)
+        result = resolve_doc_level_filters(filters, pg, SOURCE)
         assert "doc_titles" not in result
         assert "doc_id" not in result
         pg.fetch_doc_ids_by_exact_titles.assert_not_called()
 
     def test_titles_when_no_docs_match_then_sentinel_doc_id(self):
         filters = {"doc_titles": ["Nonexistent"]}
-        result = resolve_doc_level_filters(filters, _pg_titles([]))
+        result = resolve_doc_level_filters(filters, _pg_titles([]), SOURCE)
         assert result["doc_id"] == [NO_MATCH_DOC_ID]
 
     def test_existing_doc_id_when_titles_set_then_intersected(self):
         filters = {"doc_titles": ["Report A"], "doc_id": "d1,d2,d3"}
-        result = resolve_doc_level_filters(filters, _pg_titles(["d2", "d3", "d4"]))
+        result = resolve_doc_level_filters(
+            filters, _pg_titles(["d2", "d3", "d4"]), SOURCE
+        )
         assert result["doc_id"] == ["d2", "d3"]
 
     def test_existing_doc_id_when_disjoint_then_sentinel(self):
         filters = {"doc_titles": ["Report A"], "doc_id": ["d1"]}
-        result = resolve_doc_level_filters(filters, _pg_titles(["d9"]))
+        result = resolve_doc_level_filters(filters, _pg_titles(["d9"]), SOURCE)
         assert result["doc_id"] == [NO_MATCH_DOC_ID]
 
     def test_invalid_titles_when_not_list_or_string_then_value_error(self):
         with pytest.raises(ValueError, match="doc_titles must be a list"):
-            resolve_doc_level_filters({"doc_titles": 123}, MagicMock())
+            resolve_doc_level_filters({"doc_titles": 123}, MagicMock(), SOURCE)
 
     def test_input_dict_when_resolved_then_not_mutated(self):
         filters = {"doc_titles": ["Report A"], "country": "Kenya"}
-        resolve_doc_level_filters(filters, _pg_titles(["d1"]))
+        resolve_doc_level_filters(filters, _pg_titles(["d1"]), SOURCE)
         assert filters == {"doc_titles": ["Report A"], "country": "Kenya"}
 
     def test_non_dict_when_passed_then_returned_unchanged(self):
-        assert resolve_doc_level_filters(None, MagicMock()) is None
+        assert resolve_doc_level_filters(None, MagicMock(), SOURCE) is None
 
     def test_country_when_set_then_left_untouched(self):
         # country is stamped on chunks and applied natively — never resolved here.
         filters = {"country": ["Kenya"], "doc_titles": ["Report A"]}
-        result = resolve_doc_level_filters(filters, _pg_titles(["d1"]))
+        result = resolve_doc_level_filters(filters, _pg_titles(["d1"]), SOURCE)
         assert result["country"] == ["Kenya"]
         assert result["doc_id"] == ["d1"]
 
@@ -102,7 +118,9 @@ class TestResolveRegion:
     def test_single_region_when_set_then_resolved_to_doc_ids(self):
         pg = MagicMock()
         pg.fetch_doc_ids_by_region.return_value = ["d1", "d2"]
-        result = resolve_doc_level_filters({"region": "Asia and the Pacific"}, pg)
+        result = resolve_doc_level_filters(
+            {"region": "Asia and the Pacific"}, pg, SOURCE
+        )
         assert "region" not in result
         assert result["doc_id"] == ["d1", "d2"]
         pg.fetch_doc_ids_by_region.assert_called_once_with("Asia and the Pacific")
@@ -111,7 +129,7 @@ class TestResolveRegion:
         pg = MagicMock()
         pg.fetch_doc_ids_by_region.side_effect = [["d1", "d2"], ["d2", "d3"]]
         result = resolve_doc_level_filters(
-            {"region": ["Asia and the Pacific", "Eastern Africa"]}, pg
+            {"region": ["Asia and the Pacific", "Eastern Africa"]}, pg, SOURCE
         )
         assert result["doc_id"] == ["d1", "d2", "d3"]  # union, sorted
         assert pg.fetch_doc_ids_by_region.call_count == 2
@@ -120,7 +138,7 @@ class TestResolveRegion:
         pg = MagicMock()
         pg.fetch_doc_ids_by_region.return_value = ["d1"]
         resolve_doc_level_filters(
-            {"region": "Middle East, Northern Africa, and Eastern Europe"}, pg
+            {"region": "Middle East, Northern Africa, and Eastern Europe"}, pg, SOURCE
         )
         pg.fetch_doc_ids_by_region.assert_called_once_with(
             "Middle East, Northern Africa, and Eastern Europe"
@@ -129,21 +147,129 @@ class TestResolveRegion:
     def test_region_when_no_docs_match_then_sentinel_doc_id(self):
         pg = MagicMock()
         pg.fetch_doc_ids_by_region.return_value = []
-        result = resolve_doc_level_filters({"region": ["Nowhere"]}, pg)
+        result = resolve_doc_level_filters({"region": ["Nowhere"]}, pg, SOURCE)
         assert result["doc_id"] == [NO_MATCH_DOC_ID]
 
     def test_invalid_region_when_not_list_or_string_then_value_error(self):
         with pytest.raises(ValueError, match="region must be a string or a list"):
-            resolve_doc_level_filters({"region": 5}, MagicMock())
+            resolve_doc_level_filters({"region": 5}, MagicMock(), SOURCE)
 
 
-class TestResolveTitlesAndRegionCombined:
+class TestResolveLanguage:
+    def test_language_names_when_set_then_normalised_to_codes(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_language.return_value = ["d1", "d2"]
+        result = resolve_doc_level_filters(
+            {"language": ["English", "French"]}, pg, SOURCE
+        )
+        assert "language" not in result
+        assert result["doc_id"] == ["d1", "d2"]
+        pg.fetch_doc_ids_by_language.assert_called_once_with(["en", "fr"])
+
+    def test_language_codes_when_given_then_passed_through(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_language.return_value = ["d1"]
+        resolve_doc_level_filters({"language": "en,fr"}, pg, SOURCE)
+        pg.fetch_doc_ids_by_language.assert_called_once_with(["en", "fr"])
+
+    def test_language_when_no_docs_match_then_sentinel_doc_id(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_language.return_value = []
+        result = resolve_doc_level_filters({"language": ["English"]}, pg, SOURCE)
+        assert result["doc_id"] == [NO_MATCH_DOC_ID]
+
+    def test_blank_language_when_only_whitespace_then_no_lookup(self):
+        pg = MagicMock()
+        result = resolve_doc_level_filters({"language": ["  "]}, pg, SOURCE)
+        assert "language" not in result
+        assert "doc_id" not in result
+        pg.fetch_doc_ids_by_language.assert_not_called()
+
+    def test_invalid_language_when_not_list_or_string_then_value_error(self):
+        with pytest.raises(ValueError, match="language must be a string or a list"):
+            resolve_doc_level_filters({"language": 7}, MagicMock(), SOURCE)
+
+
+class TestResolveSrcFields:
+    @pytest.fixture
+    def _src_mapping(self, monkeypatch):
+        monkeypatch.setattr(
+            filter_helpers,
+            "get_src_field_mapping",
+            lambda source: {"src_evaluation_category": "Evaluation category"},
+        )
+
+    def test_src_field_when_set_then_resolved_via_jsonb_lookup(
+        self, _src_mapping, monkeypatch
+    ):
+        calls = []
+
+        def fake_jsonb(pg, raw_key, values):
+            calls.append((raw_key, values))
+            return ["d1", "d2"]
+
+        monkeypatch.setattr(filter_helpers, "doc_ids_from_pg_jsonb", fake_jsonb)
+        result = resolve_doc_level_filters(
+            {"src_evaluation_category": ["Centralized"]}, MagicMock(), SOURCE
+        )
+        assert "src_evaluation_category" not in result
+        assert result["doc_id"] == ["d1", "d2"]
+        assert calls == [("Evaluation category", ["Centralized"])]
+
+    def test_src_field_when_comma_string_then_split_into_values(
+        self, _src_mapping, monkeypatch
+    ):
+        calls = []
+        monkeypatch.setattr(
+            filter_helpers,
+            "doc_ids_from_pg_jsonb",
+            lambda pg, raw_key, values: calls.append(values) or ["d1"],
+        )
+        resolve_doc_level_filters(
+            {"src_evaluation_category": "Centralized, Decentralized"},
+            MagicMock(),
+            SOURCE,
+        )
+        assert calls == [["Centralized", "Decentralized"]]
+
+    def test_src_field_when_no_docs_match_then_sentinel_doc_id(
+        self, _src_mapping, monkeypatch
+    ):
+        monkeypatch.setattr(
+            filter_helpers, "doc_ids_from_pg_jsonb", lambda pg, raw_key, values: []
+        )
+        result = resolve_doc_level_filters(
+            {"src_evaluation_category": ["Centralized"]}, MagicMock(), SOURCE
+        )
+        assert result["doc_id"] == [NO_MATCH_DOC_ID]
+
+    def test_src_field_when_not_in_mapping_then_left_untouched(self):
+        # Only config-declared src_* fields resolve; unknown keys pass through.
+        filters = {"src_unknown": ["x"], "doc_titles": ["Report A"]}
+        result = resolve_doc_level_filters(filters, _pg_titles(["d1"]), SOURCE)
+        assert result["src_unknown"] == ["x"]
+        assert result["doc_id"] == ["d1"]
+
+    def test_invalid_src_value_when_not_list_or_string_then_value_error(
+        self, _src_mapping
+    ):
+        with pytest.raises(
+            ValueError, match="src_evaluation_category must be a string or a list"
+        ):
+            resolve_doc_level_filters(
+                {"src_evaluation_category": 3}, MagicMock(), SOURCE
+            )
+
+
+class TestResolveCombined:
     def test_titles_and_region_when_both_set_then_intersected(self):
         pg = MagicMock()
         pg.fetch_doc_ids_by_exact_titles.return_value = ["d1", "d2", "d3"]
         pg.fetch_doc_ids_by_region.return_value = ["d2", "d3", "d4"]
         result = resolve_doc_level_filters(
-            {"doc_titles": ["Report A"], "region": ["Asia and the Pacific"]}, pg
+            {"doc_titles": ["Report A"], "region": ["Asia and the Pacific"]},
+            pg,
+            SOURCE,
         )
         assert result["doc_id"] == ["d2", "d3"]
 
@@ -152,6 +278,17 @@ class TestResolveTitlesAndRegionCombined:
         pg.fetch_doc_ids_by_exact_titles.return_value = ["d1"]
         pg.fetch_doc_ids_by_region.return_value = ["d9"]
         result = resolve_doc_level_filters(
-            {"doc_titles": ["Report A"], "region": ["Asia and the Pacific"]}, pg
+            {"doc_titles": ["Report A"], "region": ["Asia and the Pacific"]},
+            pg,
+            SOURCE,
         )
         assert result["doc_id"] == [NO_MATCH_DOC_ID]
+
+    def test_language_and_region_when_both_set_then_intersected(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_region.return_value = ["d1", "d2"]
+        pg.fetch_doc_ids_by_language.return_value = ["d2", "d3"]
+        result = resolve_doc_level_filters(
+            {"region": ["Asia and the Pacific"], "language": ["English"]}, pg, SOURCE
+        )
+        assert result["doc_id"] == ["d2"]

--- a/ui/backend/services/test_runner.py
+++ b/ui/backend/services/test_runner.py
@@ -133,9 +133,10 @@ async def _run_search(
     (same retrieval, result building, field-boost/dedup post-processing), so an
     experiment reproduces what a user sees in the app.
 
-    Document-level filters (``doc_titles``, ``region``) are resolved to ``doc_id``
-    filters here (via :func:`resolve_doc_level_filters`) because the harness calls
-    the chunk search directly and so bypasses the route handler's own resolvers.
+    Document-level filters (``doc_titles``, ``region``, ``language`` and the
+    data source's ``src_*`` fields) are resolved to ``doc_id`` filters here (via
+    :func:`resolve_doc_level_filters`) because the harness calls the chunk
+    search directly and so bypasses the route handler's own resolvers.
 
     Parameters default to the ``/search`` endpoint's own defaults; the
     experiment ``config`` overrides them (e.g. ``embedding_model``, ``rerank``,
@@ -154,7 +155,7 @@ async def _run_search(
     min_chunk_size = int(params.get("min_chunk_size", 0))
     filters = case_input.get("filters") or None
     if filters:
-        filters = resolve_doc_level_filters(filters, pg)
+        filters = resolve_doc_level_filters(filters, pg, source)
     raw = await _run_search_chunks(
         query,
         limit=limit,

--- a/ui/backend/utils/filter_helpers.py
+++ b/ui/backend/utils/filter_helpers.py
@@ -7,9 +7,11 @@ from qdrant_client.http import models
 from pipeline.db import (
     get_default_filter_fields,
     get_field_mapping,
+    get_src_field_mapping,
     get_taxonomy_filter_fields,
 )
 from ui.backend.utils.document_utils import map_core_field_to_storage
+from ui.backend.utils.facet_helpers import doc_ids_from_pg_jsonb
 from ui.backend.utils.language_codes import LANGUAGE_CODES
 
 
@@ -189,7 +191,14 @@ def _existing_doc_id_set(value: Any) -> Optional[Set[str]]:
 
 
 # Doc-level filters resolved to a doc_id set for the harness chunk search.
-_DOC_LEVEL_FILTER_KEYS = ("doc_titles", "region")
+# ``src_*`` fields (from the data source's ``src_field_mapping``) are detected
+# dynamically in :func:`_is_doc_level_key`.
+_DOC_LEVEL_FILTER_KEYS = ("doc_titles", "region", "language")
+
+
+def _is_doc_level_key(key: str, src_mapping: Dict[str, str]) -> bool:
+    """True when a filter key must be resolved to doc_ids for the chunk search."""
+    return key in _DOC_LEVEL_FILTER_KEYS or key in src_mapping
 
 
 def _title_doc_ids(value: Any, pg) -> Optional[Set[str]]:
@@ -238,23 +247,99 @@ def _region_doc_ids(value: Any, pg) -> Optional[Set[str]]:
     return doc_ids
 
 
-def resolve_doc_level_filters(filters: Dict[str, Any], pg) -> Dict[str, Any]:
-    """Resolve document-level filters (``doc_titles``, ``region``) to ``doc_id``.
+def _language_names(value: Any) -> List[str]:
+    """Coerce a ``language`` filter value into a list of language names/codes.
+
+    Accepts a list of strings, or a single/comma-joined string for convenience.
+    Blank entries are dropped.
+
+    Raises:
+        ValueError: If the value is neither a string nor a list/tuple.
+    """
+    if isinstance(value, str):
+        items: List[Any] = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        items = list(value)
+    else:
+        raise ValueError("language must be a string or a list of languages")
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _language_doc_ids(value: Any, pg) -> Optional[Set[str]]:
+    """Resolve a ``language`` value to a doc_id set (None if empty).
+
+    Language lives on documents (``sys_language``), not on chunks, so it is
+    resolved via PostgreSQL exactly like the ``/search`` route does. Values may
+    be full language names (as faceted in the UI) or ISO codes; names are
+    normalised to codes first.
+    """
+    if value is None:
+        return None
+    names = _language_names(value)
+    if not names:
+        return None
+    codes = [LANGUAGE_CODES.get(name, name) for name in names]
+    return set(pg.fetch_doc_ids_by_language(codes))
+
+
+def _src_field_values(field: str, value: Any) -> List[str]:
+    """Coerce a ``src_*`` filter value into a list of values (comma-splitting
+    bare strings, matching the search route's convention).
+
+    Raises:
+        ValueError: If the value is neither a string nor a list/tuple.
+    """
+    if isinstance(value, str):
+        items: List[Any] = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        items = list(value)
+    else:
+        raise ValueError(f"{field} must be a string or a list of values")
+    return [str(item).strip() for item in items if str(item).strip()]
+
+
+def _pop_src_field_constraints(
+    result: Dict[str, Any], src_mapping: Dict[str, str], pg
+) -> List[Set[str]]:
+    """Pop each present ``src_*`` filter and resolve it to a doc_id set.
+
+    ``src_*`` values live in the ``docs.src_doc_raw_metadata`` JSONB (only
+    sparsely stamped onto chunks), so each field is resolved via PostgreSQL —
+    the same source its facet counts come from. Values OR within a field; the
+    returned sets AND across fields.
+    """
+    constraints: List[Set[str]] = []
+    for field, raw_key in src_mapping.items():
+        if field not in result:
+            continue
+        values = _src_field_values(field, result.pop(field))
+        if values:
+            constraints.append(set(doc_ids_from_pg_jsonb(pg, raw_key, values)))
+    return constraints
+
+
+def resolve_doc_level_filters(
+    filters: Dict[str, Any], pg, data_source: str
+) -> Dict[str, Any]:
+    """Resolve document-level filters to a ``doc_id`` filter for the harness.
 
     The eval harness calls the chunk search directly and so bypasses the search
-    route's own resolvers. This lets users filter by exact document title (as
-    displayed in the UI) and by region — both document-level, not stored on
-    chunks — instead of raw doc_ids. Each is resolved to doc_ids at run time and
-    AND-combined with any existing ``doc_id`` filter (regions OR within their
-    facet). When the combination matches nothing, the filter is pinned to
-    :data:`NO_MATCH_DOC_ID` so the run returns no results (never unfiltered).
+    route's own resolvers. Filter fields whose values live on documents rather
+    than chunks — ``doc_titles`` (exact UI titles), ``region``, ``language`` and
+    the data source's config-declared ``src_*`` fields — must therefore be
+    resolved to doc_ids at run time, mirroring the ``/search`` route. Each
+    resolved set is AND-combined with any existing ``doc_id`` filter (values OR
+    within a field). When the combination matches nothing, the filter is pinned
+    to :data:`NO_MATCH_DOC_ID` so the run returns no results (never unfiltered).
 
-    ``country`` is intentionally left untouched: it is stamped on chunks and
-    applied natively by the chunk search.
+    Chunk-resident fields (``country``, ``document_type``, ``organization``,
+    year ranges, taxonomy ``tag_*`` fields, …) are intentionally left untouched:
+    the chunk search applies them natively as payload filters.
 
     Args:
         filters: Case ``filters`` dict. Not mutated; a new dict is returned.
         pg: Postgres client for the case's data source.
+        data_source: Data source key, used to look up its ``src_field_mapping``.
 
     Returns:
         A new filters dict with resolved keys replaced by a ``doc_id`` filter, or
@@ -262,21 +347,24 @@ def resolve_doc_level_filters(filters: Dict[str, Any], pg) -> Dict[str, Any]:
     """
     if not isinstance(filters, dict):
         return filters
-    if not any(key in filters for key in _DOC_LEVEL_FILTER_KEYS):
+    src_mapping = get_src_field_mapping(data_source) or {}
+    if not any(_is_doc_level_key(key, src_mapping) for key in filters):
         return filters
     result = dict(filters)
     constraints: List[Set[str]] = []
     existing = _existing_doc_id_set(result.get("doc_id"))
     if existing is not None:
         constraints.append(existing)
-    title_ids = _title_doc_ids(result.pop("doc_titles", None), pg)
-    if title_ids is not None:
-        constraints.append(title_ids)
-    region_ids = _region_doc_ids(result.pop("region", None), pg)
-    if region_ids is not None:
-        constraints.append(region_ids)
+    for resolved in (
+        _title_doc_ids(result.pop("doc_titles", None), pg),
+        _region_doc_ids(result.pop("region", None), pg),
+        _language_doc_ids(result.pop("language", None), pg),
+    ):
+        if resolved is not None:
+            constraints.append(resolved)
+    constraints.extend(_pop_src_field_constraints(result, src_mapping, pg))
     if not constraints:
         return result
-    resolved = set.intersection(*constraints)
-    result["doc_id"] = sorted(resolved) if resolved else [NO_MATCH_DOC_ID]
+    resolved_ids = set.intersection(*constraints)
+    result["doc_id"] = sorted(resolved_ids) if resolved_ids else [NO_MATCH_DOC_ID]
     return result

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -12173,13 +12173,13 @@ a.admin-citation-clickable:hover {
   background: var(--color-surface-alt, #f6f8fa);
 }
 
-/* Publication-year min/max inputs in the case editor */
-.testing-year-range {
+/* Range-field min/max inputs in the case editor */
+.testing-range-inputs {
   display: flex;
   align-items: center;
   gap: 0.5rem;
 }
-.testing-year-range input {
+.testing-range-inputs input {
   width: 6rem;
 }
 

--- a/ui/frontend/src/components/admin/testing/CaseEditor.tsx
+++ b/ui/frontend/src/components/admin/testing/CaseEditor.tsx
@@ -1,21 +1,65 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import API_BASE_URL from '../../../config';
-import type { Facets } from '../../../types/api';
+import type { Facets, RangeInfo } from '../../../types/api';
 import type { TestCase } from '../../../types/testing';
 import { prettyJson } from './testingFormat';
 import DocumentTitleSelect from './DocumentTitleSelect';
 import FacetMultiSelect from './FacetMultiSelect';
-import FilterHelp from './FilterHelp';
+
+/**
+ * Which filters the case builder offers, derived from the data source's
+ * config-driven search facets (the `/facets` response). This is the same
+ * source that drives the search page's filter panel, so the eval builder
+ * always mirrors the filters a user sees in regular search.
+ */
+export interface CaseFilterConfig {
+  /** Core field -> display label, rendered as facet-value multiselects. */
+  facetFields: Record<string, string>;
+  /** Core field -> display label, rendered as min/max range inputs. */
+  rangeFields: Record<string, string>;
+  /** Label of the document-title filter field, when the config declares one. */
+  titleLabel: string | null;
+}
+
+export const emptyFilterConfig = (): CaseFilterConfig => ({
+  facetFields: {},
+  rangeFields: {},
+  titleLabel: null,
+});
+
+// Split the config's filter fields the same way the search panel does: fields
+// with range info become min/max inputs, `title` becomes the document picker
+// (stored as `doc_titles`), everything else a facet-value multiselect.
+export const filterConfigFromFacets = (facets: Facets): CaseFilterConfig => {
+  const config = emptyFilterConfig();
+  Object.entries(facets.filter_fields || {}).forEach(([field, label]) => {
+    if (field === 'title') {
+      config.titleLabel = label;
+    } else if (facets.range_fields?.[field]) {
+      config.rangeFields[field] = label;
+    } else {
+      config.facetFields[field] = label;
+    }
+  });
+  return config;
+};
+
+export interface RangeDraft {
+  min: string; // empty = unset
+  max: string; // empty = unset
+}
 
 export interface CaseDraft {
   query: string;
-  yearMin: string; // published_year_min (empty = unset)
-  yearMax: string; // published_year_max (empty = unset)
   docTitles: string[]; // filters.doc_titles (exact UI titles)
-  country: string[]; // filters.country
-  region: string[]; // filters.region
-  advancedJson: string; // remaining filters + params, as JSON
+  facetValues: Record<string, string[]>; // core field -> selected values
+  ranges: Record<string, RangeDraft>; // core field -> {field}_min/{field}_max
+  // Keys the builder does not own are carried through unchanged so editing a
+  // case never drops them: filter keys the config doesn't declare, and input
+  // keys other than query/filters (e.g. `params` from an import or the API).
+  extraFilters: Record<string, unknown>;
+  extraInput: Record<string, unknown>;
   tags: string; // comma separated
   notes: string;
 }
@@ -31,7 +75,7 @@ type JsonObject = Record<string, unknown>;
 const isPlainObject = (value: unknown): value is JsonObject =>
   !!value && typeof value === 'object' && !Array.isArray(value);
 
-// A doc_titles value is pulled into the builder only when it is a clean list of
+// A filter value is pulled into the builder only when it is a clean list of
 // strings; anything else stays in the advanced JSON so it round-trips untouched.
 const asStringList = (value: unknown): string[] | null => {
   if (!Array.isArray(value)) return null;
@@ -61,29 +105,33 @@ const takeStringList = (obj: JsonObject, key: string): string[] => {
 };
 
 interface SplitFilters {
-  yearMin: string;
-  yearMax: string;
   docTitles: string[];
-  country: string[];
-  region: string[];
+  facetValues: Record<string, string[]>;
+  ranges: Record<string, RangeDraft>;
   rest: JsonObject;
 }
 
-// Split a stored `filters` object into the builder-owned fields (year range,
-// doc_titles, country, region) and the remaining keys that stay in advanced JSON.
-const splitFilters = (filters: unknown): SplitFilters => {
+// Split a stored `filters` object into the builder-owned fields — those the
+// data source's filter config declares — and the remaining keys that stay in
+// advanced JSON.
+const splitFilters = (filters: unknown, config: CaseFilterConfig): SplitFilters => {
   if (!isPlainObject(filters)) {
-    return { yearMin: '', yearMax: '', docTitles: [], country: [], region: [], rest: {} };
+    return { docTitles: [], facetValues: {}, ranges: {}, rest: {} };
   }
   const rest: JsonObject = { ...filters };
-  return {
-    yearMin: takeNumberString(rest, 'published_year_min'),
-    yearMax: takeNumberString(rest, 'published_year_max'),
-    docTitles: takeStringList(rest, 'doc_titles'),
-    country: takeStringList(rest, 'country'),
-    region: takeStringList(rest, 'region'),
-    rest,
-  };
+  const docTitles = config.titleLabel ? takeStringList(rest, 'doc_titles') : [];
+  const facetValues: Record<string, string[]> = {};
+  Object.keys(config.facetFields).forEach((field) => {
+    const values = takeStringList(rest, field);
+    if (values.length > 0) facetValues[field] = values;
+  });
+  const ranges: Record<string, RangeDraft> = {};
+  Object.keys(config.rangeFields).forEach((field) => {
+    const min = takeNumberString(rest, `${field}_min`);
+    const max = takeNumberString(rest, `${field}_max`);
+    if (min !== '' || max !== '') ranges[field] = { min, max };
+  });
+  return { docTitles, facetValues, ranges, rest };
 };
 
 /* ------------------------------------------------------------------ */
@@ -92,61 +140,52 @@ const splitFilters = (filters: unknown): SplitFilters => {
 
 export const emptyDraft = (): CaseDraft => ({
   query: '',
-  yearMin: '',
-  yearMax: '',
   docTitles: [],
-  country: [],
-  region: [],
-  advancedJson: '',
+  facetValues: {},
+  ranges: {},
+  extraFilters: {},
+  extraInput: {},
   tags: '',
   notes: '',
 });
 
-export const caseToDraft = (testCase: TestCase): CaseDraft => {
+export const caseToDraft = (testCase: TestCase, config: CaseFilterConfig): CaseDraft => {
   const input = (testCase.input || {}) as JsonObject;
   const { query, filters, ...restTop } = input as {
     query?: unknown;
     filters?: unknown;
     [k: string]: unknown;
   };
-  const split = splitFilters(filters);
-  const advanced: JsonObject = { ...restTop };
-  if (Object.keys(split.rest).length > 0) advanced.filters = split.rest;
+  const split = splitFilters(filters, config);
   return {
     query: typeof query === 'string' ? query : '',
-    yearMin: split.yearMin,
-    yearMax: split.yearMax,
     docTitles: split.docTitles,
-    country: split.country,
-    region: split.region,
-    advancedJson: Object.keys(advanced).length > 0 ? prettyJson(advanced) : '',
+    facetValues: split.facetValues,
+    ranges: split.ranges,
+    extraFilters: split.rest,
+    extraInput: restTop,
     tags: (testCase.tags || []).join(', '),
     notes: testCase.notes || '',
   };
 };
 
-const parseAdvanced = (json: string): JsonObject => {
-  if (!json.trim()) return {};
-  const parsed = JSON.parse(json);
-  if (isPlainObject(parsed)) return parsed;
-  throw new Error('Filters/params JSON must be an object');
-};
-
-// Merge the builder-owned filter fields onto any `filters` from advanced JSON.
-const buildFilters = (draft: CaseDraft, advFilters: unknown): JsonObject => {
-  const base: JsonObject = isPlainObject(advFilters) ? { ...advFilters } : {};
-  if (draft.yearMin.trim() !== '') base.published_year_min = Number(draft.yearMin);
-  if (draft.yearMax.trim() !== '') base.published_year_max = Number(draft.yearMax);
+// Merge the builder-owned filter fields onto the carried-through extras.
+const buildFilters = (draft: CaseDraft): JsonObject => {
+  const base: JsonObject = { ...draft.extraFilters };
   if (draft.docTitles.length > 0) base.doc_titles = draft.docTitles;
-  if (draft.country.length > 0) base.country = draft.country;
-  if (draft.region.length > 0) base.region = draft.region;
+  Object.entries(draft.facetValues).forEach(([field, values]) => {
+    if (values.length > 0) base[field] = values;
+  });
+  Object.entries(draft.ranges).forEach(([field, range]) => {
+    if (range.min.trim() !== '') base[`${field}_min`] = Number(range.min);
+    if (range.max.trim() !== '') base[`${field}_max`] = Number(range.max);
+  });
   return base;
 };
 
 export const draftToPayload = (draft: CaseDraft): CasePayload => {
-  const { filters: advFilters, ...advRest } = parseAdvanced(draft.advancedJson);
-  const mergedFilters = buildFilters(draft, advFilters);
-  const input: JsonObject = { query: draft.query, ...advRest };
+  const mergedFilters = buildFilters(draft);
+  const input: JsonObject = { query: draft.query, ...draft.extraInput };
   if (Object.keys(mergedFilters).length > 0) input.filters = mergedFilters;
   const tags = draft.tags
     .split(',')
@@ -160,11 +199,52 @@ export const draftToPayload = (draft: CaseDraft): CasePayload => {
 };
 
 /* ------------------------------------------------------------------ */
+/*  Filter field inputs                                               */
+/* ------------------------------------------------------------------ */
+
+interface RangeFieldInputProps {
+  field: string;
+  label: string;
+  range: RangeDraft;
+  bounds?: RangeInfo;
+  onChange: (field: string, range: RangeDraft) => void;
+}
+
+const RangeFieldInput: React.FC<RangeFieldInputProps> = ({
+  field,
+  label,
+  range,
+  bounds,
+  onChange,
+}) => (
+  <div className="form-group">
+    <label>{label} (optional)</label>
+    <div className="testing-range-inputs">
+      <input
+        type="number"
+        aria-label={`${label} from`}
+        value={range.min}
+        onChange={(e) => onChange(field, { ...range, min: e.target.value })}
+        placeholder={bounds ? String(bounds.min) : 'From'}
+      />
+      <span className="text-muted">–</span>
+      <input
+        type="number"
+        aria-label={`${label} to`}
+        value={range.max}
+        onChange={(e) => onChange(field, { ...range, max: e.target.value })}
+        placeholder={bounds ? String(bounds.max) : 'To'}
+      />
+    </div>
+  </div>
+);
+
+/* ------------------------------------------------------------------ */
 /*  Editor form (inputs only — assertions live on experiments)        */
 /* ------------------------------------------------------------------ */
 
 interface CaseEditorProps {
-  initial: CaseDraft;
+  initialCase: TestCase | null;
   dataSource: string;
   saving: boolean;
   submitLabel: string;
@@ -173,54 +253,79 @@ interface CaseEditorProps {
 }
 
 const CaseEditor: React.FC<CaseEditorProps> = ({
-  initial,
+  initialCase,
   dataSource,
   saving,
   submitLabel,
   onSubmit,
   onCancel,
 }) => {
-  const [draft, setDraft] = useState<CaseDraft>(initial);
-  const [localError, setLocalError] = useState('');
-  const [countryOptions, setCountryOptions] = useState<string[]>([]);
-  const [regionOptions, setRegionOptions] = useState<string[]>([]);
+  const [config, setConfig] = useState<CaseFilterConfig | null>(null);
+  const [facetOptions, setFacetOptions] = useState<Record<string, string[]>>({});
+  const [rangeBounds, setRangeBounds] = useState<Record<string, RangeInfo>>({});
+  const [optionsError, setOptionsError] = useState(false);
+  const [draft, setDraft] = useState<CaseDraft | null>(null);
 
-  // Load the data source's country/region facet values so those filters can be
-  // picked from real options instead of hand-written JSON.
+  // Load the data source's search facets: they define which filter fields the
+  // builder offers (from config.json's filter fields) and their pickable values.
   useEffect(() => {
-    if (!dataSource) return undefined;
+    if (!dataSource) {
+      setConfig(emptyFilterConfig());
+      return undefined;
+    }
     let cancelled = false;
     axios
       .get<Facets>(`${API_BASE_URL}/facets`, { params: { data_source: dataSource } })
       .then((resp) => {
         if (cancelled) return;
-        const facets = resp.data.facets || {};
-        setCountryOptions((facets.country || []).map((f) => f.value));
-        setRegionOptions((facets.region || []).map((f) => f.value));
+        const options: Record<string, string[]> = {};
+        Object.entries(resp.data.facets || {}).forEach(([field, values]) => {
+          options[field] = values.map((f) => f.value);
+        });
+        setFacetOptions(options);
+        setRangeBounds(resp.data.range_fields || {});
+        setConfig(filterConfigFromFacets(resp.data));
       })
       .catch(() => {
-        // Non-fatal: the pickers simply offer no options if facets can't load.
+        // Facets are required to offer pickers; without them the builder still
+        // works through the advanced JSON box, and says so.
+        if (cancelled) return;
+        setOptionsError(true);
+        setConfig(emptyFilterConfig());
       });
     return () => {
       cancelled = true;
     };
   }, [dataSource]);
 
-  const update = (patch: Partial<CaseDraft>) => setDraft((d) => ({ ...d, ...patch }));
+  // The filter split depends on the loaded config, so the draft is initialised
+  // once the facets request settles.
+  useEffect(() => {
+    if (config === null) return;
+    setDraft((d) => d ?? (initialCase ? caseToDraft(initialCase, config) : emptyDraft()));
+  }, [config, initialCase]);
 
-  const handleSubmit = () => {
-    setLocalError('');
-    try {
-      onSubmit(draftToPayload(draft));
-    } catch (err: any) {
-      setLocalError(err.message || 'Invalid JSON in filters/params');
-    }
-  };
+  if (config === null || draft === null) {
+    return <div className="testing-case-editor text-muted">Loading filter options…</div>;
+  }
+
+  const update = (patch: Partial<CaseDraft>) => setDraft((d) => d && { ...d, ...patch });
+
+  const updateFacetValues = (field: string, values: string[]) =>
+    update({ facetValues: { ...draft.facetValues, [field]: values } });
+
+  const updateRange = (field: string, range: RangeDraft) =>
+    update({ ranges: { ...draft.ranges, [field]: range } });
+
+  const handleSubmit = () => onSubmit(draftToPayload(draft));
+
+  // Carried-through keys the builder does not own (e.g. `params` or filter
+  // fields the config doesn't declare), shown read-only so nothing is hidden.
+  const extras: JsonObject = { ...draft.extraInput };
+  if (Object.keys(draft.extraFilters).length > 0) extras.filters = draft.extraFilters;
 
   return (
     <div className="testing-case-editor">
-      {localError && <div className="auth-error">{localError}</div>}
-
       <div className="form-group">
         <label htmlFor="case-query">Query</label>
         <input
@@ -232,75 +337,70 @@ const CaseEditor: React.FC<CaseEditorProps> = ({
         />
       </div>
 
-      <div className="form-group">
-        <label>Documents (optional)</label>
-        <DocumentTitleSelect
-          dataSource={dataSource}
-          value={draft.docTitles}
-          onChange={(docTitles) => update({ docTitles })}
-        />
-        <small className="text-muted">
-          Restrict the case to specific documents by their exact UI title.
-        </small>
-      </div>
+      {optionsError && (
+        <p className="text-muted">
+          Couldn&apos;t load the data source&apos;s filter fields — the case&apos;s
+          existing filters are kept, but cannot be edited here.
+        </p>
+      )}
 
-      {(countryOptions.length > 0 || draft.country.length > 0) && (
+      {config.titleLabel && (
         <div className="form-group">
-          <label>Country (optional)</label>
-          <FacetMultiSelect
-            options={countryOptions}
-            value={draft.country}
-            onChange={(country) => update({ country })}
-            placeholder="Type to filter countries…"
+          <label>{config.titleLabel} (optional)</label>
+          <DocumentTitleSelect
+            dataSource={dataSource}
+            value={draft.docTitles}
+            onChange={(docTitles) => update({ docTitles })}
           />
+          <small className="text-muted">
+            Restrict the case to specific documents by their exact UI title.
+          </small>
         </div>
       )}
 
-      {(regionOptions.length > 0 || draft.region.length > 0) && (
+      {Object.entries(config.facetFields).map(([field, label]) => {
+        const options = facetOptions[field] || [];
+        const selected = draft.facetValues[field] || [];
+        if (options.length === 0 && selected.length === 0) return null;
+        return (
+          <div className="form-group" key={field}>
+            <label>{label} (optional)</label>
+            <FacetMultiSelect
+              options={options}
+              value={selected}
+              onChange={(values) => updateFacetValues(field, values)}
+              placeholder={`Type to filter ${label.toLowerCase()}…`}
+            />
+          </div>
+        );
+      })}
+
+      {Object.entries(config.rangeFields).map(([field, label]) => (
+        <RangeFieldInput
+          key={field}
+          field={field}
+          label={label}
+          range={draft.ranges[field] || { min: '', max: '' }}
+          bounds={rangeBounds[field]}
+          onChange={updateRange}
+        />
+      ))}
+
+      {Object.keys(extras).length > 0 && (
         <div className="form-group">
-          <label>Region (optional)</label>
-          <FacetMultiSelect
-            options={regionOptions}
-            value={draft.region}
-            onChange={(region) => update({ region })}
-            placeholder="Type to filter regions…"
+          <label htmlFor="case-extra">Other filters / params (read-only)</label>
+          <textarea
+            id="case-extra"
+            className="testing-json-textarea"
+            value={prettyJson(extras)}
+            readOnly
+            rows={4}
           />
+          <small className="text-muted">
+            Set via CSV import or the API; kept unchanged when saving.
+          </small>
         </div>
       )}
-
-      <div className="form-group">
-        <label>Publication year (optional)</label>
-        <div className="testing-year-range">
-          <input
-            type="number"
-            aria-label="Published year from"
-            value={draft.yearMin}
-            onChange={(e) => update({ yearMin: e.target.value })}
-            placeholder="From"
-          />
-          <span className="text-muted">–</span>
-          <input
-            type="number"
-            aria-label="Published year to"
-            value={draft.yearMax}
-            onChange={(e) => update({ yearMax: e.target.value })}
-            placeholder="To"
-          />
-        </div>
-      </div>
-
-      <details className="form-group testing-advanced-filters">
-        <summary className="testing-raw-toggle">Advanced filters / params (JSON)</summary>
-        <textarea
-          id="case-extra"
-          className="testing-json-textarea"
-          value={draft.advancedJson}
-          onChange={(e) => update({ advancedJson: e.target.value })}
-          placeholder={'{\n  "filters": { "country": "Kenya" },\n  "params": {}\n}'}
-          rows={5}
-        />
-        <FilterHelp />
-      </details>
 
       <div className="form-group">
         <label htmlFor="case-tags">Tags (comma separated)</label>

--- a/ui/frontend/src/components/admin/testing/DatasetEditor.tsx
+++ b/ui/frontend/src/components/admin/testing/DatasetEditor.tsx
@@ -4,11 +4,7 @@ import * as XLSX from 'xlsx-js-style';
 import API_BASE_URL from '../../../config';
 import type { TestCase, TestDataset } from '../../../types/testing';
 import ConfirmModal from '../ConfirmModal';
-import CaseEditor, {
-  CasePayload,
-  caseToDraft,
-  emptyDraft,
-} from './CaseEditor';
+import CaseEditor, { CasePayload } from './CaseEditor';
 import { SAMPLE_DATASET_CSV } from './csv';
 
 /* ------------------------------------------------------------------ */
@@ -291,7 +287,7 @@ const DatasetEditor: React.FC<DatasetEditorProps> = ({ dataset, onBack }) => {
         {creating && (
           <div className="testing-case-editor-wrap">
             <CaseEditor
-              initial={emptyDraft()}
+              initialCase={null}
               dataSource={dataset.data_source}
               saving={saving}
               submitLabel="Create Case"
@@ -304,7 +300,8 @@ const DatasetEditor: React.FC<DatasetEditorProps> = ({ dataset, onBack }) => {
         {editingCase && (
           <div className="testing-case-editor-wrap">
             <CaseEditor
-              initial={caseToDraft(editingCase)}
+              key={editingCase.id}
+              initialCase={editingCase}
               dataSource={dataset.data_source}
               saving={saving}
               submitLabel="Save Case"

--- a/ui/frontend/src/components/admin/testing/FilterHelp.tsx
+++ b/ui/frontend/src/components/admin/testing/FilterHelp.tsx
@@ -1,26 +1,32 @@
 import React from 'react';
 
 /**
- * Collapsible help explaining how to format a test case's search filters.
- *
- * Shared by the manual case editor and the "Create Dataset + Experiment" upload
- * modal so both entry points describe the same filter contract. Rendered as a
- * native <details> disclosure (the app has no dedicated tooltip component).
+ * Collapsible help explaining how to format the `filters` column of a case
+ * CSV upload. Manual case entry needs no JSON — the case editor builds its
+ * filter controls from the data source's configured search filter fields.
+ * Rendered as a native <details> disclosure (the app has no dedicated tooltip
+ * component).
  */
 const FilterHelp: React.FC = () => (
   <details className="testing-filter-help">
-    <summary className="testing-raw-toggle">ⓘ How do filters work?</summary>
+    <summary className="testing-raw-toggle">ⓘ How do CSV filters work?</summary>
     <div className="text-muted testing-filter-help-body">
       <p style={{ margin: '0.4rem 0' }}>
-        Filters restrict which documents a case searches. In JSON they live under
-        a <code>filters</code> key, e.g.
-        {' '}
-        <code>{'{ "filters": { … }, "params": { … } }'}</code>.
+        The optional <code>filters</code> column restricts which documents a
+        case searches, using the same filter fields the search page offers for
+        the data source (they come from the data source&apos;s configuration).
+        The cell holds a JSON object:
       </p>
       <ul style={{ margin: '0.4rem 0 0', paddingLeft: '1.1rem' }}>
         <li>
-          <strong>Publication year</strong> — <code>published_year_min</code> and{' '}
-          <code>published_year_max</code> (numbers), e.g.
+          <strong>Facet fields</strong> — lists of values keyed by the field
+          name, e.g.
+          {' '}
+          <code>{'"country": ["Kenya"]'}</code>.
+        </li>
+        <li>
+          <strong>Range fields</strong> — <code>{'<field>_min'}</code> /{' '}
+          <code>{'<field>_max'}</code> (numbers), e.g.
           {' '}
           <code>{'"published_year_min": 2018'}</code>.
         </li>
@@ -29,25 +35,10 @@ const FilterHelp: React.FC = () => (
           exact document titles <em>as they appear in the UI</em>, e.g.
           {' '}
           <code>{'"doc_titles": ["Evaluation of X", "Annual Report 2021"]'}</code>.
-          Titles are matched exactly (case-insensitive); use the document picker
-          above to avoid typos.
-        </li>
-        <li>
-          <strong>Country / region</strong> — <code>country</code> and{' '}
-          <code>region</code> as lists of values, e.g.
-          {' '}
-          <code>{'"country": ["Kenya"], "region": ["Asia and the Pacific"]'}</code>.
-          Use the pickers above to choose from the data source's values.
-        </li>
-        <li>
-          <strong>Other fields</strong> — e.g. <code>organization</code>,{' '}
-          <code>document_type</code> as string values.
+          Titles are matched exactly (case-insensitive). A value that matches no
+          document yields zero results for the case, never an unfiltered run.
         </li>
       </ul>
-      <p style={{ margin: '0.4rem 0 0' }}>
-        Use a separate <code>params</code> key for search behaviour (e.g.{' '}
-        <code>rerank</code>, <code>limit</code>), not for document filtering.
-      </p>
     </div>
   </details>
 );

--- a/ui/frontend/src/tests/caseEditorDraft.test.ts
+++ b/ui/frontend/src/tests/caseEditorDraft.test.ts
@@ -1,19 +1,57 @@
 import {
+  CaseFilterConfig,
   caseToDraft,
   draftToPayload,
   emptyDraft,
+  emptyFilterConfig,
+  filterConfigFromFacets,
 } from '../components/admin/testing/CaseEditor';
+import type { Facets } from '../types/api';
 import type { TestCase } from '../types/testing';
 
 jest.mock('../config', () => ({ __esModule: true, default: '/api' }));
 
 const REGION = 'Asia and the Pacific';
+const YEAR_LABEL = 'Year Published';
+const TITLE_LABEL = 'Document Title';
+
+// A WFP-like config-driven filter field set (mirrors default_filter_fields).
+const CONFIG: CaseFilterConfig = {
+  facetFields: {
+    src_evaluation_category: 'Evaluation Category',
+    document_type: 'Document Type',
+    region: 'Region',
+    country: 'Country',
+    language: 'Language',
+  },
+  rangeFields: { published_year: YEAR_LABEL },
+  titleLabel: TITLE_LABEL,
+};
 
 const makeCase = (input: Record<string, unknown>, extra: Partial<TestCase> = {}): TestCase =>
   ({ id: 'c1', input, ...extra } as TestCase);
 
+describe('filterConfigFromFacets', () => {
+  test('splits facet, range and title fields like the search panel', () => {
+    const facets: Facets = {
+      facets: {},
+      filter_fields: {
+        title: TITLE_LABEL,
+        country: 'Country',
+        published_year: YEAR_LABEL,
+      },
+      range_fields: { published_year: { min: 2000, max: 2024 } },
+    };
+    expect(filterConfigFromFacets(facets)).toEqual({
+      facetFields: { country: 'Country' },
+      rangeFields: { published_year: YEAR_LABEL },
+      titleLabel: TITLE_LABEL,
+    });
+  });
+});
+
 describe('caseToDraft', () => {
-  test('splits year range and doc_titles out of the filters object', () => {
+  test('splits config-declared fields out of the filters object', () => {
     const draft = caseToDraft(
       makeCase(
         {
@@ -22,22 +60,22 @@ describe('caseToDraft', () => {
             published_year_min: 2018,
             published_year_max: 2022,
             doc_titles: ['Report A'],
-            country: 'Kenya',
+            src_evaluation_category: ['Centralized'],
+            organization: 'WFP',
           },
           params: { rerank: true },
         },
         { tags: ['smoke'], notes: 'n' },
       ),
+      CONFIG,
     );
     expect(draft.query).toBe('girls education');
-    expect(draft.yearMin).toBe('2018');
-    expect(draft.yearMax).toBe('2022');
+    expect(draft.ranges).toEqual({ published_year: { min: '2018', max: '2022' } });
     expect(draft.docTitles).toEqual(['Report A']);
-    // Remaining filter keys + params round-trip through the advanced JSON box.
-    expect(JSON.parse(draft.advancedJson)).toEqual({
-      filters: { country: 'Kenya' },
-      params: { rerank: true },
-    });
+    expect(draft.facetValues).toEqual({ src_evaluation_category: ['Centralized'] });
+    // Keys the config does not declare are carried through unchanged.
+    expect(draft.extraFilters).toEqual({ organization: 'WFP' });
+    expect(draft.extraInput).toEqual({ params: { rerank: true } });
     expect(draft.tags).toBe('smoke');
     expect(draft.notes).toBe('n');
   });
@@ -48,27 +86,41 @@ describe('caseToDraft', () => {
         query: 'q',
         filters: { country: ['Kenya', 'Uganda'], region: [REGION] },
       }),
+      CONFIG,
     );
-    expect(draft.country).toEqual(['Kenya', 'Uganda']);
-    expect(draft.region).toEqual([REGION]);
-    expect(draft.advancedJson).toBe('');
+    expect(draft.facetValues).toEqual({ country: ['Kenya', 'Uganda'], region: [REGION] });
+    expect(draft.extraFilters).toEqual({});
+    expect(draft.extraInput).toEqual({});
   });
 
-  test('leaves advanced JSON empty when input is only a query', () => {
-    const draft = caseToDraft(makeCase({ query: 'q' }));
+  test('keeps every filter as an extra when the config declares no fields', () => {
+    const filters = { country: ['Kenya'], doc_titles: ['Report A'] };
+    const draft = caseToDraft(makeCase({ query: 'q', filters }), emptyFilterConfig());
+    expect(draft.facetValues).toEqual({});
+    expect(draft.docTitles).toEqual([]);
+    expect(draft.extraFilters).toEqual(filters);
+  });
+
+  test('leaves extras empty when input is only a query', () => {
+    const draft = caseToDraft(makeCase({ query: 'q' }), CONFIG);
     expect(draft).toMatchObject({
       query: 'q',
-      yearMin: '',
-      yearMax: '',
       docTitles: [],
-      advancedJson: '',
+      facetValues: {},
+      ranges: {},
+      extraFilters: {},
+      extraInput: {},
     });
   });
 
-  test('keeps a non-list doc_titles value in advanced JSON', () => {
-    const draft = caseToDraft(makeCase({ query: 'q', filters: { doc_titles: 'not-a-list' } }));
+  test('keeps a non-list filter value as an extra', () => {
+    const draft = caseToDraft(
+      makeCase({ query: 'q', filters: { doc_titles: 'not-a-list', country: 'Kenya' } }),
+      CONFIG,
+    );
     expect(draft.docTitles).toEqual([]);
-    expect(JSON.parse(draft.advancedJson)).toEqual({ filters: { doc_titles: 'not-a-list' } });
+    expect(draft.facetValues).toEqual({});
+    expect(draft.extraFilters).toEqual({ doc_titles: 'not-a-list', country: 'Kenya' });
   });
 });
 
@@ -77,8 +129,7 @@ describe('draftToPayload', () => {
     const payload = draftToPayload({
       ...emptyDraft(),
       query: 'q',
-      yearMin: '2018',
-      yearMax: '2022',
+      ranges: { published_year: { min: '2018', max: '2022' } },
       docTitles: ['Report A'],
     });
     expect(payload.input).toEqual({
@@ -97,12 +148,11 @@ describe('draftToPayload', () => {
     expect(payload.tags).toBeUndefined();
   });
 
-  test('merges country and region lists into filters', () => {
+  test('merges facet value lists into filters', () => {
     const payload = draftToPayload({
       ...emptyDraft(),
       query: 'q',
-      country: ['Kenya'],
-      region: [REGION],
+      facetValues: { country: ['Kenya'], region: [REGION], language: [] },
     });
     expect(payload.input).toEqual({
       query: 'q',
@@ -110,25 +160,20 @@ describe('draftToPayload', () => {
     });
   });
 
-  test('merges advanced filters with builder fields (builder wins on year/docs)', () => {
+  test('merges extras with builder fields (builder wins on its keys)', () => {
     const payload = draftToPayload({
       ...emptyDraft(),
       query: 'q',
-      yearMin: '2020',
+      ranges: { published_year: { min: '2020', max: '' } },
       docTitles: ['B'],
-      advancedJson: JSON.stringify({ filters: { country: 'Kenya' }, params: { limit: 10 } }),
+      extraFilters: { country: 'Kenya' },
+      extraInput: { params: { limit: 10 } },
     });
     expect(payload.input).toEqual({
       query: 'q',
       params: { limit: 10 },
       filters: { country: 'Kenya', published_year_min: 2020, doc_titles: ['B'] },
     });
-  });
-
-  test('throws when advanced JSON is not an object', () => {
-    expect(() =>
-      draftToPayload({ ...emptyDraft(), query: 'q', advancedJson: '[1, 2]' }),
-    ).toThrow(/must be an object/);
   });
 });
 
@@ -141,14 +186,25 @@ describe('caseToDraft -> draftToPayload round-trip', () => {
         doc_titles: ['A', 'B'],
         country: ['Kenya'],
         region: [REGION],
+        src_evaluation_category: ['Centralized'],
+        organization: 'WFP',
       },
       params: { rerank: true },
     };
     const payload = draftToPayload(
-      caseToDraft(makeCase(input, { tags: ['t'], notes: 'n' })),
+      caseToDraft(makeCase(input, { tags: ['t'], notes: 'n' }), CONFIG),
     );
     expect(payload.input).toEqual(input);
     expect(payload.tags).toEqual(['t']);
     expect(payload.notes).toBe('n');
+  });
+
+  test('preserves filters untouched when the config declares no fields', () => {
+    const input = {
+      query: 'q',
+      filters: { country: ['Kenya'], doc_titles: ['A'] },
+    };
+    const payload = draftToPayload(caseToDraft(makeCase(input), emptyFilterConfig()));
+    expect(payload.input).toEqual(input);
   });
 });

--- a/ui/frontend/src/tests/caseEditorForm.test.tsx
+++ b/ui/frontend/src/tests/caseEditorForm.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+
+jest.mock('../config', () => ({ __esModule: true, default: '/api' }));
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+import CaseEditor from '../components/admin/testing/CaseEditor';
+import type { TestCase } from '../types/testing';
+
+// A config-driven facet response, as the /facets endpoint builds it from the
+// data source's filter fields in config.json.
+const FACETS = {
+  facets: {
+    src_evaluation_category: [
+      { value: 'Centralized', count: 3 },
+      { value: 'Decentralized', count: 5 },
+    ],
+    country: [{ value: 'Kenya', count: 4 }],
+    language: [{ value: 'English', count: 9 }],
+    published_year: [
+      { value: '2020', count: 2 },
+      { value: '2021', count: 7 },
+    ],
+  },
+  filter_fields: {
+    title: 'Document Title',
+    src_evaluation_category: 'Evaluation Category',
+    published_year: 'Year Published',
+    country: 'Country',
+    language: 'Language',
+  },
+  range_fields: {},
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedAxios.get.mockImplementation((url: string) => {
+    if (url.includes('/facets')) return Promise.resolve({ data: FACETS });
+    return Promise.resolve({ data: {} });
+  });
+});
+
+const COUNTRY_FIELD = 'Country (optional)';
+const SUBMIT = 'Create Case';
+const EXTRAS_LABEL = 'Other filters / params (read-only)';
+const EDIT_QUERY = 'school feeding';
+
+const renderEditor = (initialCase: TestCase | null = null) => {
+  const onSubmit = jest.fn();
+  render(
+    <CaseEditor
+      initialCase={initialCase}
+      dataSource="wfp"
+      saving={false}
+      submitLabel={SUBMIT}
+      onSubmit={onSubmit}
+      onCancel={jest.fn()}
+    />,
+  );
+  return onSubmit;
+};
+
+describe('CaseEditor', () => {
+  test('renders one picker per config-declared filter field', async () => {
+    renderEditor();
+    await waitFor(() => screen.getByText('Document Title (optional)'));
+    expect(screen.getByText('Evaluation Category (optional)')).toBeInTheDocument();
+    expect(screen.getByText('Year Published (optional)')).toBeInTheDocument();
+    expect(screen.getByText(COUNTRY_FIELD)).toBeInTheDocument();
+    expect(screen.getByText('Language (optional)')).toBeInTheDocument();
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('/facets'),
+      expect.objectContaining({ params: { data_source: 'wfp' } }),
+    );
+  });
+
+  test('omits fields the config does not declare', async () => {
+    renderEditor();
+    await waitFor(() => screen.getByText(COUNTRY_FIELD));
+    expect(screen.queryByText('Region (optional)')).not.toBeInTheDocument();
+  });
+
+  test('selecting a facet value submits it under the field key', async () => {
+    const onSubmit = renderEditor();
+    await waitFor(() => screen.getByText('Evaluation Category (optional)'));
+    const picker = screen.getByPlaceholderText('Type to filter evaluation category…');
+    fireEvent.change(picker, { target: { value: 'Centr' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Centralized' }));
+    fireEvent.change(screen.getByLabelText('Query'), { target: { value: 'q' } });
+    fireEvent.click(screen.getByRole('button', { name: SUBMIT }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      input: { query: 'q', filters: { src_evaluation_category: ['Centralized'] } },
+      tags: undefined,
+      notes: undefined,
+    });
+  });
+
+  test('loads an existing case and preserves keys the builder does not own', async () => {
+    const onSubmit = renderEditor({
+      id: 'c1',
+      input: {
+        query: EDIT_QUERY,
+        filters: { country: ['Kenya'], organization: 'WFP' },
+        params: { rerank: true },
+      },
+    } as TestCase);
+    await waitFor(() => screen.getByText(COUNTRY_FIELD));
+    expect(screen.getByDisplayValue(EDIT_QUERY)).toBeInTheDocument();
+    expect(screen.getByText('Kenya')).toBeInTheDocument();
+    // Keys the config does not declare are shown read-only and kept on save.
+    const extras = screen.getByLabelText(EXTRAS_LABEL) as HTMLTextAreaElement;
+    expect(extras).toHaveAttribute('readOnly');
+    expect(JSON.parse(extras.value)).toEqual({
+      params: { rerank: true },
+      filters: { organization: 'WFP' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: SUBMIT }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      input: {
+        query: EDIT_QUERY,
+        params: { rerank: true },
+        filters: { organization: 'WFP', country: ['Kenya'] },
+      },
+      tags: undefined,
+      notes: undefined,
+    });
+  });
+
+  test('omits the read-only extras block when the builder owns every key', async () => {
+    renderEditor();
+    await waitFor(() => screen.getByText(COUNTRY_FIELD));
+    expect(screen.queryByLabelText(EXTRAS_LABEL)).not.toBeInTheDocument();
+  });
+
+  test('keeps existing filters untouched when facets cannot load', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('boom'));
+    const onSubmit = renderEditor({
+      id: 'c1',
+      input: { query: 'q', filters: { country: ['Kenya'] } },
+    } as TestCase);
+    await waitFor(() =>
+      screen.getByText(/Couldn't load the data source's filter fields/),
+    );
+    expect(screen.queryByText(COUNTRY_FIELD)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: SUBMIT }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      input: { query: 'q', filters: { country: ['Kenya'] } },
+      tags: undefined,
+      notes: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Description

The eval case builder hardcoded four filters (`doc_titles`, country, region, publication year) while regular search builds its filter panel from the datasource's `default_filter_fields` + taxonomy fields in `config.json`. This PR makes `config.json` the single place that defines filters for **both** surfaces:

- **Config-driven case builder** — `CaseEditor` now derives its controls from the same `/facets` response the search panel uses: the `title` field becomes the document picker (stored as `doc_titles`), fields with range info become min/max inputs, and every other declared field (incl. `src_*` and taxonomy `tag_*`) a facet-value multiselect. Add/remove a field in `config.json` and both search and eval follow, no code change.
- **Harness parity with `/search`** — `resolve_doc_level_filters()` now also resolves `language` (names normalised to ISO codes) and the config-declared `src_*` fields to `doc_id` constraints, alongside `doc_titles`/`region`. Previously those fields were silently misapplied against chunk payloads when set on an eval case. No-match values still pin the no-match sentinel (zero results, never an unfiltered run).
- **Advanced JSON box retired** — keys the builder does not own (`params`, undeclared filter fields from CSV import or the API) are carried through unchanged on save and shown read-only, so editing a case never drops them. `FilterHelp` now serves only the CSV upload modal and documents the actual cell format.
- Docs updated (`docs/admin/evaluation.md`).

## Type of Change
- [x] Bug fix

## Testing
- [x] Tests pass locally — backend: 30 resolver unit tests (`tests/unit/test_harness_doc_filters.py`); frontend: full suite 663 passing incl. rewritten `caseEditorDraft` conversion tests and new `caseEditorForm` render tests
- [x] New tests added for new functionality
- [x] Manual testing completed — `/facets` verified config-driven for the WFP source; resolver exercised read-only against a live DB (language → doc_ids, `src_evaluation_category` → doc_ids, unknown value → sentinel)

## Checklist
- [x] Code follows project style guidelines (pre-commit hooks pass: black, isort, flake8, mypy, bandit, code-metrics; eslint/tsc clean)
- [x] Self-review of code completed
- [x] Documentation updated
- [x] No breaking changes — existing case filters (incl. `published_year_min/max`) round-trip untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)