### PR TITLE
build(deps): bump langchain family to coherent latest set

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,12 +69,12 @@ asyncpg==0.31.0
 aiosmtplib==5.1.0
 
 # LangChain and LLM integration
-langchain==1.2.10
-langchain-core==1.2.19
-langchain-community==0.4.1
-langchain-huggingface==1.2.0
-langchain-openai==1.1.10
-langchain-anthropic==1.3.3
+langchain==1.3.18
+langchain-core==1.6.1
+langchain-community==0.4.2
+langchain-huggingface==1.2.2
+langchain-openai==1.6.0
+langchain-anthropic==1.7.0
 langchain-google-vertexai>=3.0.0,<4.0.0
 
 # Google Cloud AI Platform (Vertex AI)
@@ -87,8 +87,8 @@ google-cloud-discoveryengine>=0.13.0
 # langgraph.runtime which the matching langgraph version does not expose,
 # breaking CI. Keep these in lockstep with the working runtime versions.
 deepagents>=0.4.0
-langgraph==1.0.10
-langgraph-prebuilt==1.0.8
+langgraph==1.2.11
+langgraph-prebuilt==1.1.0
 langgraph-checkpoint-postgres>=2.0.25
 
 # Task queue

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ aiosmtplib==5.1.0
 # LangChain and LLM integration
 langchain==1.3.18
 langchain-core==1.6.1
-langchain-community==0.4.2
+langchain-community==0.4.1
 langchain-huggingface==1.2.2
 langchain-openai==1.6.0
 langchain-anthropic==1.7.0


### PR DESCRIPTION
Supersedes #430, which cannot pass CI individually: the langchain-family packages are mutually pinned, so single-package bumps are unresolvable. This bumps langchain 1.2.10→1.3.18, langchain-core 1.2.19→1.6.1, langchain-huggingface 1.2.0→1.2.2, langchain-openai 1.1.10→1.6.0, langchain-anthropic 1.3.3→1.7.0, langgraph 1.0.10→1.2.11, langgraph-prebuilt 1.0.8→1.1.0 as one coherent set. langchain-community stays at 0.4.1 — its bump is tracked separately in #428. Resolution verified locally with pip install --dry-run on Python 3.11.