### PR TITLE
fix: extend LLM token-usage tracking to every surface via server-side recording

### DIFF
--- a/a2a_server/task_handler.py
+++ b/a2a_server/task_handler.py
@@ -215,6 +215,7 @@ async def _run_research(
         data_source=data_source,
         deep_research=deep_research,
         model_combo=model_combo,
+        usage_activity_type="a2a-assistant",
     )
 
     parts: List[Any] = [TextPart(text=response.answer)]
@@ -267,9 +268,10 @@ async def _run_research_streaming(
     answer_text = ""
     sources: List[Dict[str, Any]] = []
     token_events: List[str] = []
+    usage: Optional[Dict[str, Any]] = None
 
     async def _consume() -> None:
-        nonlocal answer_text, sources
+        nonlocal answer_text, sources, usage
         async for event in stream_research_response(
             query=query,
             data_source=data_source,
@@ -291,6 +293,8 @@ async def _run_research_streaming(
                 token_events.append(_sse_rpc(rpc_id, chunk_event.model_dump()))
             elif event_type == "sources":
                 sources.extend(event.get("sources", []))
+            elif event_type == "done":
+                usage = event.get("usage")
             elif event_type == "error":
                 raise RuntimeError(event.get("error", "Unknown assistant error"))
 
@@ -301,6 +305,10 @@ async def _run_research_streaming(
             raise RuntimeError(
                 f"Assistant timed out after {_ASSISTANT_TIMEOUT_SECONDS}s"
             )
+
+    from mcp_server.tools.assistant import record_assistant_usage
+
+    record_assistant_usage(usage, query, data_source, deep_research, "a2a-assistant")
 
     for evt in token_events:
         yield evt

--- a/alembic/versions/0032_add_eval_token_usage.py
+++ b/alembic/versions/0032_add_eval_token_usage.py
@@ -1,0 +1,55 @@
+"""Add token-usage and cost columns to test_results.
+
+The evaluation harness makes real LLM calls (AI-summary generation plus one
+LLM-judge call per distinct rubric per case) whose token usage was previously
+invisible. Each evaluated case now persists its combined usage:
+
+- ``prompt_tokens``     : input tokens across the case's summary + judge calls.
+- ``completion_tokens`` : output tokens across the case's summary + judge calls.
+- ``cost_usd``          : cost summed per call from each call's own model rate
+  (6 decimals so sub-cent values stay visible; NULL when no rate is known).
+
+Run-level totals are aggregated into ``test_runs.summary_stats`` (JSONB, no
+schema change) and mirrored into a per-run ``user_activity`` row so the admin
+Token Usage rollup includes evaluation spend.
+
+All columns are nullable with no defaults — historical rows render as "—"
+and no backfill is needed.
+
+Revision ID: 0032_add_eval_token_usage
+Revises: 0031_add_brief_comments
+Create Date: 2026-08-26
+
+Note: the revision ID is intentionally kept under 32 characters to fit the
+stock ``alembic_version.version_num`` column type (``varchar(32)``).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op  # type: ignore[attr-defined]
+
+revision = "0032_add_eval_token_usage"
+down_revision = "0031_add_brief_comments"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "test_results",
+        sa.Column("prompt_tokens", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "test_results",
+        sa.Column("completion_tokens", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "test_results",
+        sa.Column("cost_usd", sa.Numeric(precision=12, scale=6), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("test_results", "cost_usd")
+    op.drop_column("test_results", "completion_tokens")
+    op.drop_column("test_results", "prompt_tokens")

--- a/docs/admin/system-monitoring.md
+++ b/docs/admin/system-monitoring.md
@@ -112,3 +112,33 @@ The Activity panel shows:
 The export includes: Date, User Email, User Name, Query, Results count, Search/Summary/Heatmap timing, AI Summary text, URL, Has Ratings flag, and Search ID.
 
 > **Privacy note:** Activity logging works for both authenticated and anonymous users (anonymous users are tracked by session ID). All activity data is automatically anonymized when a user deletes their account.
+
+### LLM Token Usage (Admin)
+
+The **Admin Panel → Token Usage** tab rolls up LLM token consumption and cost
+from the activity log, bucketed by day / week / month and grouped by user or
+user group, with an optional activity-type filter and XLSX export.
+
+Token usage is recorded **server-side at the source**: the backend writes (or
+accumulates onto) the activity row the moment an LLM call finishes, so every
+token-consuming part of the system is covered — not just calls made from a
+browser tab. Tracked activity types:
+
+| Type | What it covers | Attributed to |
+|------|----------------|---------------|
+| `search` | Search AI summaries, including drill-down summaries (accumulated onto the search's row) | The searching user / session |
+| `assistant-basic` / `assistant-deep-research` | Research assistant turns (all internal agent steps summed) | The chatting user / session |
+| `brief` | One row per brief, accumulating outline generation, per-section deep research, and section edits | The brief's author |
+| `highlight` | Semantic highlighting LLM calls, accumulated per originating search | The viewing user / session |
+| `evaluation` | One row per evaluation run (AI-summary + LLM-judge calls, also visible per run in the Evaluation tab) | The admin who clicked **Run** |
+| `a2a-assistant` | Research assistant calls made through the A2A protocol server (the MCP server directs research to A2A; `mcp-assistant` is reserved for a future MCP research tool) | Anonymous; the caller's API identity is kept in the row's filters |
+| `pipeline` | Ingestion stages (summarization, TOC classification, taxonomy tagging) — one row per document per stage | Anonymous; stage, data source, and document id are kept in the row's filters |
+
+Cost (USD) is computed server-side per call from the pricing table in
+`ui/backend/utils/llm_costs.py`, keyed by the `supported_llms` model key.
+Models without a configured rate (e.g. self-hosted HuggingFace models) show
+token counts with a "—" cost.
+
+> **Not metered:** embedding and reranker calls. Rerankers report no token
+> counts, and the embedding client does not currently expose the provider's
+> usage envelope — both are candidates for a follow-up.

--- a/mcp_server/http_server.py
+++ b/mcp_server/http_server.py
@@ -403,6 +403,14 @@ class MCPApp:
                 try:
                     a2a_auth_info = await verify_mcp_auth(request)
                     a2a_principal = a2a_auth_info.get("user_id")
+                    # Mirror the MCP branch: expose the caller's identity via
+                    # the per-request auth context so token-usage recording
+                    # (mcp_server.tools.assistant.record_assistant_usage)
+                    # attributes A2A spend to the real API identity.
+                    request_auth.set(
+                        a2a_auth_info or {"type": "unknown", "user_id": "unknown"}
+                    )
+                    request_client_ip.set(_get_client_ip(scope))
                 except PermissionError as exc:
                     logger.warning("A2A auth DENIED: %s", exc)
                     body = json.dumps({"detail": str(exc)}).encode()

--- a/mcp_server/tools/assistant.py
+++ b/mcp_server/tools/assistant.py
@@ -26,11 +26,50 @@ _CITATION_GUIDANCE = (
 _ASSISTANT_TIMEOUT_SECONDS = 120
 
 
+def record_assistant_usage(
+    usage: Optional[Dict[str, Any]],
+    query: str,
+    data_source: Optional[str],
+    deep_research: bool,
+    activity_type: str,
+) -> None:
+    """Record an external (MCP/A2A) assistant call's token usage server-side.
+
+    These calls never touch a browser, so the backend writes the activity row
+    directly: anonymous ``user_id``, typed by protocol, with the caller's
+    auth identity (from the per-request auth context, which the HTTP server
+    sets for both the MCP and A2A branches) kept in the filters JSONB.
+
+    Monitoring only: scheduled as a background task and never raises into
+    the tool call (the answer has already been produced).
+    """
+    try:
+        from mcp_server.audit import request_auth
+        from ui.backend.services.usage_recorder import schedule_llm_usage_recording
+
+        auth_info = request_auth.get()
+        schedule_llm_usage_recording(
+            usage=usage,
+            activity_type=activity_type,
+            query=query,
+            server_owned=True,
+            filters_extra={
+                "data_source": data_source,
+                "deep_research": deep_research,
+                "auth_type": auth_info.get("type"),
+                "auth_user_id": str(auth_info.get("user_id", "")),
+            },
+        )
+    except Exception:
+        logger.warning("Failed to record assistant usage", exc_info=True)
+
+
 async def mcp_ask_assistant(
     query: str,
     data_source: Optional[str] = None,
     deep_research: bool = False,
     model_combo: Optional[str] = None,
+    usage_activity_type: str = "mcp-assistant",
 ) -> MCPAssistantResponse:
     """Ask the AI research assistant a question about evaluation documents.
 
@@ -44,6 +83,8 @@ async def mcp_ask_assistant(
         data_source: Data collection to search (e.g. "uneg", "worldbank").
         deep_research: Enable multi-pass deep research mode for complex
             questions (slower but more thorough).
+        usage_activity_type: Activity type the call's token usage is
+            recorded under (the A2A handler passes ``a2a-assistant``).
 
     Returns:
         MCPAssistantResponse with the synthesized answer and sources.
@@ -52,9 +93,10 @@ async def mcp_ask_assistant(
 
     answer_text = ""
     sources: List[Dict[str, Any]] = []
+    usage: Optional[Dict[str, Any]] = None
 
     async def _consume_stream():
-        nonlocal answer_text, sources
+        nonlocal answer_text, sources, usage
         from pipeline.db import UI_MODEL_COMBOS, get_default_model_combo
 
         resolved = model_combo or get_default_model_combo()
@@ -79,6 +121,8 @@ async def mcp_ask_assistant(
                 answer_text += event.get("token", "")
             elif event_type == "sources":
                 sources = event.get("sources", [])
+            elif event_type == "done":
+                usage = event.get("usage")
             elif event_type == "error":
                 error_msg = event.get("error", "Unknown error")
                 raise RuntimeError(f"Assistant error: {error_msg}")
@@ -100,6 +144,9 @@ async def mcp_ask_assistant(
             )
         # Partial answer is still useful — return what we have
 
+    record_assistant_usage(
+        usage, query, data_source, deep_research, usage_activity_type
+    )
     citations, references = await _build_citations_from_sources(sources, data_source)
 
     return MCPAssistantResponse(

--- a/pipeline/orchestrator/worker.py
+++ b/pipeline/orchestrator/worker.py
@@ -383,7 +383,9 @@ def _init_summarizer(
     sum_config = pipeline_config.get("summarize", {}) if pipeline_config else {}
     if not sum_config.get("enabled", True):
         return
-    summarizer = SummarizeProcessor(config=sum_config)
+    summarizer = SummarizeProcessor(
+        config=sum_config, data_source=_worker_context.get("data_source")
+    )
     summarizer.setup(embedding_service=embedding_service)
     _worker_context["summarizer"] = summarizer
 

--- a/pipeline/processors/summarization/summarizer.py
+++ b/pipeline/processors/summarization/summarizer.py
@@ -31,6 +31,7 @@ from pipeline.processors.base import BaseProcessor
 from pipeline.utilities.embedding_service import EmbeddingService
 from pipeline.utilities.llm_retry import invoke_with_retry
 from pipeline.utilities.logging_utils import _log_context
+from pipeline.utilities.usage_recorder import UsageCollector, record_pipeline_usage
 from utils import llm_factory
 from utils.langsmith_util import setup_langsmith_tracing
 
@@ -86,7 +87,7 @@ class SummarizeProcessor(BaseProcessor):
     name = "SummarizeProcessor"
     stage_name = "summarize"
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], data_source: Optional[str] = None):
         """
         Initialize summarizer configuration.
 
@@ -97,9 +98,13 @@ class SummarizeProcessor(BaseProcessor):
                     - llm_workers: Concurrency limit (default 1)
                     - temperature: LLM temperature (default 0.1)
                     - max_tokens: Output token limit
+            data_source: Datasource key, used to attribute recorded LLM
+                token usage (see ``pipeline.utilities.usage_recorder``).
         """
         super().__init__()
         self.config = config
+        self.data_source = data_source
+        self._usage = UsageCollector()
         self._embedding_model = None
         self._hf_token: Optional[str] = None
 
@@ -243,6 +248,9 @@ class SummarizeProcessor(BaseProcessor):
 
         logger.info("Summarizing: %s", title)
 
+        # No reset here: record_pipeline_usage in the finally below drains the
+        # collector, and an explicit reset would drop other documents'
+        # in-flight counts when scripts share one processor across threads.
         try:
             markdown_path = self._find_markdown_file(parsed_folder)
             if not markdown_path:
@@ -261,6 +269,16 @@ class SummarizeProcessor(BaseProcessor):
         except Exception as e:  # pylint: disable=broad-exception-caught
             logger.error("Exception summarizing %s: %s", title, e)
             return self._build_failure(doc, str(e), str(e))
+        finally:
+            # Record whatever the doc consumed — including partial usage from
+            # a failed map-reduce — as one 'pipeline' activity row per model.
+            record_pipeline_usage(
+                self._usage,
+                stage=self.stage_name,
+                data_source=self.data_source,
+                doc_id=str(doc.get("id") or ""),
+                query=f"{self.stage_name}: {title}",
+            )
 
     def _find_markdown_file(self, parsed_folder: str) -> Optional[str]:
         markdown_files = list(Path(parsed_folder).glob("*.md"))
@@ -489,6 +507,9 @@ class SummarizeProcessor(BaseProcessor):
             inference_provider=self.inference_provider if include_inference else None,
         )
         response = invoke_with_retry(llm, [HumanMessage(content=prompt)])
+        # Attribute usage to the configured model key (the pricing-table key),
+        # regardless of whether the call resolved it to a provider model id.
+        self._usage.add_response(response, self.model_key)
         if hasattr(response, "content"):
             return response.content.strip()
         return str(response).strip()

--- a/pipeline/processors/tagging/tagger_base.py
+++ b/pipeline/processors/tagging/tagger_base.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Optional
 
 from fastembed import TextEmbedding
 
+from pipeline.utilities.usage_recorder import UsageCollector
+
 
 class BaseTagger(ABC):
     """Abstract base class for chunk taggers."""
@@ -14,6 +16,13 @@ class BaseTagger(ABC):
 
     def __init__(self, embedding_model: Optional[TextEmbedding] = None):
         self._embedding_model = embedding_model
+        # Shared per-document token-usage accumulator, injected by the
+        # TaggerProcessor so all sub-taggers' LLM calls are cost-tracked.
+        self.usage_collector: Optional[UsageCollector] = None
+
+    def set_usage_collector(self, collector: Optional[UsageCollector]) -> None:
+        """Attach the processor's shared token-usage accumulator."""
+        self.usage_collector = collector
 
     @abstractmethod
     def setup(self) -> None:

--- a/pipeline/processors/tagging/tagger_llm.py
+++ b/pipeline/processors/tagging/tagger_llm.py
@@ -204,8 +204,14 @@ def invoke_and_parse_toc(
     toc_entries: List[Dict[str, Any]],
     locked_labels_by_index: Dict[int, str],
     additional_instruction: Optional[str],
+    usage_collector: Optional[Any] = None,
+    model_key: Optional[str] = None,
 ) -> Optional[Dict[int, str]]:
-    """Invoke the LLM and parse/validate the TOC classification output."""
+    """Invoke the LLM and parse/validate the TOC classification output.
+
+    When *usage_collector* is provided, the response's reported token usage
+    is accumulated under *model_key* for pipeline cost tracking.
+    """
     messages: List[BaseMessage] = [SystemMessage(content=system_prompt)]
     if additional_instruction:
         messages.append(SystemMessage(content=additional_instruction))
@@ -215,6 +221,8 @@ def invoke_and_parse_toc(
         response = invoke_with_retry(llm, messages)
     except Exception:  # pylint: disable=broad-exception-caught
         return None
+    if usage_collector is not None:
+        usage_collector.add_response(response, model_key)
     response_text = str(response.content).strip()
 
     try:
@@ -308,6 +316,7 @@ def call_llm_for_toc(
     llm_config: Dict[str, Any],
     total_pages: Optional[int] = None,
     retry_on_failure: bool = True,
+    usage_collector: Optional[Any] = None,
 ) -> Dict[int, str]:
     """
     Call LLM to label TOC entries. Locked labels are included in the payload
@@ -317,6 +326,9 @@ def call_llm_for_toc(
 
     When the TOC is too large for the context window, entries are split into
     equal batches and each batch is classified independently.
+
+    When *usage_collector* is provided, every LLM call's reported token usage
+    is accumulated under the configured model key for pipeline cost tracking.
     """
     model_key, provider, temperature, max_tokens, inference_provider = (
         resolve_llm_config(llm_config)
@@ -384,6 +396,8 @@ def call_llm_for_toc(
                 if any(e["index"] == k for e in batch)
             },
             additional_instruction=None,
+            usage_collector=usage_collector,
+            model_key=model_key,
         )
         if labels_by_index:
             merged_labels.update(labels_by_index)
@@ -404,6 +418,8 @@ def call_llm_for_toc(
                     "Return valid JSON only. No prose. No markdown. "
                     "Output must be a JSON array."
                 ),
+                usage_collector=usage_collector,
+                model_key=model_key,
             )
             if labels_by_index:
                 merged_labels.update(labels_by_index)

--- a/pipeline/processors/tagging/tagger_processor.py
+++ b/pipeline/processors/tagging/tagger_processor.py
@@ -11,6 +11,7 @@ from pipeline.processors.tagging.tagger_base import BaseTagger
 from pipeline.processors.tagging.tagger_section_type import SectionTypeTagger
 from pipeline.processors.tagging.tagger_taxonomy import TaxonomyTagger
 from pipeline.utilities.embedding_service import EmbeddingService
+from pipeline.utilities.usage_recorder import UsageCollector, record_pipeline_usage
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ class TaggerProcessor(BaseProcessor):
         super().__init__()
         self.data_source = data_source
         self.config = config or {}
+        self._usage = UsageCollector()
         self._database: Optional[Database] = None
         self._pg: Optional[PostgresClient] = None
         self._embedding_model = None
@@ -89,11 +91,24 @@ class TaggerProcessor(BaseProcessor):
             section_type_tagger,
             taxonomy_tagger,
         ]
+        for tagger in self._taggers:
+            tagger.set_usage_collector(self._usage)
 
     def teardown(self) -> None:
         self._embedding_model = None
         self._taggers = []
         super().teardown()
+
+    def _record_doc_usage(self, doc: Dict[str, Any], doc_id: str) -> None:
+        """Flush the shared collector into one 'pipeline' activity row per model."""
+        title = doc.get("map_title") or doc_id
+        record_pipeline_usage(
+            self._usage,
+            stage=self.stage_name,
+            data_source=self.data_source,
+            doc_id=doc_id,
+            query=f"{self.stage_name}: {title}",
+        )
 
     def process_document(self, doc: Dict[str, Any]) -> Dict[str, Any]:
         """Apply all taggers to chunks of a document."""
@@ -110,19 +125,23 @@ class TaggerProcessor(BaseProcessor):
 
         logger.info("Tagging %d chunks for doc %s", len(chunks), doc_id)
 
-        updates_count = 0
-        for chunk_id, chunk_payload in chunks:
-            updates = self._tag_single_chunk(chunk_payload, doc)
-            if updates:
-                self._update_chunk(chunk_id, updates)
-                updates_count += 1
+        try:
+            updates_count = 0
+            for chunk_id, chunk_payload in chunks:
+                updates = self._tag_single_chunk(chunk_payload, doc)
+                if updates:
+                    self._update_chunk(chunk_id, updates)
+                    updates_count += 1
 
-        logger.info(
-            "Updated %d/%d chunks for doc %s", updates_count, len(chunks), doc_id
-        )
+            logger.info(
+                "Updated %d/%d chunks for doc %s", updates_count, len(chunks), doc_id
+            )
 
-        if self._pg is not None:
-            self._update_document_tags(doc, doc_id)
+            if self._pg is not None:
+                self._update_document_tags(doc, doc_id)
+        finally:
+            # Record the doc's LLM usage — including partial usage on failure.
+            self._record_doc_usage(doc, doc_id)
 
         return {
             "success": True,
@@ -204,17 +223,24 @@ class TaggerProcessor(BaseProcessor):
         if section_type_tagger is None:
             return {"success": False, "error": "SectionTypeTagger not found"}
 
-        classifications = section_type_tagger.classify_document_toc(doc)
+        try:
+            classifications = section_type_tagger.classify_document_toc(doc)
 
-        stage_info = make_stage(
-            success=True, sections_count=len(classifications) if classifications else 0
-        )
-        existing_stages = self._get_existing_stages(doc)
-        updated_stages = update_stages(existing_stages, "tag", stage_info)
+            stage_info = make_stage(
+                success=True,
+                sections_count=len(classifications) if classifications else 0,
+            )
+            existing_stages = self._get_existing_stages(doc)
+            updated_stages = update_stages(existing_stages, "tag", stage_info)
 
-        # Taxonomy Tagging
-        if self._pg is not None:
-            self._apply_taxonomy_tags(doc, doc_id)
+            # Taxonomy Tagging
+            if self._pg is not None:
+                self._apply_taxonomy_tags(doc, doc_id)
+        finally:
+            # Record after BOTH the TOC classification and the taxonomy
+            # tagging (which also calls the LLM), so this doc's usage is not
+            # flushed early and misattributed to the next document.
+            self._record_doc_usage(doc, doc_id)
 
         if self._pg is not None:
             try:
@@ -251,12 +277,15 @@ class TaggerProcessor(BaseProcessor):
         if not chunks:
             return {"success": True, "skipped": True, "reason": "No chunks found"}
 
-        updates_count = 0
-        for chunk_id, chunk_payload in chunks:
-            updates = self._tag_single_chunk(chunk_payload, doc)
-            if updates:
-                self._update_chunk(chunk_id, updates)
-                updates_count += 1
+        try:
+            updates_count = 0
+            for chunk_id, chunk_payload in chunks:
+                updates = self._tag_single_chunk(chunk_payload, doc)
+                if updates:
+                    self._update_chunk(chunk_id, updates)
+                    updates_count += 1
+        finally:
+            self._record_doc_usage(doc, doc_id)
 
         logger.info(
             "Tagged %d/%d chunks for doc %s", updates_count, len(chunks), doc_id

--- a/pipeline/processors/tagging/tagger_section_type.py
+++ b/pipeline/processors/tagging/tagger_section_type.py
@@ -214,6 +214,7 @@ class SectionTypeTagger(BaseTagger):
                 llm_config=self.llm_config,
                 total_pages=total_pages,
                 retry_on_failure=True,
+                usage_collector=self.usage_collector,
             )
         else:
             llm_labels_by_index = dict(locked_labels_by_index)

--- a/pipeline/processors/tagging/tagger_taxonomy.py
+++ b/pipeline/processors/tagging/tagger_taxonomy.py
@@ -159,6 +159,8 @@ class TaxonomyTagger(BaseTagger):
 
         try:
             response = invoke_with_retry(llm, messages)
+            if self.usage_collector is not None:
+                self.usage_collector.add_response(response, model_key)
             return self._parse_llm_response(str(response.content))
         except Exception as exc:
             logger.error("LLM call failed for taxonomy: %s", exc)

--- a/pipeline/utilities/usage_recorder.py
+++ b/pipeline/utilities/usage_recorder.py
@@ -1,0 +1,172 @@
+"""LLM token-usage recording for pipeline stages (summarize / tag).
+
+The admin "Token Usage" rollup reads the ``user_activity`` table, which was
+historically only written from the browser — batch ingestion spend was
+invisible. Pipeline stages now accumulate the token usage reported on each
+LangChain response into a :class:`UsageCollector` and, once per document per
+stage, write one anonymous ``user_activity`` row per model used, typed
+``pipeline`` with the stage / data source / document id kept in the filters
+JSONB.
+
+The writer talks straight to the shared Postgres instance (the same
+``POSTGRES_*`` environment the user module uses) with a short-lived psycopg2
+connection — one insert per document per stage, so no pooling is needed.
+Recording is fire-and-forget by design (mirroring the MCP audit log): an
+ingestion run must never fail because usage accounting did, so errors are
+logged and swallowed.
+"""
+
+import json
+import logging
+import threading
+import uuid
+from typing import Any, Dict, List, Optional
+
+from ui.backend.utils.llm_costs import compute_cost
+
+logger = logging.getLogger(__name__)
+
+
+class UsageCollector:
+    """Thread-safe accumulator of per-model token usage for one document.
+
+    ``add_response`` reads the ``usage_metadata`` LangChain attaches to
+    ``AIMessage`` responses (``{input_tokens, output_tokens, ...}``). Chunk
+    summarization fans out over a thread pool, so accumulation is locked.
+
+    Concurrency caveat: when maintenance scripts share ONE processor
+    instance across document-level worker threads, per-document attribution
+    becomes approximate — a flush drains whatever has accumulated so far,
+    which may include another in-flight document's calls. Totals are always
+    preserved (nothing is dropped or double-counted); only the doc_id label
+    of concurrent flushes can be off. The pipeline workers themselves
+    process documents sequentially per processor, where attribution is
+    exact.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._by_model: Dict[str, Dict[str, int]] = {}
+
+    def add_response(self, response: Any, model_key: Optional[str]) -> None:
+        """Accumulate one LLM response's reported usage under *model_key*.
+
+        Monitoring only: called inline from the pipeline's LLM call sites,
+        so a malformed usage payload must never fail the stage — it is
+        logged and skipped instead.
+        """
+        try:
+            meta = getattr(response, "usage_metadata", None)
+            if not isinstance(meta, dict):
+                return
+            prompt = int(meta.get("input_tokens") or 0)
+            completion = int(meta.get("output_tokens") or 0)
+            if not prompt and not completion:
+                return
+            key = model_key or "unknown"
+            with self._lock:
+                totals = self._by_model.setdefault(
+                    key, {"prompt_tokens": 0, "completion_tokens": 0, "calls": 0}
+                )
+                totals["prompt_tokens"] += prompt
+                totals["completion_tokens"] += completion
+                totals["calls"] += 1
+        except Exception:
+            logger.warning("Failed to accumulate LLM usage", exc_info=True)
+
+    def reset(self) -> None:
+        """Drop accumulated usage (start of a new document)."""
+        with self._lock:
+            self._by_model = {}
+
+    def entries(self) -> List[Dict[str, Any]]:
+        """One usage dict per model: ``{llm_model, prompt_tokens, ...}``."""
+        with self._lock:
+            return [
+                {"llm_model": model, **dict(totals)}
+                for model, totals in self._by_model.items()
+            ]
+
+
+def _connect():
+    """Open a short-lived connection to the shared (user-module) database.
+
+    Uses the pipeline's canonical DSN builder so the in-Docker
+    ``localhost`` → ``postgres`` host remap and env-var fallbacks stay in
+    one place.
+    """
+    import psycopg2
+
+    from pipeline.db.postgres_client_base import build_postgres_dsn
+
+    return psycopg2.connect(build_postgres_dsn())
+
+
+_INSERT_SQL = """
+    INSERT INTO user_activity
+        (search_id, query, filters, llm_model,
+         prompt_tokens, completion_tokens, cost_usd)
+    VALUES (%s, %s, %s, %s, %s, %s, %s)
+"""
+
+
+def record_pipeline_usage(
+    collector: UsageCollector,
+    *,
+    stage: str,
+    data_source: Optional[str],
+    doc_id: Optional[str],
+    query: str,
+) -> bool:
+    """Write one ``user_activity`` row per model the collector saw.
+
+    Args:
+        collector: Accumulated usage for one document's stage processing.
+        stage: Pipeline stage name (``summarize``, ``tag``).
+        data_source: Datasource key the document belongs to.
+        doc_id: Document id, kept in the filters JSONB for traceability.
+        query: Row label, e.g. ``"summarize: <title>"``.
+
+    Returns:
+        True when at least one row was written.
+    """
+    try:
+        entries = collector.entries()
+        collector.reset()
+        if not entries:
+            return False
+        conn = _connect()
+        try:
+            with conn.cursor() as cur:
+                for entry in entries:
+                    cost = compute_cost(
+                        entry.get("llm_model"),
+                        entry.get("prompt_tokens"),
+                        entry.get("completion_tokens"),
+                    )
+                    filters = {
+                        "type": "pipeline",
+                        "stage": stage,
+                        "data_source": data_source,
+                        "doc_id": doc_id,
+                        "calls": entry.get("calls"),
+                    }
+                    cur.execute(
+                        _INSERT_SQL,
+                        (
+                            str(uuid.uuid4()),
+                            query[:5000],
+                            json.dumps(filters),
+                            entry.get("llm_model"),
+                            entry.get("prompt_tokens"),
+                            entry.get("completion_tokens"),
+                            cost,
+                        ),
+                    )
+            conn.commit()
+        finally:
+            conn.close()
+        return True
+    except Exception:  # pragma: no cover - defensive: never break the pipeline
+        logger.warning("Failed to record pipeline LLM usage", exc_info=True)
+        return False

--- a/scripts/maintenance/reduce_long_summaries.py
+++ b/scripts/maintenance/reduce_long_summaries.py
@@ -146,6 +146,20 @@ def process_doc_worker(doc_id, doc_data, data_source, wet_run):
 
     except Exception as e:
         thread_logger.error(f"Error processing {doc_id}: {e}")
+    finally:
+        # Flush this document's LLM token usage into the admin usage rollup
+        # (the summarizer only auto-flushes via process_document, which this
+        # script bypasses by calling _llm_summary directly).
+        if global_summarizer is not None:
+            from pipeline.utilities.usage_recorder import record_pipeline_usage
+
+            record_pipeline_usage(
+                global_summarizer._usage,
+                stage="summarize",
+                data_source=data_source,
+                doc_id=str(doc_id),
+                query=f"summarize (reduce): {doc_data.get('map_title', doc_id)}",
+            )
 
 
 def fix_long_summaries(

--- a/tests/unit/test_activity_routes.py
+++ b/tests/unit/test_activity_routes.py
@@ -640,6 +640,49 @@ class TestLogActivityUpsert:
         assert result == "ok"
 
     @pytest.mark.asyncio
+    async def test_update_preserves_server_recorded_usage_when_omitted(self):
+        """Regression: a re-POST without usage (every Brief save) must not
+        null out token counts recorded server-side by the streaming routes."""
+        sid = uuid.uuid4()
+        existing = _make_activity(
+            search_id=sid,
+            llm_model="gpt-4.1-mini",
+            prompt_tokens=1200,
+            completion_tokens=300,
+            cost_usd=Decimal("0.000960"),
+        )
+        body = _brief_body(sid)  # no usage fields
+        session = _fake_session()
+        with patch(
+            "ui.backend.routes.activity._find_existing_activity",
+            new=AsyncMock(return_value=existing),
+        ):
+            await log_activity(body, user=None, session=session)
+        assert existing.llm_model == "gpt-4.1-mini"
+        assert existing.prompt_tokens == 1200
+        assert existing.completion_tokens == 300
+        assert existing.cost_usd == Decimal("0.000960")
+
+    @pytest.mark.asyncio
+    async def test_update_applies_usage_when_provided(self):
+        """A re-POST that does carry usage still overwrites (patch semantics)."""
+        sid = uuid.uuid4()
+        existing = _make_activity(search_id=sid, prompt_tokens=10)
+        body = _brief_body(
+            sid, llm_model="gpt-4.1-mini", prompt_tokens=500, completion_tokens=100
+        )
+        session = _fake_session()
+        with patch(
+            "ui.backend.routes.activity._find_existing_activity",
+            new=AsyncMock(return_value=existing),
+        ):
+            await log_activity(body, user=None, session=session)
+        assert existing.prompt_tokens == 500
+        assert existing.completion_tokens == 100
+        assert existing.llm_model == "gpt-4.1-mini"
+        assert existing.cost_usd is not None
+
+    @pytest.mark.asyncio
     async def test_does_not_blank_summary_when_omitted(self):
         sid = uuid.uuid4()
         existing = _make_activity(search_id=sid, ai_summary="keep me")

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -136,7 +136,7 @@ async def test_datasources_config(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_generate_summary(monkeypatch):
-    async def fake_generate(
+    async def fake_generate_with_usage(
         query: str,
         results: list,
         max_results: int,
@@ -145,7 +145,11 @@ async def test_generate_summary(monkeypatch):
         max_tokens: int | None = None,
         system_prompt_override: str | None = None,
     ):
-        return "summary"
+        return "summary", {
+            "llm_model": "gpt-4.1-mini",
+            "prompt_tokens": 12,
+            "completion_tokens": 3,
+        }
 
     def fake_render(
         query: str,
@@ -156,7 +160,7 @@ async def test_generate_summary(monkeypatch):
         return "prompt"
 
     llm_module = ModuleType("llm_service")
-    llm_module.generate_ai_summary = fake_generate
+    llm_module.generate_ai_summary_with_usage = fake_generate_with_usage
     llm_module.render_prompt = fake_render
     monkeypatch.setitem(sys.modules, "llm_service", llm_module)
 
@@ -171,6 +175,10 @@ async def test_generate_summary(monkeypatch):
     assert response.summary == "summary"
     assert response.prompt == "prompt"
     assert response.results_count == 1
+    # Usage is no longer discarded — it is returned to the caller.
+    assert response.usage is not None
+    assert response.usage.prompt_tokens == 12
+    assert response.usage.completion_tokens == 3
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_brief_outline.py
+++ b/tests/unit/test_brief_outline.py
@@ -82,7 +82,7 @@ class TestGenerateBriefOutline:
         with patch(
             "ui.backend.services.llm_service.get_llm", return_value=fake_llm
         ) as mock_get_llm:
-            title, headings = await generate_brief_outline(
+            title, headings, usage = await generate_brief_outline(
                 question="How effective is anticipatory action for floods?",
                 model_key="some-model",
             )
@@ -97,3 +97,5 @@ class TestGenerateBriefOutline:
         assert title == "Anticipatory Action"
         assert [h["title"] for h in headings] == ["Overview", "Flood programmes"]
         assert [h["level"] for h in headings] == [1, 2]
+        # Usage payload carries the model key (mock reports no token counts).
+        assert usage == {"llm_model": "some-model"}

--- a/tests/unit/test_brief_revise.py
+++ b/tests/unit/test_brief_revise.py
@@ -45,7 +45,7 @@ class TestReviseBriefSection:
         with patch(
             "ui.backend.services.llm_service.get_llm", return_value=fake_llm
         ) as mock_get_llm:
-            result = await revise_brief_section(
+            result, usage = await revise_brief_section(
                 content='Article 53 declares basic education "free and compulsory" [1].',
                 instruction="Make it more concise",
                 model_key="some-model",
@@ -63,12 +63,14 @@ class TestReviseBriefSection:
         assert "&#34;" not in joined
         # Output entities are decoded so the stored markdown is clean.
         assert result == 'The report says "free and compulsory" [1].'
+        # Usage payload carries the model key (mock reports no token counts).
+        assert usage == {"llm_model": "some-model"}
 
     @pytest.mark.asyncio
     async def test_strips_code_fence_from_output(self):
         fake_llm = self._mock_llm("```markdown\nRevised body [1].\n```")
         with patch("ui.backend.services.llm_service.get_llm", return_value=fake_llm):
-            result = await revise_brief_section(
+            result, _usage = await revise_brief_section(
                 content="Body [1].", instruction="tighten", model_key="m"
             )
         assert result == "Revised body [1]."

--- a/tests/unit/test_evaluation_metrics.py
+++ b/tests/unit/test_evaluation_metrics.py
@@ -32,3 +32,37 @@ def test_compute_summary_stats_empty_then_safe_defaults():
 def test_compute_summary_stats_all_pass_then_full_rate():
     stats = compute_summary_stats([{"status": "pass", "score": 1.0}] * 3, 10)
     assert stats["pass_rate"] == 1.0 and stats["mean_score"] == 1.0
+
+
+def test_compute_summary_stats_sums_token_usage_and_cost():
+    results = [
+        {
+            "status": "pass",
+            "score": 1.0,
+            "prompt_tokens": 1000,
+            "completion_tokens": 200,
+            "cost_usd": 0.00072,
+        },
+        {
+            "status": "fail",
+            "score": 0.0,
+            "prompt_tokens": 500,
+            "completion_tokens": 100,
+            "cost_usd": 0.00036,
+        },
+        # Errored case with no LLM usage at all.
+        {"status": "error", "score": None},
+    ]
+    stats = compute_summary_stats(results, 100)
+    assert stats["prompt_tokens"] == 1500
+    assert stats["completion_tokens"] == 300
+    assert stats["total_tokens"] == 1800
+    assert stats["cost_usd"] == pytest.approx(0.00108)
+
+
+def test_compute_summary_stats_when_no_usage_then_zero_tokens_null_cost():
+    stats = compute_summary_stats([{"status": "pass", "score": 1.0}], 10)
+    assert stats["prompt_tokens"] == 0
+    assert stats["completion_tokens"] == 0
+    assert stats["total_tokens"] == 0
+    assert stats["cost_usd"] is None

--- a/tests/unit/test_pipeline_usage_recorder.py
+++ b/tests/unit/test_pipeline_usage_recorder.py
@@ -1,0 +1,141 @@
+"""Tests for pipeline LLM usage collection and recording
+(``pipeline.utilities.usage_recorder``)."""
+
+import json
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pipeline.utilities.usage_recorder import UsageCollector, record_pipeline_usage
+
+pytestmark = pytest.mark.unit
+
+
+def _response(input_tokens=0, output_tokens=0):
+    return SimpleNamespace(
+        usage_metadata={"input_tokens": input_tokens, "output_tokens": output_tokens}
+    )
+
+
+# ---------------------------------------------------------------------------
+# UsageCollector
+# ---------------------------------------------------------------------------
+
+
+class TestUsageCollector:
+    def test_add_response_accumulates_per_model(self):
+        collector = UsageCollector()
+        collector.add_response(_response(100, 20), "gpt-4.1-mini")
+        collector.add_response(_response(50, 10), "gpt-4.1-mini")
+        collector.add_response(_response(7, 3), "gemini-2.0-flash")
+        entries = {e["llm_model"]: e for e in collector.entries()}
+        assert entries["gpt-4.1-mini"] == {
+            "llm_model": "gpt-4.1-mini",
+            "prompt_tokens": 150,
+            "completion_tokens": 30,
+            "calls": 2,
+        }
+        assert entries["gemini-2.0-flash"]["calls"] == 1
+
+    def test_add_response_when_no_usage_metadata_then_ignored(self):
+        collector = UsageCollector()
+        collector.add_response(SimpleNamespace(content="hi"), "gpt-4.1-mini")
+        collector.add_response(_response(0, 0), "gpt-4.1-mini")
+        assert collector.entries() == []
+
+    def test_add_response_without_model_key_uses_unknown(self):
+        collector = UsageCollector()
+        collector.add_response(_response(5, 5), None)
+        assert collector.entries()[0]["llm_model"] == "unknown"
+
+    def test_reset_drops_accumulated_usage(self):
+        collector = UsageCollector()
+        collector.add_response(_response(5, 5), "m")
+        collector.reset()
+        assert collector.entries() == []
+
+
+# ---------------------------------------------------------------------------
+# record_pipeline_usage
+# ---------------------------------------------------------------------------
+
+
+class TestRecordPipelineUsage:
+    def _collector(self):
+        collector = UsageCollector()
+        collector.add_response(_response(1000, 500), "gpt-4.1-mini")
+        return collector
+
+    def test_record_when_empty_then_skips_without_connecting(self):
+        with patch("pipeline.utilities.usage_recorder._connect") as mock_connect:
+            recorded = record_pipeline_usage(
+                UsageCollector(),
+                stage="summarize",
+                data_source="wfp",
+                doc_id="doc-1",
+                query="summarize: Title",
+            )
+        assert recorded is False
+        mock_connect.assert_not_called()
+
+    def test_record_inserts_one_row_per_model_with_cost(self):
+        conn = MagicMock()
+        cursor = conn.cursor.return_value.__enter__.return_value
+        with patch("pipeline.utilities.usage_recorder._connect", return_value=conn):
+            recorded = record_pipeline_usage(
+                self._collector(),
+                stage="summarize",
+                data_source="wfp",
+                doc_id="doc-1",
+                query="summarize: Title",
+            )
+        assert recorded is True
+        cursor.execute.assert_called_once()
+        _sql, params = cursor.execute.call_args.args
+        # (search_id, query, filters, llm_model, prompt, completion, cost)
+        assert params[1] == "summarize: Title"
+        filters = json.loads(params[2])
+        assert filters == {
+            "type": "pipeline",
+            "stage": "summarize",
+            "data_source": "wfp",
+            "doc_id": "doc-1",
+            "calls": 1,
+        }
+        assert params[3] == "gpt-4.1-mini"
+        assert params[4] == 1000
+        assert params[5] == 500
+        # 1000 * 0.0004/1k + 500 * 0.0016/1k
+        assert params[6] == Decimal("0.001200")
+        conn.commit.assert_called_once()
+        conn.close.assert_called_once()
+
+    def test_record_resets_collector(self):
+        collector = self._collector()
+        with patch(
+            "pipeline.utilities.usage_recorder._connect", return_value=MagicMock()
+        ):
+            record_pipeline_usage(
+                collector,
+                stage="tag",
+                data_source="wfp",
+                doc_id="doc-1",
+                query="tag: Title",
+            )
+        assert collector.entries() == []
+
+    def test_record_when_db_unreachable_then_swallows(self):
+        with patch(
+            "pipeline.utilities.usage_recorder._connect",
+            side_effect=RuntimeError("no db"),
+        ):
+            recorded = record_pipeline_usage(
+                self._collector(),
+                stage="tag",
+                data_source="wfp",
+                doc_id="doc-1",
+                query="tag: Title",
+            )
+        assert recorded is False

--- a/tests/unit/test_test_runner.py
+++ b/tests/unit/test_test_runner.py
@@ -569,3 +569,186 @@ async def test_evaluate_case_uses_injected_judge_factory():
     )
     assert outcome["status"] == "pass"
     assert outcome["score"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# Token usage tracking (summary + judge calls → case totals → run rollup)
+# ---------------------------------------------------------------------------
+
+
+async def test_case_usage_totals_sums_summary_and_judge_per_model():
+    output = {
+        "usage": {
+            "llm_model": "gpt-4.1-mini",
+            "prompt_tokens": 1000,
+            "completion_tokens": 500,
+        },
+        "judge_usage": [
+            {
+                "llm_model": "gemini-2.0-flash",
+                "prompt_tokens": 200,
+                "completion_tokens": 100,
+            },
+        ],
+    }
+    totals = test_runner._case_usage_totals(output)
+    assert totals["prompt_tokens"] == 1200
+    assert totals["completion_tokens"] == 600
+    # Cost is per-call from each call's own model rate:
+    # gpt-4.1-mini: 1000*0.0004/1k + 500*0.0016/1k = 0.0012
+    # gemini-2.0-flash: 200*0.0001/1k + 100*0.0004/1k = 0.00006
+    assert float(totals["cost_usd"]) == pytest.approx(0.00126)
+
+
+async def test_case_usage_totals_when_no_llm_calls_then_all_none():
+    totals = test_runner._case_usage_totals({"results": [], "count": 0})
+    assert totals == {
+        "prompt_tokens": None,
+        "completion_tokens": None,
+        "cost_usd": None,
+    }
+
+
+async def test_evaluate_case_carries_usage_totals_into_outcome():
+    async def runner(_case_input):
+        return {
+            "summary": "s",
+            "usage": {
+                "llm_model": "gpt-4.1-mini",
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+            },
+        }
+
+    outcome = await evaluate_case({}, [], runner)
+    assert outcome["prompt_tokens"] == 10
+    assert outcome["completion_tokens"] == 5
+    assert outcome["cost_usd"] is not None
+
+
+async def test_evaluate_case_error_outcome_has_null_usage():
+    async def runner(_case_input):
+        raise RuntimeError("boom")
+
+    outcome = await evaluate_case({}, [], runner)
+    assert outcome["status"] == "error"
+    assert outcome["prompt_tokens"] is None
+    assert outcome["cost_usd"] is None
+
+
+async def test_judge_factory_stashes_judge_usage_on_output(monkeypatch):
+    async def fake_judge_call(_prompt, _model_key):
+        return (
+            '{"score": 1.0, "reason": "ok"}',
+            {"llm_model": "gpt-4.1-mini", "prompt_tokens": 40, "completion_tokens": 8},
+        )
+
+    monkeypatch.setattr(test_runner, "_judge_call", fake_judge_call)
+    factory = test_runner.make_judge_factory({"judge_model": "gpt-4.1-mini"})
+    output = {"raw_summary": "text", "references": [], "search_results": []}
+    judge_fn = await factory(
+        output,
+        [
+            {"type": "llm_judge", "rubric": "r1"},
+            {"type": "llm_judge", "rubric": "r1"},  # deduped — judged once
+            {"type": "llm_judge", "rubric": "r2"},
+        ],
+    )
+    # One usage entry per distinct rubric.
+    assert len(output["judge_usage"]) == 2
+    assert output["judge_usage"][0]["prompt_tokens"] == 40
+    score, reason, _prompt = judge_fn("text", "r1")
+    assert score == 1.0 and reason == "ok"
+
+
+async def test_record_run_usage_writes_evaluation_activity_row(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    recorded = AsyncMock(return_value=True)
+    monkeypatch.setattr("ui.backend.services.usage_recorder.record_llm_usage", recorded)
+
+    user_id = uuid.uuid4()
+    dataset = TestDataset(id=uuid.uuid4(), capability="ai_summary", data_source="uneg")
+    experiment = TestExperiment(
+        id=uuid.uuid4(), dataset_id=dataset.id, name="My experiment"
+    )
+    run = TestRun(
+        id=uuid.uuid4(),
+        experiment_id=experiment.id,
+        run_number=3,
+        status="completed",
+        created_by_user_id=user_id,
+        summary_stats={
+            "total": 4,
+            "prompt_tokens": 4000,
+            "completion_tokens": 900,
+            "total_tokens": 4900,
+            "cost_usd": 0.00304,
+        },
+    )
+    await test_runner._record_run_usage(
+        experiment, run, dataset, {"summary_model": "gpt-4.1-mini"}
+    )
+
+    recorded.assert_awaited_once()
+    kwargs = recorded.await_args.kwargs
+    assert kwargs["activity_type"] == "evaluation"
+    assert kwargs["user_id"] == user_id
+    assert kwargs["search_id"] == run.id
+    assert kwargs["query"] == "Evaluation: My experiment (run 3)"
+    assert kwargs["usage"] == {
+        "llm_model": "gpt-4.1-mini",
+        "prompt_tokens": 4000,
+        "completion_tokens": 900,
+    }
+    assert float(kwargs["cost_usd"]) == pytest.approx(0.00304)
+    assert kwargs["filters_extra"]["experiment_name"] == "My experiment"
+    assert kwargs["filters_extra"]["data_source"] == "uneg"
+    assert kwargs["filters_extra"]["cases"] == 4
+
+
+async def test_execute_attributes_run_to_triggering_user(monkeypatch):
+    async def fake_runner(_case_input):
+        return {"results": [{"id": "A", "doc_id": "A"}], "count": 1}
+
+    async def fake_factory(_output, _expectations):
+        return lambda _text, _rubric: 0.0
+
+    record_calls = []
+
+    async def fake_record(experiment, run, dataset, cfg):
+        record_calls.append(run)
+
+    c1 = uuid.uuid4()
+    cases = [TestCase(id=c1, input={"query": "a"})]
+    monkeypatch.setattr(test_runner, "build_case_runner", lambda *a, **k: fake_runner)
+    monkeypatch.setattr(test_runner, "make_judge_factory", lambda _cfg: fake_factory)
+    monkeypatch.setattr(test_runner, "_record_run_usage", fake_record)
+
+    async def fake_load_cases(_session, _dataset_id):
+        return cases
+
+    monkeypatch.setattr(test_runner, "_load_cases", fake_load_cases)
+
+    dataset = TestDataset(id=uuid.uuid4(), capability="search", data_source="uneg")
+    creator, clicker = uuid.uuid4(), uuid.uuid4()
+    experiment = TestExperiment(
+        id=uuid.uuid4(),
+        dataset_id=dataset.id,
+        status="pending",
+        created_by_user_id=creator,
+        config=None,
+        case_expectations={
+            "columns": [{"type": "min_results", "value": 1}],
+            "cases": {str(c1): {"active": True, "cols": [True]}},
+        },
+    )
+    session = _FakeSession(dataset)
+
+    await _execute(session, experiment, triggered_by_user_id=clicker)
+
+    # The run — and therefore its token usage — is attributed to whoever
+    # clicked Run, not the experiment's creator.
+    (run,) = [o for o in session.added if isinstance(o, TestRun)]
+    assert run.created_by_user_id == clicker
+    assert record_calls == [run]

--- a/tests/unit/test_usage_recorder.py
+++ b/tests/unit/test_usage_recorder.py
@@ -1,0 +1,350 @@
+"""Tests for the server-side LLM usage recorder
+(``ui.backend.services.usage_recorder``)."""
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from ui.backend.services.usage_recorder import has_usage, record_llm_usage, usage_cost
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """Async-context-manager session stub for the recorder's upsert path."""
+
+    def __init__(self, existing=None):
+        self.existing = existing
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, stmt):
+        result = MagicMock()
+        result.scalars.return_value.first.return_value = self.existing
+        return result
+
+    def add(self, row):
+        self.added.append(row)
+
+    async def commit(self):
+        self.committed = True
+
+
+def _factory(session):
+    return lambda: session
+
+
+def _existing_row(**overrides):
+    defaults = {
+        "user_id": None,
+        "session_id": "sess-1",
+        "search_id": uuid.uuid4(),
+        "filters": {"type": "brief"},
+        "llm_model": "gpt-4.1-mini",
+        "prompt_tokens": 1000,
+        "completion_tokens": 200,
+        "cost_usd": Decimal("0.000720"),
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+_USAGE = {"llm_model": "gpt-4.1-mini", "prompt_tokens": 1000, "completion_tokens": 500}
+# 1000 * 0.0004/1k + 500 * 0.0016/1k
+_USAGE_COST = Decimal("0.001200")
+
+
+# ---------------------------------------------------------------------------
+# has_usage / usage_cost
+# ---------------------------------------------------------------------------
+
+
+class TestUsagePayloadHelpers:
+    def test_has_usage_when_tokens_present_then_true(self):
+        assert has_usage({"prompt_tokens": 1}) is True
+        assert has_usage({"completion_tokens": 2}) is True
+
+    def test_has_usage_when_empty_or_model_only_then_false(self):
+        assert has_usage(None) is False
+        assert has_usage({}) is False
+        assert has_usage({"llm_model": "gpt-4.1-mini"}) is False
+        assert has_usage({"prompt_tokens": 0, "completion_tokens": 0}) is False
+
+    def test_has_usage_when_malformed_counts_then_false(self):
+        assert has_usage({"prompt_tokens": "abc"}) is False
+        assert has_usage({"prompt_tokens": -5}) is False
+
+    def test_usage_cost_matches_pricing_table(self):
+        assert usage_cost(_USAGE) == _USAGE_COST
+
+    def test_usage_cost_unknown_model_is_none(self):
+        assert usage_cost({"llm_model": "mystery", "prompt_tokens": 10}) is None
+
+
+# ---------------------------------------------------------------------------
+# record_llm_usage
+# ---------------------------------------------------------------------------
+
+
+class TestRecordLlmUsage:
+    @pytest.mark.asyncio
+    async def test_record_when_no_tokens_then_skips(self):
+        session = _FakeSession()
+        recorded = await record_llm_usage(
+            usage={"llm_model": "gpt-4.1-mini"},
+            activity_type="evaluation",
+            query="q",
+            session_factory=_factory(session),
+        )
+        assert recorded is False
+        assert session.added == []
+        assert session.committed is False
+
+    @pytest.mark.asyncio
+    async def test_record_when_no_existing_row_then_inserts_typed_row(self):
+        session = _FakeSession(existing=None)
+        run_id = uuid.uuid4()
+        user_id = uuid.uuid4()
+        recorded = await record_llm_usage(
+            usage=_USAGE,
+            activity_type="evaluation",
+            query="Evaluation: exp (run 3)",
+            user_id=user_id,
+            search_id=run_id,
+            filters_extra={"run_number": 3},
+            session_factory=_factory(session),
+        )
+        assert recorded is True
+        assert session.committed is True
+        (row,) = session.added
+        assert row.search_id == run_id
+        assert row.user_id == user_id
+        assert row.query == "Evaluation: exp (run 3)"
+        assert row.filters == {"run_number": 3, "type": "evaluation"}
+        assert row.llm_model == "gpt-4.1-mini"
+        assert row.prompt_tokens == 1000
+        assert row.completion_tokens == 500
+        assert row.cost_usd == _USAGE_COST
+
+    @pytest.mark.asyncio
+    async def test_record_when_row_exists_then_accumulates(self):
+        existing = _existing_row()
+        session = _FakeSession(existing=existing)
+        recorded = await record_llm_usage(
+            usage=_USAGE,
+            activity_type="brief",
+            query="ignored for existing rows",
+            session_id="sess-1",
+            search_id=existing.search_id,
+            session_factory=_factory(session),
+        )
+        assert recorded is True
+        assert session.added == []  # accumulated in place, no new row
+        assert existing.prompt_tokens == 2000
+        assert existing.completion_tokens == 700
+        assert existing.cost_usd == Decimal("0.000720") + _USAGE_COST
+        # Existing filters are never touched on accumulation.
+        assert existing.filters == {"type": "brief"}
+
+    @pytest.mark.asyncio
+    async def test_record_when_model_unknown_then_tokens_without_cost(self):
+        session = _FakeSession(existing=None)
+        recorded = await record_llm_usage(
+            usage={"llm_model": "qwen2.5-7b-instruct", "prompt_tokens": 50},
+            activity_type="mcp-assistant",
+            query="q",
+            session_factory=_factory(session),
+        )
+        assert recorded is True
+        (row,) = session.added
+        assert row.prompt_tokens == 50
+        assert row.cost_usd is None
+
+    @pytest.mark.asyncio
+    async def test_record_when_cost_precomputed_then_not_recomputed(self):
+        session = _FakeSession(existing=None)
+        await record_llm_usage(
+            usage=_USAGE,
+            activity_type="evaluation",
+            query="q",
+            cost_usd=Decimal("9.999999"),
+            session_factory=_factory(session),
+        )
+        (row,) = session.added
+        assert row.cost_usd == Decimal("9.999999")
+
+    @pytest.mark.asyncio
+    async def test_record_when_search_id_invalid_then_new_row_still_written(self):
+        session = _FakeSession(existing=None)
+        recorded = await record_llm_usage(
+            usage=_USAGE,
+            activity_type="highlight",
+            query="q",
+            search_id="not-a-uuid",
+            session_factory=_factory(session),
+        )
+        assert recorded is True
+        (row,) = session.added
+        assert isinstance(row.search_id, uuid.UUID)
+
+    @pytest.mark.asyncio
+    async def test_record_when_session_factory_raises_then_swallows(self):
+        def _boom():
+            raise RuntimeError("db down")
+
+        recorded = await record_llm_usage(
+            usage=_USAGE,
+            activity_type="evaluation",
+            query="q",
+            session_factory=_boom,
+        )
+        assert recorded is False
+
+    @pytest.mark.asyncio
+    async def test_record_anonymous_row_keeps_session_id(self):
+        session = _FakeSession(existing=None)
+        await record_llm_usage(
+            usage=_USAGE,
+            activity_type=None,
+            query="plain search summary",
+            session_id="sess-9",
+            search_id=uuid.uuid4(),
+            session_factory=_factory(session),
+        )
+        (row,) = session.added
+        assert row.user_id is None
+        assert row.session_id == "sess-9"
+        # No type → the row defaults to 'search' semantics (no filters).
+        assert row.filters is None
+
+
+# ---------------------------------------------------------------------------
+# Owner scoping — a client-supplied id never matches another owner's row
+# ---------------------------------------------------------------------------
+
+
+class TestOwnerScoping:
+    @pytest.mark.asyncio
+    async def test_lookup_is_owner_scoped(self):
+        """The SELECT must constrain on user_id (or session_id) when given."""
+        captured = {}
+
+        class _CapturingSession(_FakeSession):
+            async def execute(self, stmt):
+                captured["stmt"] = str(stmt)
+                return await super().execute(stmt)
+
+        session = _CapturingSession(existing=None)
+        user_id = uuid.uuid4()
+        await record_llm_usage(
+            usage=_USAGE,
+            activity_type=None,
+            query="q",
+            user_id=user_id,
+            search_id=uuid.uuid4(),
+            session_factory=_factory(session),
+        )
+        assert "user_id" in captured["stmt"]
+
+    @pytest.mark.asyncio
+    async def test_lookup_scopes_by_session_when_anonymous(self):
+        captured = {}
+
+        class _CapturingSession(_FakeSession):
+            async def execute(self, stmt):
+                captured["stmt"] = str(stmt)
+                return await super().execute(stmt)
+
+        session = _CapturingSession(existing=None)
+        await record_llm_usage(
+            usage=_USAGE,
+            activity_type=None,
+            query="q",
+            session_id="sess-1",
+            search_id=uuid.uuid4(),
+            session_factory=_factory(session),
+        )
+        assert "session_id" in captured["stmt"]
+
+
+# ---------------------------------------------------------------------------
+# server_owned matching + background scheduling
+# ---------------------------------------------------------------------------
+
+
+class TestServerOwnedMatching:
+    @pytest.mark.asyncio
+    async def test_client_id_without_owner_never_matches_existing_row(self):
+        """A client-supplied id with no owner context must not accumulate onto
+        an existing row (cross-owner pollution guard) — it gets a fresh row."""
+        existing = _existing_row(user_id=uuid.uuid4(), session_id=None)
+        session = _FakeSession(existing=existing)
+        await record_llm_usage(
+            usage=_USAGE,
+            activity_type=None,
+            query="q",
+            search_id=existing.search_id,  # attacker-guessed id, no owner
+            session_factory=_factory(session),
+        )
+        # Existing row untouched; the usage landed on a new row instead.
+        assert existing.prompt_tokens == 1000
+        (row,) = session.added
+        assert row.prompt_tokens == 1000
+
+    @pytest.mark.asyncio
+    async def test_server_owned_id_matches_existing_row_without_owner(self):
+        existing = _existing_row(user_id=None, session_id=None)
+        session = _FakeSession(existing=existing)
+        await record_llm_usage(
+            usage=_USAGE,
+            activity_type="evaluation",
+            query="q",
+            search_id=existing.search_id,
+            server_owned=True,
+            session_factory=_factory(session),
+        )
+        assert session.added == []
+        assert existing.prompt_tokens == 2000
+
+
+class TestBackgroundScheduling:
+    @pytest.mark.asyncio
+    async def test_schedule_records_in_background(self):
+        import asyncio
+
+        from ui.backend.services.usage_recorder import schedule_llm_usage_recording
+
+        session = _FakeSession(existing=None)
+        schedule_llm_usage_recording(
+            usage=_USAGE,
+            activity_type="brief",
+            query="q",
+            session_id="sess-1",
+            session_factory=_factory(session),
+        )
+        # The write happens off the caller's path; let the task run.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert session.committed is True
+        (row,) = session.added
+        assert row.prompt_tokens == 1000
+
+    def test_schedule_without_running_loop_never_raises(self):
+        from ui.backend.services.usage_recorder import schedule_llm_usage_recording
+
+        # No running event loop here — scheduling must swallow, not raise.
+        schedule_llm_usage_recording(usage=_USAGE, activity_type="brief", query="q")

--- a/ui/backend/auth/optional_user.py
+++ b/ui/backend/auth/optional_user.py
@@ -1,0 +1,32 @@
+"""Shared optional-user dependency for routes that work with or without auth.
+
+Several routes resolve the current user opportunistically — authenticated
+users get attributed, anonymous visitors still work. Historically each route
+file carried its own copy of the ``USER_MODULE`` conditional-import block;
+new routes should import :data:`resolve_optional_user` from here instead of
+adding another copy.
+"""
+
+import os
+from typing import Any, Callable
+
+_UM_RAW = os.environ.get("USER_MODULE", "off").lower()
+USER_MODULE_ENABLED = _UM_RAW not in ("off", "0", "false", "no")
+
+
+async def _anonymous_user() -> None:
+    """No-op user resolver for deployments without the user module."""
+    return None
+
+
+def _build_dep() -> Callable[..., Any]:
+    """Resolve the dependency once at import (same timing as the old blocks)."""
+    if USER_MODULE_ENABLED:
+        from ui.backend.auth.users import optional_current_user
+
+        return optional_current_user
+    return _anonymous_user
+
+
+# FastAPI dependency: yields the authenticated user or None.
+resolve_optional_user = _build_dep()

--- a/ui/backend/auth/schemas.py
+++ b/ui/backend/auth/schemas.py
@@ -747,6 +747,15 @@ class AssistantChatRequest(BaseModel):
             "follow-up turns."
         ),
     )
+    # Activity row (search_id) this turn's token usage is recorded onto,
+    # server-side, when the stream finishes — plus the anonymous session id
+    # for owner scoping. Brief sections pass their brief's stable activity
+    # id here so all section research accumulates onto one row, and set
+    # usage_context='brief' so a newly created row is typed 'brief' rather
+    # than 'assistant-deep-research'.
+    activity_id: Optional[str] = Field(None, max_length=100)
+    session_id: Optional[str] = Field(None, max_length=64)
+    usage_context: Optional[str] = Field(None, max_length=32)
 
 
 class ThreadRenameRequest(BaseModel):

--- a/ui/backend/auth/testing_models.py
+++ b/ui/backend/auth/testing_models.py
@@ -16,8 +16,9 @@ runtime ORM mapping only.
 
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, Numeric, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -233,6 +234,13 @@ class TestResult(Base):
     assertion_results: Mapped[list | None] = mapped_column(JSONB, nullable=True)
     latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Combined LLM usage for this case (summary generation + judge calls);
+    # cost is summed per call from each call's own model rate.
+    prompt_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    completion_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(precision=12, scale=6), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, nullable=False
     )

--- a/ui/backend/main.py
+++ b/ui/backend/main.py
@@ -6,14 +6,13 @@ FastAPI server that provides semantic search over indexed documents in Qdrant.
 import logging
 import os
 import signal
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Request  # noqa: F401
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
-from pydantic import BaseModel
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -28,6 +27,7 @@ from pipeline.db import (
     load_datasources_config,
 )
 from pipeline.utilities.tasks import app as celery_app
+from ui.backend import schemas as _api_schemas
 from ui.backend.routes import assistant as assistant_routes
 from ui.backend.routes import brief as brief_routes
 from ui.backend.routes import config as config_routes
@@ -696,134 +696,24 @@ if USER_MODULE_MODE == "on_active":
     app.add_middleware(ActiveAuthMiddleware, auth_secret=AUTH_SECRET, api_key=API_KEY)
 
 
-# Models
-class SearchResult(BaseModel):
-    id: Optional[str] = None  # Chunk ID (for UI compatibility)
-    chunk_id: str
-    doc_id: str
-    document_title: Optional[str] = None  # Document title (for UI compatibility)
-    data_source: Optional[str] = None  # Data source (for UI filtering)
-    text: str
-    page_num: int
-    chunk_elements: Optional[List[Dict[str, Any]]] = (
-        None  # Unified array with all elements (text, images, tables)
-    )
-    headings: List[str]
-    section_type: Optional[str] = None
-    score: float
-    # Visual content metadata
-    item_types: Optional[List[str]] = None  # e.g., ['TableItem', 'PictureItem']
-    # Backward compatibility fields
-    bbox: Optional[List] = None  # Legacy field
-    elements: Optional[List[Dict[str, Any]]] = None  # Legacy field
-    table_data: Optional[Dict[str, Any]] = None  # Legacy field
-    tables: Optional[List[Dict[str, Any]]] = None  # Legacy field
-    images: Optional[List[Dict[str, Any]]] = None  # Legacy field
-    # Core fields for backward compatibility
-    title: str
-    organization: Optional[str] = None
-    year: Optional[str] = None
-    file_format: Optional[str] = None
-    # ALL document metadata as flexible JSON - any field can appear here
-    metadata: Dict[str, Any] = {}
-    sys_parsed_folder: Optional[str] = None
-    sys_filepath: Optional[str] = None
-    sys_full_summary: Optional[str] = None
-
-    class Config:
-        extra = "allow"  # Allow additional fields not explicitly defined
-
-
-class ModelConfig(BaseModel):
-    name: str
-    description: str
-    is_default: bool
-
-
-class SearchResponse(BaseModel):
-    results: List[SearchResult]
-    total: int
-    query: str
-    filters: Optional[Dict[str, List[str]]] = None
-
-
-class FacetValue(BaseModel):
-    value: str
-    count: int
-    organization: Optional[str] = None  # For title facets - associated org
-    published_year: Optional[str] = None  # For title facets - associated year
-
-
-class Facets(BaseModel):
-    """Dynamic facets response using core field names."""
-
-    facets: Dict[str, List[FacetValue]]  # core_field_name -> list of facet values
-    filter_fields: Dict[str, str]  # core_field_name -> display label (from config)
-
-
-class HighlightBox(BaseModel):
-    page: int
-    bbox: Dict[str, float]  # {l, r, t, b}
-    text: str
-
-
-class HighlightResponse(BaseModel):
-    highlights: List[HighlightBox]
-    total: int
-
-
-class HighlightMatch(BaseModel):
-    start: int
-    end: int
-    text: str
-    match_type: str  # "exact_phrase", "word", "semantic"
-    word: Optional[str] = None  # For word matches
-    similarity: Optional[float] = None  # For semantic matches
-
-
-class SummaryModelConfig(BaseModel):
-    model: str
-    max_tokens: int
-    temperature: float
-    chunk_overlap: int
-    chunk_tokens_ratio: float
-
-
-class UnifiedHighlightRequest(BaseModel):
-    query: str
-    text: str
-    highlight_type: str = "both"  # "keyword", "semantic", or "both"
-    semantic_threshold: float = 0.4
-    min_sentence_length_ratio: float = 1.5
-    semantic_model_config: Optional[SummaryModelConfig] = None
-
-
-class UnifiedHighlightResponse(BaseModel):
-    highlighted_text: str  # Text with <em> tags inserted
-    matches: List[HighlightMatch]  # For backward compatibility
-    total: int
-    types_returned: List[str]  # Which types were actually returned
-
-
-class AISummaryRequest(BaseModel):
-    query: str
-    results: List[SearchResult]
-    max_results: int = 20
-    summary_model: Optional[str] = None
-    summary_model_config: Optional[SummaryModelConfig] = None
-
-
-class TranslateRequest(BaseModel):
-    text: str
-    target_language: str
-    source_language: Optional[str] = None
-
-
-class AISummaryResponse(BaseModel):
-    summary: str
-    query: str
-    results_count: int
-    prompt: str = ""
+# Models: the routes bind the canonical request/response models from
+# ui.backend.schemas; these aliases exist only for backwards compatibility
+# with code (and tests) that historically imported them from main. Aliasing
+# instead of redefining keeps them from silently drifting out of sync.
+SearchResult = _api_schemas.SearchResult
+ModelConfig = _api_schemas.ModelConfig
+SearchResponse = _api_schemas.SearchResponse
+FacetValue = _api_schemas.FacetValue
+Facets = _api_schemas.Facets
+HighlightBox = _api_schemas.HighlightBox
+HighlightResponse = _api_schemas.HighlightResponse
+HighlightMatch = _api_schemas.HighlightMatch
+SummaryModelConfig = _api_schemas.SummaryModelConfig
+UnifiedHighlightRequest = _api_schemas.UnifiedHighlightRequest
+UnifiedHighlightResponse = _api_schemas.UnifiedHighlightResponse
+AISummaryRequest = _api_schemas.AISummaryRequest
+TranslateRequest = _api_schemas.TranslateRequest
+AISummaryResponse = _api_schemas.AISummaryResponse
 
 
 app.include_router(config_routes.router)

--- a/ui/backend/routes/activity.py
+++ b/ui/backend/routes/activity.py
@@ -249,10 +249,10 @@ async def log_activity(
         if body.ai_summary is not None:
             row.ai_summary = body.ai_summary
         row.url = body.url
-        row.llm_model = body.llm_model
-        row.prompt_tokens = body.prompt_tokens
-        row.completion_tokens = body.completion_tokens
-        row.cost_usd = cost
+        # Usage is patch-only: token counts may already have been recorded
+        # server-side (streaming endpoints, brief sections), so a re-POST
+        # without usage — e.g. every Brief save — must not null them out.
+        _apply_token_usage(row, body)
         activity = existing
     else:
         activity = UserActivity(

--- a/ui/backend/routes/assistant.py
+++ b/ui/backend/routes/assistant.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import selectinload
 
 from ui.backend.auth.schemas import AssistantChatRequest, ThreadRenameRequest
 from ui.backend.services.assistant_service import stream_research_response
+from ui.backend.services.usage_recorder import schedule_llm_usage_recording
 from ui.backend.utils.app_limits import get_rate_limits, limiter
 
 logger = logging.getLogger(__name__)
@@ -162,6 +163,39 @@ async def _load_conversation_history(body, user, session):
         return []
 
 
+def _record_assistant_usage(event: dict, body: AssistantChatRequest, user) -> None:
+    """Record a finished assistant turn's usage onto its activity row.
+
+    Keyed by the ``activity_id`` the client sends with the request so the
+    tokens land on the same row the client logs the conversation under.
+    Brief section research passes its brief's stable id plus
+    ``usage_context='brief'`` so every section's usage accumulates onto the
+    one brief row — typed ``brief`` even when this recording creates it.
+
+    Monitoring only: scheduled as a background task, so it adds no latency
+    to — and can never fail — the stream (the done event always reaches
+    the client).
+    """
+    usage = event.get("usage")
+    if not usage or not body.activity_id:
+        return
+    if body.usage_context == "brief":
+        activity_type = "brief"
+    elif body.deep_research:
+        activity_type = "assistant-deep-research"
+    else:
+        activity_type = "assistant-basic"
+    schedule_llm_usage_recording(
+        usage=usage,
+        activity_type=activity_type,
+        query=body.query,
+        # getattr: direct handler calls (tests) receive the Depends sentinel.
+        user_id=getattr(user, "id", None),
+        session_id=body.session_id,
+        search_id=body.activity_id,
+    )
+
+
 async def _stream_with_heartbeat(ait):
     """Yield events from *ait*, inserting SSE heartbeat comments on idle."""
     task = None
@@ -242,7 +276,9 @@ async def stream_assistant_chat(
                     last_synthesis = event.get("token", "")
                 elif etype == "sources":
                     last_sources = event.get("sources")
-                elif _should_persist(event, user, session):
+                if etype == "done":
+                    _record_assistant_usage(event, body, user)
+                if _should_persist(event, user, session):
                     logger.info(
                         "[deepres] done event: deep=%s synthesis_len=%d sources_count=%d",
                         body.deep_research,

--- a/ui/backend/routes/brief.py
+++ b/ui/backend/routes/brief.py
@@ -12,10 +12,11 @@ full detail is logged server-side only.
 
 import logging
 import sys
-from typing import Optional
+from typing import Any, Dict, Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
+from ui.backend.auth.optional_user import resolve_optional_user as _resolve_user_dep
 from ui.backend.schemas import (
     BriefHeading,
     BriefOutlineRequest,
@@ -24,12 +25,33 @@ from ui.backend.schemas import (
     BriefReviseResponse,
 )
 from ui.backend.services import llm_service as llm_service_module
+from ui.backend.services.usage_recorder import schedule_llm_usage_recording
 from ui.backend.utils.app_limits import get_rate_limits, limiter
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 _RL_SEARCH, _RL_DEFAULT, RATE_LIMIT_AI = get_rate_limits()
+
+
+def _record_brief_usage(
+    usage: Dict[str, Any], query: str, body: Any, user: Any
+) -> None:
+    """Accumulate one brief LLM call's usage onto the brief's activity row.
+
+    Monitoring only: scheduled as a background task, so it adds no latency
+    to — and can never fail — the outline/revise response.
+    """
+    schedule_llm_usage_recording(
+        usage=usage,
+        activity_type="brief",
+        query=query,
+        # getattr: direct handler calls (tests) receive the Depends sentinel.
+        user_id=getattr(user, "id", None),
+        session_id=body.session_id,
+        search_id=body.activity_id,
+    )
+
 
 # Guardrail: a brief question is a short prompt, not a document.
 _MAX_QUESTION_CHARS = 2000
@@ -81,7 +103,9 @@ def _resolve_configured_model(data_source: str) -> Optional[str]:
 @router.post("/brief/outline", response_model=BriefOutlineResponse)
 @limiter.limit(RATE_LIMIT_AI)
 async def generate_outline(
-    request: Request, body: BriefOutlineRequest
+    request: Request,
+    body: BriefOutlineRequest,
+    user=Depends(_resolve_user_dep),
 ) -> BriefOutlineResponse:
     """Generate a research-brief outline (title + section headings) from a question."""
     question = (body.question or "").strip()
@@ -106,13 +130,14 @@ async def generate_outline(
 
     try:
         llm_service = _get_llm_service()
-        _title, headings = await llm_service.generate_brief_outline(
+        _title, headings, usage = await llm_service.generate_brief_outline(
             question=question,
             model_key=model_key,
             sources=sources,
             instructions=body.instructions,
             num_headings=body.num_headings,
         )
+        _record_brief_usage(usage, question, body, user)
         # The brief title is the user's topic, per product spec.
         return BriefOutlineResponse(
             title=question,
@@ -126,7 +151,9 @@ async def generate_outline(
 @router.post("/brief/revise", response_model=BriefReviseResponse)
 @limiter.limit(RATE_LIMIT_AI)
 async def revise_section(
-    request: Request, body: BriefReviseRequest
+    request: Request,
+    body: BriefReviseRequest,
+    user=Depends(_resolve_user_dep),
 ) -> BriefReviseResponse:
     """Surgically revise a section's markdown per an instruction (Brief "Edit").
 
@@ -153,12 +180,13 @@ async def revise_section(
 
     try:
         llm_service = _get_llm_service()
-        revised = await llm_service.revise_brief_section(
+        revised, usage = await llm_service.revise_brief_section(
             content=content,
             instruction=instruction,
             model_key=model_key,
             voice_instructions=(body.voice_instructions or "").strip() or None,
         )
+        _record_brief_usage(usage, instruction, body, user)
         return BriefReviseResponse(content=revised)
     except Exception:
         logger.error("Brief section revise failed", exc_info=True)

--- a/ui/backend/routes/highlight.py
+++ b/ui/backend/routes/highlight.py
@@ -1,13 +1,15 @@
 import asyncio
 import json
 import re
+import uuid
 from difflib import SequenceMatcher
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from qdrant_client.http import models as qmodels
 
 from pipeline.utilities.text_cleaning import clean_text
+from ui.backend.auth.optional_user import resolve_optional_user as _resolve_user_dep
 from ui.backend.schemas import (
     HighlightBox,
     HighlightMatch,
@@ -31,6 +33,40 @@ from ui.backend.utils.highlight_helpers import (
 
 router = APIRouter()
 _highlight_cache: Dict[Any, Any] = {}
+
+
+def _record_highlight_usage(
+    usage: Dict[str, Any], request: UnifiedHighlightRequest, user: Any
+) -> None:
+    """Accumulate semantic-highlight LLM usage onto a per-search activity row.
+
+    Highlight calls fire once per viewed document, so instead of one row per
+    call the usage accumulates onto a single ``highlight`` row derived from
+    the originating search's id. Without a search context each call records
+    its own row (the usage is never dropped).
+
+    Monitoring only: scheduled as a background task, so it adds no latency
+    to — and can never fail — the highlight response.
+    """
+    try:
+        from ui.backend.services.usage_recorder import schedule_llm_usage_recording
+
+        search_id = None
+        if request.search_id:
+            # Deterministic sibling id of the search row, so all highlight
+            # calls for one search share one 'highlight' activity row.
+            search_id = uuid.uuid5(uuid.NAMESPACE_URL, f"highlight:{request.search_id}")
+        schedule_llm_usage_recording(
+            usage=usage,
+            activity_type="highlight",
+            query=request.query,
+            # getattr: direct handler calls (tests) receive the Depends sentinel.
+            user_id=getattr(user, "id", None),
+            session_id=request.session_id,
+            search_id=search_id,
+        )
+    except Exception:
+        logger.warning("Failed to record highlight usage", exc_info=True)
 
 
 def _bbox_gaps(bboxes: List[tuple]) -> List[float]:
@@ -484,7 +520,7 @@ async def _get_semantic_llm_output(
         logger.info("Using cached LLM output for semantic highlighting")
         return cache[cache_key]
 
-    llm_output = await get_semantic_llm_output(query, clean_text, request)
+    llm_output, _usage = await get_semantic_llm_output(query, clean_text, request)
     cache[cache_key] = llm_output
     return llm_output
 
@@ -516,7 +552,9 @@ async def _find_semantic_matches(
 
 
 @router.post("/highlight", response_model=UnifiedHighlightResponse)
-async def highlight_text(request: UnifiedHighlightRequest):
+async def highlight_text(
+    request: UnifiedHighlightRequest, user=Depends(_resolve_user_dep)
+):
     """
     Unified highlighting endpoint that supports keyword and/or semantic highlighting.
 
@@ -571,7 +609,10 @@ async def highlight_text(request: UnifiedHighlightRequest):
         # SEMANTIC HIGHLIGHTING (LLM-based)
         if highlight_type in ["semantic", "both"]:
             try:
-                llm_output = await get_semantic_llm_output(query, clean_text, request)
+                llm_output, usage = await get_semantic_llm_output(
+                    query, clean_text, request
+                )
+                _record_highlight_usage(usage, request, user)
                 try:
                     phrases = parse_semantic_phrases(llm_output)
                     semantic_matches = await find_semantic_matches(

--- a/ui/backend/routes/llm_usage.py
+++ b/ui/backend/routes/llm_usage.py
@@ -59,6 +59,12 @@ _VALID_ACTIVITY_TYPES = {
     "assistant-basic",
     "assistant-deep-research",
     "brief",
+    # Server-side recorded types (see ui/backend/services/usage_recorder.py).
+    "highlight",
+    "evaluation",
+    "mcp-assistant",
+    "a2a-assistant",
+    "pipeline",
 }
 
 _DEFAULT_RANGE_DAYS = 30

--- a/ui/backend/routes/summary.py
+++ b/ui/backend/routes/summary.py
@@ -7,8 +7,14 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 
-from ui.backend.schemas import AISummaryRequest, AISummaryResponse, TranslateRequest
+from ui.backend.schemas import (
+    AISummaryRequest,
+    AISummaryResponse,
+    LlmUsagePayload,
+    TranslateRequest,
+)
 from ui.backend.services import llm_service as llm_service_module
+from ui.backend.services.usage_recorder import schedule_llm_usage_recording
 from ui.backend.utils.app_limits import (
     get_rate_limit_translate,
     get_rate_limits,
@@ -83,6 +89,33 @@ async def _resolve_summary_prompt(user, session) -> str | None:
         "No group summary prompt found for user=%s", getattr(user, "email", "unknown")
     )
     return None
+
+
+def _record_summary_usage(usage: dict, body: AISummaryRequest, user) -> None:
+    """Accumulate a summary call's usage onto its search activity row.
+
+    Server-side recording keyed by the ``search_id`` the frontend sends with
+    the request — this covers drill-down summaries too (same id, so their
+    usage sums onto the parent search's row) without relying on the client
+    echoing usage back through the activity routes. Requests without a
+    ``search_id`` are left to the legacy client echo path — recording them
+    here as well would double-count against older bundles that still PATCH
+    usage through the activity routes.
+
+    Monitoring only: scheduled as a background task, so it adds no latency
+    to — and can never fail — the summary path.
+    """
+    if not body.search_id:
+        return
+    schedule_llm_usage_recording(
+        usage=usage,
+        activity_type=None,
+        query=body.query,
+        # getattr: direct handler calls (tests) receive the Depends sentinel.
+        user_id=getattr(user, "id", None),
+        session_id=body.session_id,
+        search_id=body.search_id,
+    )
 
 
 @router.post("/translate")
@@ -190,8 +223,9 @@ async def stream_summary(
                 completion_data["langsmith_trace_url"] = stream_metadata[
                     "langsmith_trace_url"
                 ]
-            # Forward LLM usage so the frontend can include it in the
-            # activity-log PATCH that fires after the stream ends.
+            # Record usage server-side against the search's activity row (the
+            # authoritative path), and still forward it on the done event for
+            # transparency / older clients that PATCH it themselves.
             usage_payload = {
                 k: stream_metadata[k]
                 for k in ("llm_model", "prompt_tokens", "completion_tokens")
@@ -199,6 +233,7 @@ async def stream_summary(
             }
             if usage_payload:
                 completion_data["usage"] = usage_payload
+                _record_summary_usage(usage_payload, body, user)
             yield f"data: {json.dumps(completion_data)}\n\n"
 
         except Exception as e:
@@ -249,7 +284,7 @@ async def generate_summary(
             temperature,
             max_tokens,
         )
-        summary = await llm_service.generate_ai_summary(
+        summary, usage = await llm_service.generate_ai_summary_with_usage(
             query=body.query,
             results=results_dicts,
             max_results=body.max_results,
@@ -258,6 +293,7 @@ async def generate_summary(
             max_tokens=max_tokens,
             system_prompt_override=system_prompt_override,
         )
+        _record_summary_usage(usage, body, user)
 
         # Get the rendered prompt for debugging/transparency
         prompt = llm_service.render_prompt(
@@ -272,6 +308,7 @@ async def generate_summary(
             query=body.query,
             results_count=len(body.results),
             prompt=prompt,
+            usage=LlmUsagePayload(**usage) if usage else None,
         )
 
     except Exception as e:

--- a/ui/backend/routes/testing.py
+++ b/ui/backend/routes/testing.py
@@ -379,7 +379,12 @@ async def run_experiment_endpoint(
     experiment.status = EXPERIMENT_PENDING
     await session.commit()
     await session.refresh(experiment)
-    background_tasks.add_task(run_experiment, experiment.id)
+    # Capture the triggering admin's id here — the request context is gone by
+    # the time the background task runs — so the run's token usage is
+    # attributed to the user who actually clicked Run.
+    background_tasks.add_task(
+        run_experiment, experiment.id, triggered_by_user_id=admin.id
+    )
     return experiment
 
 

--- a/ui/backend/schemas/__init__.py
+++ b/ui/backend/schemas/__init__.py
@@ -97,6 +97,14 @@ class SummaryModelConfig(BaseModel):
     chunk_tokens_ratio: float
 
 
+class LlmUsagePayload(BaseModel):
+    """Token usage reported for one LLM call (activity-log field shape)."""
+
+    llm_model: Optional[str] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+
+
 class UnifiedHighlightRequest(BaseModel):
     query: str
     text: str
@@ -104,6 +112,10 @@ class UnifiedHighlightRequest(BaseModel):
     semantic_threshold: float = 0.4
     min_sentence_length_ratio: float = 1.5
     semantic_model_config: Optional[SummaryModelConfig] = None
+    # Current search context so semantic-highlight LLM usage can be recorded
+    # server-side (one accumulating 'highlight' activity row per search).
+    search_id: Optional[str] = None
+    session_id: Optional[str] = None
 
 
 class UnifiedHighlightResponse(BaseModel):
@@ -119,6 +131,12 @@ class AISummaryRequest(BaseModel):
     max_results: int = 20
     summary_model: Optional[str] = None
     summary_model_config: Optional[SummaryModelConfig] = None
+    # Activity row (search_id) this summary's token usage is recorded onto,
+    # server-side, when generation finishes — plus the anonymous session id
+    # for owner scoping. Drill-down summaries reuse the parent search's id so
+    # their usage accumulates onto the same row.
+    search_id: Optional[str] = None
+    session_id: Optional[str] = None
 
 
 class TranslateRequest(BaseModel):
@@ -132,6 +150,7 @@ class AISummaryResponse(BaseModel):
     query: str
     results_count: int
     prompt: str = ""
+    usage: Optional[LlmUsagePayload] = None
 
 
 class LLMConfig(BaseModel):
@@ -195,6 +214,10 @@ class BriefOutlineRequest(BaseModel):
     # Optional sample of the most relevant corpus material (from a prior /search)
     # so the outline reflects what the system actually contains.
     sources: Optional[List[BriefSourceSample]] = None
+    # The brief's stable activity id (+ anonymous session id) so outline LLM
+    # usage is recorded server-side onto the brief's activity row.
+    activity_id: Optional[str] = None
+    session_id: Optional[str] = None
 
 
 class BriefOutlineResponse(BaseModel):
@@ -211,6 +234,10 @@ class BriefReviseRequest(BaseModel):
     model: Optional[str] = None
     # Optional voice & tone profile instructions applied to the rewritten text.
     voice_instructions: Optional[str] = None
+    # The brief's stable activity id (+ anonymous session id) so revise LLM
+    # usage is recorded server-side onto the brief's activity row.
+    activity_id: Optional[str] = None
+    session_id: Optional[str] = None
 
 
 class BriefReviseResponse(BaseModel):

--- a/ui/backend/schemas/testing.py
+++ b/ui/backend/schemas/testing.py
@@ -116,6 +116,10 @@ class TestResultRead(BaseModel):
     assertion_results: Optional[List[Dict[str, Any]]] = None
     latency_ms: Optional[int] = None
     error_message: Optional[str] = None
+    # Combined LLM usage for the case (summary + judge calls).
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    cost_usd: Optional[float] = None
     created_at: datetime
 
 
@@ -129,6 +133,9 @@ class TestRunRead(BaseModel):
     summary_stats: Optional[Dict[str, Any]] = None
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
+    # The user the run (and its token usage) is attributed to — whoever
+    # clicked Run, falling back to the experiment's creator.
+    created_by_user_id: Optional[uuid.UUID] = None
     created_at: datetime
     results: List[TestResultRead] = Field(default_factory=list)
 

--- a/ui/backend/services/evaluation_metrics.py
+++ b/ui/backend/services/evaluation_metrics.py
@@ -11,10 +11,28 @@ RESULT_FAIL = "fail"
 RESULT_ERROR = "error"
 
 
+def _sum_token_usage(case_results: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Sum per-case LLM usage into run totals.
+
+    Cost is JSON-safe (float, 6 decimals) because the totals live in the
+    ``summary_stats`` JSONB column; None when no case reported a cost.
+    """
+    prompt = sum(int(r.get("prompt_tokens") or 0) for r in case_results)
+    completion = sum(int(r.get("completion_tokens") or 0) for r in case_results)
+    costs = [r["cost_usd"] for r in case_results if r.get("cost_usd") is not None]
+    return {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": prompt + completion,
+        "cost_usd": round(float(sum(float(c) for c in costs)), 6) if costs else None,
+    }
+
+
 def compute_summary_stats(
     case_results: List[Dict[str, Any]], duration_ms: int
 ) -> Dict[str, Any]:
-    """Roll up per-case outcomes into counts, pass_rate, mean_score, duration.
+    """Roll up per-case outcomes into counts, pass_rate, mean_score, duration,
+    and total LLM token usage / cost.
 
     ``pass_rate`` is a fraction in [0, 1]; ``mean_score`` averages only the
     non-null case scores (None when no case produced a score). All numbers are
@@ -33,4 +51,5 @@ def compute_summary_stats(
         "pass_rate": round(passed / total, 4) if total else 0.0,
         "mean_score": round(sum(scores) / len(scores), 4) if scores else None,
         "duration_ms": duration_ms,
+        **_sum_token_usage(case_results),
     }

--- a/ui/backend/services/llm_service.py
+++ b/ui/backend/services/llm_service.py
@@ -441,7 +441,7 @@ async def generate_brief_outline(
     sources: Optional[List[Dict[str, Any]]] = None,
     instructions: str | None = None,
     num_headings: int | None = None,
-) -> tuple[str, List[Dict[str, Any]]]:
+) -> tuple[str, List[Dict[str, Any]], Dict[str, Any]]:
     """Generate research-brief section headings for a topic.
 
     ``question`` is the brief topic. ``instructions`` is optional author
@@ -451,9 +451,10 @@ async def generate_brief_outline(
     grounded in the themes actually present in the library. Prompts live in
     ``prompts/brief_outline_*.j2``.
 
-    Returns ``(title, headings)``; ``title`` falls back to the topic when the
-    model does not supply one (callers typically force the title to the topic).
-    Each heading is ``{"title": str, "level": 1 | 2}``.
+    Returns ``(title, headings, usage)``; ``title`` falls back to the topic
+    when the model does not supply one (callers typically force the title to
+    the topic). Each heading is ``{"title": str, "level": 1 | 2}``; ``usage``
+    is the token-usage payload from ``summarize_usage_metadata``.
     """
     system_prompt = _brief_outline_system_template.render()
     user_prompt = _brief_outline_user_template.render(
@@ -471,10 +472,14 @@ async def generate_brief_outline(
         SystemMessage(content=system_prompt),
         HumanMessage(content=user_prompt),
     ]
-    response = await llm.ainvoke(messages)  # type: ignore[arg-type]
+    usage_handler = UsageMetadataCallbackHandler()
+    response = await llm.ainvoke(
+        messages, config={"callbacks": [usage_handler]}  # type: ignore[arg-type]
+    )
     raw = str(response.content).strip()
     logger.info("Brief outline raw response (%d chars): %s", len(raw), raw[:500])
-    return parse_brief_outline(raw, fallback_title=question.strip())
+    title, headings = parse_brief_outline(raw, fallback_title=question.strip())
+    return title, headings, summarize_usage_metadata(usage_handler, model_key)
 
 
 def _strip_section_wrapper(text: str) -> str:
@@ -501,12 +506,13 @@ async def revise_brief_section(
     temperature: float | None = None,
     max_tokens: int | None = None,
     voice_instructions: str | None = None,
-) -> str:
+) -> tuple[str, Dict[str, Any]]:
     """Surgically revise one brief section's markdown per an instruction.
 
     A single LLM call — NOT deep research — so the existing wording and inline
     ``[n]`` citation markers are preserved and only the smallest necessary
-    changes are made. Returns the revised section markdown (wrappers stripped).
+    changes are made. Returns ``(revised_markdown, usage)`` where ``usage`` is
+    the token-usage payload from ``summarize_usage_metadata``.
     Prompts live in ``prompts/brief_revise_*.j2``.
     """
     # The shared prompt Jinja env autoescapes (Bandit requires it), but these
@@ -532,11 +538,15 @@ async def revise_brief_section(
         SystemMessage(content=system_prompt),
         HumanMessage(content=user_prompt),
     ]
-    response = await llm.ainvoke(messages)  # type: ignore[arg-type]
+    usage_handler = UsageMetadataCallbackHandler()
+    response = await llm.ainvoke(
+        messages, config={"callbacks": [usage_handler]}  # type: ignore[arg-type]
+    )
     # Some models HTML-escape quotes/ampersands in their output (e.g. &#34;),
     # which would render literally in the section. Decode entities back to plain
     # text so the stored markdown is clean.
-    return html.unescape(_strip_section_wrapper(str(response.content)))
+    revised = html.unescape(_strip_section_wrapper(str(response.content)))
+    return revised, summarize_usage_metadata(usage_handler, model_key)
 
 
 # GoogleTranslator rejects requests of 5000+ characters outright, so long

--- a/ui/backend/services/test_runner.py
+++ b/ui/backend/services/test_runner.py
@@ -498,21 +498,31 @@ def _format_judge_context(output: Dict[str, Any]) -> str:
     return "\n\n".join(blocks) if blocks else "(no search results)"
 
 
-async def _judge_call(prompt: str, model_key: Optional[str]) -> str:
+async def _judge_call(
+    prompt: str, model_key: Optional[str]
+) -> Tuple[str, Dict[str, Any]]:
     """Raw LLM completion for judging — deliberately NOT routed through the
-    AI-summary templates (which would reframe the rubric as a search query)."""
+    AI-summary templates (which would reframe the rubric as a search query).
+
+    Returns ``(reply_text, usage)`` where ``usage`` is the token-usage payload
+    from ``summarize_usage_metadata`` so judge calls are cost-tracked.
+    """
+    from langchain_core.callbacks import UsageMetadataCallbackHandler
     from langchain_core.messages import HumanMessage, SystemMessage
 
+    from ui.backend.services.llm_service import summarize_usage_metadata
     from utils.llm_factory import get_llm
 
     llm = get_llm(model=model_key, temperature=0.0, max_tokens=300)
+    usage_handler = UsageMetadataCallbackHandler()
     response = await llm.ainvoke(
         [
             SystemMessage(content=_JUDGE_SYSTEM_PROMPT),
             HumanMessage(content=prompt),
-        ]
+        ],
+        config={"callbacks": [usage_handler]},
     )
-    return str(response.content)
+    return str(response.content), summarize_usage_metadata(usage_handler, model_key)
 
 
 def make_judge_factory(config: Dict[str, Any]) -> JudgeFactory:
@@ -555,8 +565,12 @@ def make_judge_factory(config: Dict[str, Any]) -> JudgeFactory:
             )
             full_prompt = f"SYSTEM:\n{_JUDGE_SYSTEM_PROMPT}\n\nUSER:\n{user_prompt}"
             logger.info("[LLM judge] model=%s rubric=%r", model_key, rubric[:300])
-            judged = await _judge_call(user_prompt, model_key)
+            judged, judge_usage = await _judge_call(user_prompt, model_key)
             logger.info("[LLM judge] response=%r", judged[:400])
+            if judge_usage and isinstance(output, dict):
+                # Stash judge usage on the case output so it is persisted in
+                # actual_output and rolled into the case's token totals.
+                output.setdefault("judge_usage", []).append(judge_usage)
             score, reason = _parse_judgement(judged)
             verdicts[rubric] = (score, reason, full_prompt)
         return lambda _text, rubric: verdicts.get(str(rubric), (0.0, "", ""))
@@ -567,6 +581,48 @@ def make_judge_factory(config: Dict[str, Any]) -> JudgeFactory:
 # ---------------------------------------------------------------------------
 # Per-case evaluation (testable with an injected runner/judge factory)
 # ---------------------------------------------------------------------------
+
+
+_NO_CASE_USAGE = {"prompt_tokens": None, "completion_tokens": None, "cost_usd": None}
+
+
+def _case_usage_totals(output: Any) -> Dict[str, Any]:
+    """Combine a case's summary + judge usage into per-case token/cost totals.
+
+    Cost is summed per LLM call from each call's own model rate (summary and
+    judge models can differ), so mixed-model cases stay accurate. All values
+    are None when the case made no LLM calls (e.g. search-only experiments).
+
+    Monitoring only: a malformed usage payload must never fail a case that
+    ran successfully, so unexpected errors are logged and yield None totals.
+    """
+    from ui.backend.utils.llm_costs import compute_cost
+
+    try:
+        entries: List[Dict[str, Any]] = []
+        if isinstance(output, dict):
+            if isinstance(output.get("usage"), dict):
+                entries.append(output["usage"])
+            entries.extend(
+                e for e in output.get("judge_usage") or [] if isinstance(e, dict)
+            )
+        prompt = sum(int(e.get("prompt_tokens") or 0) for e in entries)
+        completion = sum(int(e.get("completion_tokens") or 0) for e in entries)
+        costs = []
+        for e in entries:
+            cost = compute_cost(
+                e.get("llm_model"), e.get("prompt_tokens"), e.get("completion_tokens")
+            )
+            if cost is not None:
+                costs.append(cost)
+        return {
+            "prompt_tokens": prompt or None,
+            "completion_tokens": completion or None,
+            "cost_usd": sum(costs) if costs else None,
+        }
+    except Exception:
+        logger.warning("Failed to total case LLM usage", exc_info=True)
+        return dict(_NO_CASE_USAGE)
 
 
 async def evaluate_case(
@@ -588,6 +644,7 @@ async def evaluate_case(
             "assertion_results": None,
             "latency_ms": int((time.time() - started) * 1000),
             "error_message": str(exc)[:500],
+            **_NO_CASE_USAGE,
         }
     latency_ms = int((time.time() - started) * 1000)
     judge_fn = await judge_factory(output, expectations) if judge_factory else None
@@ -601,6 +658,9 @@ async def evaluate_case(
         "assertion_results": assertion_results,
         "latency_ms": latency_ms,
         "error_message": None,
+        # Judge usage is stashed on the output by the judge factory, so the
+        # totals must be computed after the judge has run.
+        **_case_usage_totals(output),
     }
 
 
@@ -751,16 +811,69 @@ def _build_result_row(
     )
 
 
-async def _execute(session, experiment: TestExperiment) -> None:
+async def _record_run_usage(
+    experiment: TestExperiment, run: TestRun, dataset: TestDataset, cfg: Dict[str, Any]
+) -> None:
+    """Mirror a finished run's token totals into a ``user_activity`` row.
+
+    One aggregated row per run (keyed by the run's own id), typed
+    ``evaluation`` and attributed to the user who triggered the run, so the
+    admin Token Usage rollup includes evaluation spend without flooding the
+    activity list with per-case rows. Cost is the per-call-accurate total
+    from ``summary_stats``, not recomputed from the summed token counts.
+
+    Monitoring only: called after the run has already been committed as
+    completed — a recording failure must never flip that run to failed, so
+    errors are logged and swallowed.
+    """
+    from decimal import Decimal
+
+    from ui.backend.services.usage_recorder import record_llm_usage
+
+    try:
+        stats = run.summary_stats or {}
+        usage = {
+            "llm_model": cfg.get("summary_model") or cfg.get("judge_model"),
+            "prompt_tokens": stats.get("prompt_tokens"),
+            "completion_tokens": stats.get("completion_tokens"),
+        }
+        cost = stats.get("cost_usd")
+        await record_llm_usage(
+            usage=usage,
+            activity_type="evaluation",
+            query=f"Evaluation: {experiment.name} (run {run.run_number})",
+            user_id=run.created_by_user_id,
+            search_id=run.id,
+            server_owned=True,
+            filters_extra={
+                "experiment_id": str(experiment.id),
+                "experiment_name": experiment.name,
+                "run_id": str(run.id),
+                "run_number": run.run_number,
+                "data_source": dataset.data_source,
+                "cases": stats.get("total"),
+            },
+            cost_usd=Decimal(str(cost)) if cost is not None else None,
+        )
+    except Exception:
+        logger.warning("Failed to record evaluation run usage", exc_info=True)
+
+
+async def _execute(
+    session, experiment: TestExperiment, triggered_by_user_id=None
+) -> None:
     dataset = await session.get(TestDataset, experiment.dataset_id)
     started = time.time()
     # Each execution is a new run; prior runs and their results are preserved.
+    # The run is attributed to whoever clicked Run (falling back to the
+    # experiment's creator for programmatic invocations) so token usage is
+    # charged to the actual spender.
     run = TestRun(
         experiment_id=experiment.id,
         run_number=await _next_run_number(session, experiment.id),
         status=EXPERIMENT_RUNNING,
         started_at=_utcnow(),
-        created_by_user_id=experiment.created_by_user_id,
+        created_by_user_id=triggered_by_user_id or experiment.created_by_user_id,
     )
     session.add(run)
     experiment.status = EXPERIMENT_RUNNING
@@ -809,6 +922,7 @@ async def _execute(session, experiment: TestExperiment) -> None:
     run.finished_at = _utcnow()
     _mirror_run_to_experiment(experiment, run)
     await session.commit()
+    await _record_run_usage(experiment, run, dataset, config)
 
 
 async def recover_orphaned_runs(session_factory=None) -> None:
@@ -845,8 +959,15 @@ async def recover_orphaned_runs(session_factory=None) -> None:
         logger.exception("Failed to recover orphaned test runs")
 
 
-async def run_experiment(experiment_id, session_factory=None) -> None:
-    """Background entrypoint: load the experiment and execute one run of it."""
+async def run_experiment(
+    experiment_id, session_factory=None, triggered_by_user_id=None
+) -> None:
+    """Background entrypoint: load the experiment and execute one run of it.
+
+    ``triggered_by_user_id`` is the admin who clicked Run (captured at the
+    route boundary before the request context is gone) — the run and its
+    token usage are attributed to them.
+    """
     factory = session_factory or async_session_factory
     async with factory() as session:
         experiment = await session.get(TestExperiment, experiment_id)
@@ -854,7 +975,7 @@ async def run_experiment(experiment_id, session_factory=None) -> None:
             logger.error("run_experiment: experiment %s not found", experiment_id)
             return
         try:
-            await _execute(session, experiment)
+            await _execute(session, experiment, triggered_by_user_id)
         except Exception:
             logger.exception("Experiment %s failed unexpectedly", experiment_id)
             await _mark_failed(session, experiment, "Experiment failed")

--- a/ui/backend/services/usage_recorder.py
+++ b/ui/backend/services/usage_recorder.py
@@ -1,0 +1,250 @@
+"""Server-side LLM usage recording into the ``user_activity`` table.
+
+Historically token usage only reached ``user_activity`` when the browser
+echoed the SSE ``done`` event's usage payload back through the activity
+routes — anything not running in a browser tab (evaluation runs, MCP/A2A
+tool calls) was invisible, and even browser paths depended on the client
+cooperating. This module records usage **at the source**: the backend
+writes (or accumulates onto) the activity row itself the moment an LLM
+call finishes, so the admin "Token Usage" rollup sees every call.
+
+Semantics:
+
+- Rows are addressed by ``search_id`` and owner-scoped exactly like the
+  client activity routes (``user_id`` first, then ``session_id``) so a
+  client-supplied id can never write into another owner's row. Purely
+  server-generated ids (evaluation runs, MCP calls) pass no owner and
+  match on ``search_id`` alone.
+- An existing row **accumulates** token counts and cost (multiple LLM
+  calls — drill-down summaries, brief sections, judge calls — sum onto
+  one row). Cost is computed per delta from the delta's own model so
+  mixed-model accumulation stays accurate; ``llm_model`` keeps the most
+  recent model as a label.
+- Recording is fire-and-forget by design (same contract as the activity
+  routes' "non-critical" client logging and the MCP audit log): a
+  failure to record usage must never break the user-facing call that
+  spent the tokens, so errors are logged server-side and swallowed.
+"""
+
+import asyncio
+import logging
+import uuid
+from decimal import Decimal
+from typing import Any, Dict, Optional, Set
+
+from sqlalchemy import select
+
+from ui.backend.auth.db import async_session_factory
+from ui.backend.auth.models import UserActivity
+from ui.backend.utils.llm_costs import compute_cost
+
+logger = logging.getLogger(__name__)
+
+# Strong references to in-flight background recording tasks so they are not
+# garbage-collected mid-write (asyncio only keeps weak refs to tasks).
+_background_tasks: Set["asyncio.Task[Any]"] = set()
+
+# Mirror the ActivityCreate schema bounds so server-recorded rows respect
+# the same limits as client-logged ones.
+_MAX_QUERY_CHARS = 5000
+_MAX_TOKENS = 10_000_000
+
+
+def usage_cost(usage: Dict[str, Any]) -> Optional[Decimal]:
+    """Cost in USD for one usage payload, or None when the model has no rate."""
+    return compute_cost(
+        usage.get("llm_model"),
+        usage.get("prompt_tokens"),
+        usage.get("completion_tokens"),
+    )
+
+
+def _clean_tokens(value: Any) -> Optional[int]:
+    """Coerce a token count to a bounded non-negative int, else None."""
+    try:
+        count = int(value)
+    except (TypeError, ValueError):
+        return None
+    if count < 0:
+        return None
+    return min(count, _MAX_TOKENS)
+
+
+def has_usage(usage: Optional[Dict[str, Any]]) -> bool:
+    """True when the payload carries at least one token count."""
+    if not usage:
+        return False
+    return bool(
+        _clean_tokens(usage.get("prompt_tokens"))
+        or _clean_tokens(usage.get("completion_tokens"))
+    )
+
+
+def _accumulate_usage(row: Any, usage: Dict[str, Any], cost: Optional[Decimal]) -> None:
+    """Add a usage delta (tokens + its own cost) onto an existing row."""
+    prompt = _clean_tokens(usage.get("prompt_tokens"))
+    completion = _clean_tokens(usage.get("completion_tokens"))
+    if prompt:
+        row.prompt_tokens = (row.prompt_tokens or 0) + prompt
+    if completion:
+        row.completion_tokens = (row.completion_tokens or 0) + completion
+    if usage.get("llm_model"):
+        row.llm_model = str(usage["llm_model"])[:128]
+    if cost is not None:
+        row.cost_usd = (row.cost_usd or Decimal(0)) + cost
+
+
+async def _find_row(
+    session: Any,
+    search_uuid: uuid.UUID,
+    user_id: Optional[uuid.UUID],
+    session_id: Optional[str],
+    server_owned: bool,
+) -> Optional[UserActivity]:
+    """Owner-scoped lookup, mirroring the client activity routes' upsert key.
+
+    A row is matched on ``search_id`` alone only for *server-generated* ids
+    (``server_owned=True`` — evaluation runs, MCP calls). Client-supplied ids
+    with no owner context never match, so an anonymous caller cannot
+    accumulate usage onto (or relabel the model of) another owner's row by
+    guessing its search id — their usage lands on a fresh row instead.
+
+    The row is locked (``FOR UPDATE``) so concurrent accumulations — e.g.
+    parallel highlight calls for one search — serialize instead of losing
+    deltas to a read-modify-write race.
+    """
+    stmt = select(UserActivity).where(UserActivity.search_id == search_uuid)
+    if user_id is not None:
+        stmt = stmt.where(UserActivity.user_id == user_id)
+    elif session_id:
+        stmt = stmt.where(UserActivity.session_id == session_id)
+    elif not server_owned:
+        return None
+    result = await session.execute(stmt.with_for_update())
+    return result.scalars().first()
+
+
+def _build_row(
+    *,
+    search_uuid: uuid.UUID,
+    activity_type: Optional[str],
+    query: str,
+    user_id: Optional[uuid.UUID],
+    session_id: Optional[str],
+    filters_extra: Optional[Dict[str, Any]],
+    usage: Dict[str, Any],
+    cost: Optional[Decimal],
+) -> UserActivity:
+    """Build a fresh activity row for a usage record with no existing row."""
+    filters: Dict[str, Any] = dict(filters_extra or {})
+    if activity_type:
+        filters["type"] = activity_type
+    row = UserActivity(
+        user_id=user_id,
+        session_id=session_id if user_id is None else None,
+        search_id=search_uuid,
+        query=query[:_MAX_QUERY_CHARS],
+        filters=filters or None,
+    )
+    _accumulate_usage(row, usage, cost)
+    return row
+
+
+def _coerce_search_id(search_id: Any) -> Optional[uuid.UUID]:
+    """Parse the caller's search/activity id; None when absent or invalid."""
+    if search_id is None:
+        return None
+    if isinstance(search_id, uuid.UUID):
+        return search_id
+    try:
+        return uuid.UUID(str(search_id))
+    except ValueError:
+        logger.warning("record_llm_usage: invalid search_id %r ignored", search_id)
+        return None
+
+
+async def record_llm_usage(
+    *,
+    usage: Optional[Dict[str, Any]],
+    activity_type: Optional[str],
+    query: str,
+    user_id: Optional[uuid.UUID] = None,
+    session_id: Optional[str] = None,
+    search_id: Any = None,
+    filters_extra: Optional[Dict[str, Any]] = None,
+    cost_usd: Optional[Decimal] = None,
+    server_owned: bool = False,
+    session_factory: Any = None,
+) -> bool:
+    """Record one LLM usage delta into ``user_activity`` (fire-and-forget).
+
+    Args:
+        usage: ``{llm_model?, prompt_tokens?, completion_tokens?}`` — the
+            shape produced by ``summarize_usage_metadata``. Skipped when it
+            carries no token counts.
+        activity_type: ``filters.type`` for a newly created row (existing
+            rows keep their filters untouched). ``None`` means the default
+            ``search`` type.
+        query: Row label when a new row is created.
+        user_id / session_id: Owner scoping for the row lookup.
+        search_id: Activity row key (str or UUID). Absent/invalid → a fresh
+            row under a random id (the usage is still never dropped).
+        filters_extra: Extra context merged into a new row's filters JSONB.
+        cost_usd: Pre-computed cost for this delta; when None the cost is
+            derived from the usage payload's model + token counts.
+        server_owned: True only for server-generated ids (evaluation runs,
+            MCP calls) — allows matching an existing row on ``search_id``
+            alone. Client-supplied ids without owner context get a fresh
+            row instead (see ``_find_row``).
+        session_factory: Injectable async session factory (tests).
+
+    Returns:
+        True when a row was written, False when skipped or failed.
+    """
+    if usage is None or not has_usage(usage):
+        return False
+    try:
+        search_uuid = _coerce_search_id(search_id) or uuid.uuid4()
+        cost = cost_usd if cost_usd is not None else usage_cost(usage)
+        factory = session_factory or async_session_factory
+        async with factory() as session:
+            row = await _find_row(
+                session, search_uuid, user_id, session_id, server_owned
+            )
+            if row is not None:
+                _accumulate_usage(row, usage, cost)
+            else:
+                session.add(
+                    _build_row(
+                        search_uuid=search_uuid,
+                        activity_type=activity_type,
+                        query=query,
+                        user_id=user_id,
+                        session_id=session_id,
+                        filters_extra=filters_extra,
+                        usage=usage,
+                        cost=cost,
+                    )
+                )
+            await session.commit()
+        return True
+    except Exception:  # pragma: no cover - defensive: never break the caller
+        logger.warning("Failed to record LLM usage", exc_info=True)
+        return False
+
+
+def schedule_llm_usage_recording(**kwargs: Any) -> None:
+    """Schedule ``record_llm_usage`` as a fire-and-forget background task.
+
+    Used by request/stream handlers so recording never adds latency to — and
+    can never fail — a product path: the DB write happens off the request,
+    after the response/stream has moved on (mirrors the MCP audit log
+    pattern). Never raises; a task reference is retained until completion so
+    the write cannot be garbage-collected mid-flight.
+    """
+    try:
+        task = asyncio.get_running_loop().create_task(record_llm_usage(**kwargs))
+        _background_tasks.add(task)
+        task.add_done_callback(_background_tasks.discard)
+    except Exception:  # pragma: no cover - defensive: never break the caller
+        logger.warning("Could not schedule LLM usage recording", exc_info=True)

--- a/ui/backend/utils/highlight_helpers.py
+++ b/ui/backend/utils/highlight_helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from jinja2 import Environment, FileSystemLoader
+from langchain_core.callbacks import UsageMetadataCallbackHandler
 from langchain_core.messages import HumanMessage, SystemMessage
 from langsmith import traceable
 
@@ -247,7 +248,14 @@ async def get_semantic_llm_output(
     query: str,
     clean_text: str,
     request: UnifiedHighlightRequest,
-) -> str:
+) -> Tuple[str, Dict[str, Any]]:
+    """Run the semantic-highlight LLM call, returning ``(output, usage)``.
+
+    ``usage`` is the token-usage payload from ``summarize_usage_metadata``;
+    a cache hit costs no tokens and returns an empty usage dict.
+    """
+    from ui.backend.services.llm_service import summarize_usage_metadata
+
     prompts_dir = Path(__file__).resolve().parents[3] / "prompts"
     jinja_env = Environment(loader=FileSystemLoader(str(prompts_dir)), autoescape=True)
     system_template = jinja_env.get_template("semantic_highlight_system.j2")
@@ -262,16 +270,21 @@ async def get_semantic_llm_output(
     llm = llm_factory.get_llm(
         model=model_key, temperature=temperature, max_tokens=max_tokens
     )
+    # Label usage with the model the call actually used, so rows from
+    # requests without a semantic_model_config are still costed.
+    usage_model_key = llm_factory.resolve_effective_model_key(model_key)
 
     cache_key = (query, hash(clean_text))
     if cache_key in HIGHLIGHT_CACHE:
-        return HIGHLIGHT_CACHE[cache_key]
+        return HIGHLIGHT_CACHE[cache_key], {}
 
+    usage_handler = UsageMetadataCallbackHandler()
     response = await llm.ainvoke(
         [
             SystemMessage(content=system_prompt),
             HumanMessage(content=user_prompt),
-        ]
+        ],
+        config={"callbacks": [usage_handler]},
     )
     content = response.content
     llm_output = (content if isinstance(content, str) else str(content)).strip()
@@ -283,7 +296,7 @@ async def get_semantic_llm_output(
     if len(HIGHLIGHT_CACHE) > 1000:
         HIGHLIGHT_CACHE.clear()
     HIGHLIGHT_CACHE[cache_key] = llm_output
-    return llm_output
+    return llm_output, summarize_usage_metadata(usage_handler, usage_model_key)
 
 
 def parse_semantic_phrases(llm_output: str) -> list[str]:

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -48,7 +48,7 @@ import FeedbackButton from './components/feedback/FeedbackButton';
 import SavedResearchModal from './components/SavedResearchModal';
 import { AuthContext, useAuthState } from './hooks/useAuth';
 import { useGroupDefaults } from './hooks/useGroupDefaults';
-import { useActivityLogging } from './hooks/useActivityLogging';
+import { getSessionId, useActivityLogging } from './hooks/useActivityLogging';
 import { buildContextualSearchQuery, serializeDrilldownTree, serializeFullDrilldownTree, patchNodeInTree } from './utils/drilldownUtils';
 import { generateUUID } from './utils/uuid';
 import { mergeFacetField } from './utils/facetMerge';
@@ -57,10 +57,11 @@ import { AssistantTab } from './components/assistant/AssistantTab';
 import { BriefTab } from './components/brief/BriefTab';
 import { AuthGate } from './components/auth/AuthGate';
 import { DEFAULT_SECTION_TYPES, DEFAULT_FIELD_BOOST_FIELDS, buildSearchURL, getSearchStateFromURL } from './utils/searchUrl';
-import { streamAiSummary, AiSummaryUsage } from './utils/aiSummaryStream';
+import { streamAiSummary } from './utils/aiSummaryStream';
 import {
   highlightTextWithAPI,
   findSemanticMatches,
+  setHighlightSearchContext,
   TextMatch
 } from './utils/textHighlighting';
 // datasource config is now fetched dynamically
@@ -1674,14 +1675,17 @@ function App() {
       query: streamQuery,
       results: leanResults,
       summaryModelConfig,
+      // Server-side usage recording context: the backend accumulates this
+      // stream's token usage onto the search's activity row (drill-down
+      // streams reuse the same id, so their usage sums onto that row too).
+      searchId: activitySearchIdRef.current || null,
       signal: abortController.signal,
       handlers: {
         onPrompt: setAiPrompt,
         onToken: setAiSummary,
-        onDone: (data) => {
-          // Stash usage so the trailing updateActivitySummary effect can
-          // include token counts + model in the PATCH that fires next.
-          aiSummaryUsageRef.current = data?.usage;
+        onDone: () => {
+          // Token usage is recorded server-side against the search row —
+          // the client no longer echoes it through the activity routes.
           setAiSummaryLoading(false);
         },
         onError: (message: string) => {
@@ -1911,6 +1915,9 @@ function App() {
           results: leanResults,
           max_results: 20,
           ...(summaryModelConfig ? { summary_model_config: summaryModelConfig } : {}),
+          // Usage-recording context: accumulate onto the search's activity row.
+          search_id: activitySearchIdRef.current || undefined,
+          session_id: getSessionId(),
         });
 
         updateNodeDataInTree(nodeId, {
@@ -1977,6 +1984,9 @@ function App() {
           results: leanResults,
           max_results: 20,
           ...(summaryModelConfig ? { summary_model_config: summaryModelConfig } : {}),
+          // Usage-recording context: accumulate onto the search's activity row.
+          search_id: activitySearchIdRef.current || undefined,
+          session_id: getSessionId(),
         }
       );
 
@@ -2184,6 +2194,9 @@ function App() {
         });
         activitySearchIdRef.current = searchId;
       }
+      // Semantic-highlight LLM calls made while viewing these results record
+      // their token usage against this search (server-side).
+      setHighlightSearchContext(searchId);
 
       // Reload facets to reflect search result distribution (with query)
       loadFacets({ includeQuery: true, queryValue: query });
@@ -2277,9 +2290,6 @@ function App() {
   const searchDurationMsRef = useRef<number>(0);
   const summaryStartMsRef = useRef<number>(0);
   const prevAiSummaryLoadingRef = useRef(false);
-  // Captured token usage from the AI summary SSE done event so the
-  // trailing PATCH /activity/{id}/summary can persist it.
-  const aiSummaryUsageRef = useRef<AiSummaryUsage | undefined>(undefined);
   useEffect(() => {
     // Detect transition from loading → done and log the completed summary
     if (
@@ -2300,9 +2310,7 @@ function App() {
         aiSummary,
         summaryDurationMs,
         drilldownTree ? serializeDrilldownTree(drilldownTree) : undefined,
-        aiSummaryUsageRef.current,
       );
-      aiSummaryUsageRef.current = undefined;
     }
     prevAiSummaryLoadingRef.current = aiSummaryLoading;
   }, [aiSummaryLoading, aiSummary, isDrilldown, updateActivitySummary, drilldownTree]);

--- a/ui/frontend/src/components/admin/ActivityManager.tsx
+++ b/ui/frontend/src/components/admin/ActivityManager.tsx
@@ -635,7 +635,19 @@ const ActivityContextPanel: React.FC<{ row: ActivityRow }> = ({ row }) => {
 // ---------------------------------------------------------------------------
 // Static filter options — user_email is dynamic (computed from data), type from known set
 const STATIC_FILTER_OPTIONS: Record<string, string[]> = {
-  type: ['search', 'heatmap', 'chat', 'assistant-basic', 'assistant-deep-research'],
+  type: [
+    'search',
+    'heatmap',
+    'chat',
+    'assistant-basic',
+    'assistant-deep-research',
+    'brief',
+    'highlight',
+    'evaluation',
+    'mcp-assistant',
+    'a2a-assistant',
+    'pipeline',
+  ],
 };
 
 interface FilterPopoverProps {

--- a/ui/frontend/src/components/admin/LlmUsageManager.tsx
+++ b/ui/frontend/src/components/admin/LlmUsageManager.tsx
@@ -45,6 +45,12 @@ const ACTIVITY_TYPES: ReadonlyArray<{ value: string; label: string }> = [
   { value: 'chat', label: 'Chat' },
   { value: 'assistant-basic', label: 'Assistant (basic)' },
   { value: 'assistant-deep-research', label: 'Assistant (deep)' },
+  { value: 'brief', label: 'Brief' },
+  { value: 'highlight', label: 'Highlighting' },
+  { value: 'evaluation', label: 'Evaluations' },
+  { value: 'mcp-assistant', label: 'MCP assistant' },
+  { value: 'a2a-assistant', label: 'A2A assistant' },
+  { value: 'pipeline', label: 'Pipeline' },
 ];
 
 const NULL_CELL = '—';

--- a/ui/frontend/src/components/admin/testing/ExperimentDetail.tsx
+++ b/ui/frontend/src/components/admin/testing/ExperimentDetail.tsx
@@ -10,10 +10,12 @@ import type {
   TestRun,
 } from '../../../types/testing';
 import {
+  formatCostUsd,
   formatMs,
   formatPercent,
   formatScore,
   formatTimestamp,
+  formatTokens,
   prettyJson,
 } from './testingFormat';
 import RunPassRateChart from './RunPassRateChart';
@@ -64,6 +66,14 @@ const RunStats: React.FC<{ run: TestRun }> = ({ run }) => {
       <div className="testing-summary-stat">
         <span className="testing-summary-label">Duration</span>
         <span>{formatMs(stats?.duration_ms)}</span>
+      </div>
+      <div className="testing-summary-stat">
+        <span className="testing-summary-label">Tokens</span>
+        <span>{formatTokens(stats?.total_tokens)}</span>
+      </div>
+      <div className="testing-summary-stat">
+        <span className="testing-summary-label">Cost</span>
+        <span>{formatCostUsd(stats?.cost_usd)}</span>
       </div>
       <div className="testing-summary-stat">
         <span className="testing-summary-label">Started</span>

--- a/ui/frontend/src/components/admin/testing/testingFormat.ts
+++ b/ui/frontend/src/components/admin/testing/testingFormat.ts
@@ -15,6 +15,16 @@ export const formatMs = (ms?: number | null): string => {
   return `${Math.round(ms)} ms`;
 };
 
+export const formatTokens = (tokens?: number | null): string => {
+  if (tokens === null || tokens === undefined) return '-';
+  return tokens.toLocaleString();
+};
+
+export const formatCostUsd = (cost?: number | null): string => {
+  if (cost === null || cost === undefined) return '-';
+  return `$${cost.toFixed(4)}`;
+};
+
 export const formatTimestamp = (ts?: string | null): string => {
   if (!ts) return '-';
   const d = new Date(ts);

--- a/ui/frontend/src/components/app/HeatmapTabContent.tsx
+++ b/ui/frontend/src/components/app/HeatmapTabContent.tsx
@@ -1050,7 +1050,10 @@ const getTranslatedSemanticMatches = async (
       translatedText,
       queryText,
       SEMANTIC_HIGHLIGHT_THRESHOLD,
-      semanticHighlightModelConfig
+      semanticHighlightModelConfig,
+      // Heatmap highlighting is not tied to the results-tab search — detach
+      // from the search usage context so tokens record standalone.
+      null
     );
   } catch (error) {
     console.error('Heatmap translated highlight failed', error);
@@ -2600,7 +2603,9 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
           text,
           queryText,
           SEMANTIC_HIGHLIGHT_THRESHOLD,
-          semanticHighlightModelConfig
+          semanticHighlightModelConfig,
+          // Heatmap highlighting is not tied to the results-tab search.
+          null
         );
         const rowKey = rowDimension === 'queries'
           ? `row-${activeCell.rowIndex}`

--- a/ui/frontend/src/components/assistant/AssistantTab.tsx
+++ b/ui/frontend/src/components/assistant/AssistantTab.tsx
@@ -7,7 +7,6 @@ import { SearchSettings } from '../../types/auth';
 import {
   streamAssistantChat,
   AssistantStreamHandlers,
-  AssistantUsage,
 } from '../../utils/assistantStream';
 import { useActivityLogging } from '../../hooks/useActivityLogging';
 import RatingModal from '../ratings/RatingModal';
@@ -256,8 +255,10 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
     const controller = new AbortController();
     abortRef.current = controller;
 
-    // Captured from the SSE done event so logSearch can persist tokens/model.
-    let lastUsage: AssistantUsage | undefined;
+    // Generated up front and sent with the stream request so the backend can
+    // record this turn's token usage server-side against the same activity
+    // row logSearch upserts below.
+    const activityId = crypto.randomUUID();
 
     const handlers: AssistantStreamHandlers = {
       onPhase: (phase) => setStreamingPhase(phase),
@@ -280,7 +281,6 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
           setActiveThreadId(data.threadId);
           if (isAuthenticated) loadThreads();
         }
-        lastUsage = data.usage;
         setLastResponseDeep(deepResearch);
       },
       onError: (message) => {
@@ -326,6 +326,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
         searchSettings: searchSettings,
         deepResearch,
         conversationHistory: history,
+        activityId,
         handlers,
         signal: controller.signal,
       });
@@ -348,8 +349,8 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
           },
         ]);
 
-        // Log assistant interaction to activity
-        const activityId = crypto.randomUUID();
+        // Log assistant interaction to activity (same id the stream recorded
+        // its token usage under, so both land on one row)
         const searchResults: SearchResult[] = finalToolCalls.flatMap((tc) =>
           (tc.results || []).map((r) => ({
             chunk_id: '',
@@ -372,7 +373,7 @@ export const AssistantTab: React.FC<AssistantTabProps> = ({
               text: r.text || '',
             })),
           })),
-        }, searchResults, undefined, finalContent, lastUsage);
+        }, searchResults, undefined, finalContent);
       }
     } finally {
       // Always clear streaming state, even on error/abort

--- a/ui/frontend/src/components/brief/briefHighlights.ts
+++ b/ui/frontend/src/components/brief/briefHighlights.ts
@@ -206,9 +206,11 @@ const enrichSource = async (
       claims.map(async ({ key, prose }) => {
         if (isStale?.()) return null;
         try {
-          const matches = (await findSemanticMatches(body, prose, threshold, modelConfig)).filter(
-            (m) => m.end - m.start >= MIN_MATCH_CHARS,
-          );
+          // null: brief citation highlighting is not tied to the results-tab
+          // search — detach from the search usage context.
+          const matches = (
+            await findSemanticMatches(body, prose, threshold, modelConfig, null)
+          ).filter((m) => m.end - m.start >= MIN_MATCH_CHARS);
           if (!matches.length) return null;
           const entry = { claim: key, matches };
           // Publish immediately: the open card gains this span now rather

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -607,6 +607,12 @@ export const useBrief = ({
     abortRef.current = controller;
     const guidance = (overrides?.instructions ?? instructions).trim();
     let gathered: BriefSourceSample[] = [];
+    // Allocate the new brief's activity id up front so the survey and outline
+    // LLM calls record their token usage onto it server-side (tokens are
+    // spent even when outline generation is aborted midway). Kept LOCAL until
+    // the outline succeeds, so a failed attempt never re-points a currently
+    // loaded brief's activity row.
+    const activityId = newActivityId();
     try {
       const surveyQuery = guidance
         ? `Research the document library to inform an evidence brief on "${topic}". Follow these author instructions closely and let them drive what you search for — focus your queries on the specific angles, sectors, regions, populations and outcomes the instructions call for, not just generic restatements of the topic: ${guidance}`
@@ -619,6 +625,7 @@ export const useBrief = ({
         assistantModelConfig,
         rerankerModel: rerankerModelRef.current,
         searchSettings: searchSettingsRef.current,
+        activityId,
         signal: controller.signal,
         handlers: {
           onActivity: (ev) => setGeneratingActivity((prev) => [ev, ...prev].slice(0, 40)),
@@ -646,10 +653,11 @@ export const useBrief = ({
         numHeadings: overrides?.numHeadings ?? numHeadings,
         model: assistantModelConfig?.model ?? null,
         sources: gathered,
+        activityId,
         signal: controller.signal,
       });
       briefIdRef.current = uid();
-      briefActivityIdRef.current = newActivityId();
+      briefActivityIdRef.current = activityId;
       remoteSavedRef.current = false;
       setCanEdit(true);
       setOwnerName(null);
@@ -823,6 +831,7 @@ export const useBrief = ({
         assistantModelConfig,
         rerankerModel: rerankerModelRef.current,
         searchSettings: searchSettingsRef.current,
+        activityId: briefActivityIdRef.current,
         mode,
         existingContent: isRevise ? priorContent : null,
         instruction,
@@ -1046,7 +1055,8 @@ export const useBrief = ({
           content: priorContent,
           instruction: instruction.trim(),
           voiceInstructions: voiceInstructionsFor(section.voiceId),
-          signal: controller.signal,
+          activityId: briefActivityIdRef.current,
+            signal: controller.signal,
         });
         if (controller.signal.aborted) return;
         const cur = sectionsRef.current.find((s) => s.id === id);

--- a/ui/frontend/src/hooks/useActivityLogging.ts
+++ b/ui/frontend/src/hooks/useActivityLogging.ts
@@ -18,16 +18,26 @@ export interface ActivityUsage {
 
 /**
  * Return a stable anonymous session ID (persisted in localStorage).
- * Used to correlate activity records for non-authenticated visitors.
+ * Used to correlate activity records for non-authenticated visitors, and
+ * sent with LLM requests so the backend can record token usage
+ * server-side against the right owner.
+ *
+ * Never throws: browsers with blocked storage (some private modes) fall
+ * back to a per-call random ID so callers (search logging, highlighting,
+ * streams) are never broken by storage access errors.
  */
-function getSessionId(): string {
+export function getSessionId(): string {
   const KEY = 'evidencelab_session_id';
-  let id = localStorage.getItem(KEY);
-  if (!id) {
-    id = crypto.randomUUID();
-    localStorage.setItem(KEY, id);
+  try {
+    let id = localStorage.getItem(KEY);
+    if (!id) {
+      id = crypto.randomUUID();
+      localStorage.setItem(KEY, id);
+    }
+    return id;
+  } catch {
+    return crypto.randomUUID();
   }
-  return id;
 }
 
 /**

--- a/ui/frontend/src/tests/briefHighlights.test.ts
+++ b/ui/frontend/src/tests/briefHighlights.test.ts
@@ -119,6 +119,8 @@ describe('highlightSectionSources', () => {
       expect.stringContaining('cash transfers improved'),
       0.6,
       undefined,
+      // Brief highlighting detaches from the results-tab search usage context.
+      null,
     );
   });
 

--- a/ui/frontend/src/tests/highlighting.test.ts
+++ b/ui/frontend/src/tests/highlighting.test.ts
@@ -41,15 +41,19 @@ describe('Semantic Highlighting', () => {
       expect.stringContaining('/api/highlight'),
       expect.objectContaining({
         method: 'POST',
-        headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({
-          query: query,
-          text: text,
-          highlight_type: 'semantic',
-          semantic_threshold: threshold
-        })
+        headers: expect.objectContaining({ 'Content-Type': 'application/json' })
       })
     );
+    const sentBody = JSON.parse((fetch as jest.Mock).mock.calls[0][1].body);
+    expect(sentBody).toMatchObject({
+      query: query,
+      text: text,
+      highlight_type: 'semantic',
+      semantic_threshold: threshold
+    });
+    // Usage-recording context (anonymous session id) rides along so the
+    // backend can attribute semantic-highlight token usage server-side.
+    expect(typeof sentBody.session_id).toBe('string');
   });
 
   test('findSemanticMatches handles empty response', async () => {

--- a/ui/frontend/src/tests/testingFormat.test.ts
+++ b/ui/frontend/src/tests/testingFormat.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Unit tests for the testing-harness formatting helpers.
+ */
+
+import {
+  formatCostUsd,
+  formatTokens,
+} from '../components/admin/testing/testingFormat';
+
+describe('formatTokens', () => {
+  test('formats counts with locale separators', () => {
+    expect(formatTokens(1234567)).toBe((1234567).toLocaleString());
+    expect(formatTokens(0)).toBe('0');
+  });
+
+  test('renders dash for missing values', () => {
+    expect(formatTokens(null)).toBe('-');
+    expect(formatTokens(undefined)).toBe('-');
+  });
+});
+
+describe('formatCostUsd', () => {
+  test('formats cost with 4 decimals and dollar sign', () => {
+    expect(formatCostUsd(0.00304)).toBe('$0.0030');
+    expect(formatCostUsd(1.5)).toBe('$1.5000');
+  });
+
+  test('renders dash for missing values', () => {
+    expect(formatCostUsd(null)).toBe('-');
+    expect(formatCostUsd(undefined)).toBe('-');
+  });
+});

--- a/ui/frontend/src/types/testing.ts
+++ b/ui/frontend/src/types/testing.ts
@@ -78,6 +78,11 @@ export interface SummaryStats {
   pass_rate: number;
   mean_score?: number | null;
   duration_ms: number;
+  // Total LLM usage across the run's cases (summary + judge calls).
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  cost_usd?: number | null;
   error?: string;
   progress?: RunProgress | null;
 }

--- a/ui/frontend/src/utils/aiSummaryStream.ts
+++ b/ui/frontend/src/utils/aiSummaryStream.ts
@@ -1,4 +1,5 @@
 import { API_KEY } from '../config';
+import { getSessionId } from '../hooks/useActivityLogging';
 import { SearchResult, SummaryModelConfig } from '../types/api';
 
 export interface AiSummaryUsage {
@@ -9,6 +10,8 @@ export interface AiSummaryUsage {
 
 interface AiSummaryDoneData {
   langsmith_trace_url?: string;
+  // Informational only: the backend records usage server-side against the
+  // search's activity row when the request carried a searchId.
   usage?: AiSummaryUsage;
 }
 
@@ -25,6 +28,11 @@ interface AiSummaryStreamOptions {
   query: string;
   results: SearchResult[];
   summaryModelConfig?: SummaryModelConfig | null;
+  // Activity row (search_id) the backend records this summary's token usage
+  // onto, server-side (drill-downs reuse the parent search's id and
+  // accumulate onto the same row). The anonymous session id is resolved
+  // internally.
+  searchId?: string | null;
   handlers: AiSummaryStreamHandlers;
   signal?: AbortSignal;
 }
@@ -145,6 +153,7 @@ export const streamAiSummary = async ({
   query,
   results,
   summaryModelConfig,
+  searchId,
   handlers,
   signal,
 }: AiSummaryStreamOptions): Promise<void> => {
@@ -157,6 +166,8 @@ export const streamAiSummary = async ({
       max_results: results.length,
       summary_model: summaryModelConfig?.model || undefined,
       summary_model_config: summaryModelConfig || undefined,
+      search_id: searchId || undefined,
+      session_id: getSessionId(),
     }),
     signal,
   });

--- a/ui/frontend/src/utils/assistantStream.ts
+++ b/ui/frontend/src/utils/assistantStream.ts
@@ -1,4 +1,5 @@
 import { API_KEY } from '../config';
+import { getSessionId } from '../hooks/useActivityLogging';
 import { SummaryModelConfig, SourceReference, SearchToolCall } from '../types/api';
 import { SearchSettings } from '../types/auth';
 
@@ -12,6 +13,8 @@ export interface AssistantDoneData {
   threadId?: string;
   messageId?: string;
   langsmith_trace_url?: string;
+  // Informational only: the backend records usage server-side against the
+  // activity row when the request carried an activityId.
   usage?: AssistantUsage;
 }
 
@@ -46,6 +49,13 @@ interface AssistantStreamOptions {
   // ISO date; constrains the library search to documents published on/after it
   // (Brief "Update" action). Sent inside search_settings.published_after.
   publishedAfter?: string | null;
+  // Activity row (search_id) the backend records this turn's token usage
+  // onto, server-side. Brief sections pass their brief's stable id so all
+  // section research accumulates onto one row, with usageContext 'brief' so
+  // a newly created row is typed 'brief'. The anonymous session id is
+  // resolved internally.
+  activityId?: string | null;
+  usageContext?: 'brief' | null;
   handlers: AssistantStreamHandlers;
   signal?: AbortSignal;
 }
@@ -221,6 +231,8 @@ export const streamAssistantChat = async ({
   deepResearch,
   conversationHistory,
   publishedAfter,
+  activityId,
+  usageContext,
   handlers,
   signal,
 }: AssistantStreamOptions): Promise<void> => {
@@ -243,6 +255,9 @@ export const streamAssistantChat = async ({
       search_settings: searchSettingsBody,
       deep_research: deepResearch || undefined,
       conversation_history: conversationHistory?.length ? conversationHistory : undefined,
+      activity_id: activityId || undefined,
+      session_id: getSessionId(),
+      usage_context: usageContext || undefined,
     }),
     signal,
   });

--- a/ui/frontend/src/utils/briefStream.ts
+++ b/ui/frontend/src/utils/briefStream.ts
@@ -8,6 +8,7 @@
 // cross-encoder runs on CPU and is far too slow for multi-query research).
 
 import { API_KEY } from '../config';
+import { getSessionId } from '../hooks/useActivityLogging';
 import { SourceReference, SummaryModelConfig } from '../types/api';
 import { SearchSettings } from '../types/auth';
 import { streamAssistantChat } from './assistantStream';
@@ -50,6 +51,10 @@ export interface RequestOutlineOptions {
   numHeadings?: number | null;
   model?: string | null;
   sources?: BriefSourceSample[];
+  // The brief's stable activity id, so the backend records outline LLM
+  // usage server-side onto the brief's activity row (the anonymous session
+  // id is resolved internally).
+  activityId?: string | null;
   signal?: AbortSignal;
 }
 
@@ -61,6 +66,7 @@ export const requestBriefOutline = async ({
   numHeadings,
   model,
   sources,
+  activityId,
   signal,
 }: RequestOutlineOptions): Promise<BriefOutline> => {
   const response = await fetch(`${apiBaseUrl}/brief/outline`, {
@@ -74,6 +80,8 @@ export const requestBriefOutline = async ({
       instructions: instructions ?? null,
       num_headings: numHeadings ?? null,
       sources: sources ?? null,
+      activity_id: activityId ?? null,
+      session_id: getSessionId(),
     }),
     signal,
   });
@@ -111,6 +119,7 @@ export const requestBriefRevise = async ({
   instruction,
   model,
   voiceInstructions,
+  activityId,
   signal,
 }: {
   apiBaseUrl: string;
@@ -119,6 +128,8 @@ export const requestBriefRevise = async ({
   instruction: string;
   model?: string | null;
   voiceInstructions?: string | null;
+  // Usage-recording context (see RequestOutlineOptions).
+  activityId?: string | null;
   signal?: AbortSignal;
 }): Promise<string> => {
   const response = await fetch(`${apiBaseUrl}/brief/revise`, {
@@ -131,6 +142,8 @@ export const requestBriefRevise = async ({
       data_source: dataSource,
       model: model ?? null,
       voice_instructions: voiceInstructions ?? null,
+      activity_id: activityId ?? null,
+      session_id: getSessionId(),
     }),
     signal,
   });
@@ -186,6 +199,10 @@ export interface RunDeepResearchOptions {
   rerankerModel?: string | null;
   searchSettings?: Partial<SearchSettings> | null;
   publishedAfter?: string | null;
+  // The brief's stable activity id, so the backend records this research
+  // turn's token usage onto the brief's activity row (typed 'brief' via
+  // the stream's usageContext).
+  activityId?: string | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -203,6 +220,7 @@ export const runDeepResearch = async ({
   rerankerModel = null,
   searchSettings = null,
   publishedAfter = null,
+  activityId = null,
   handlers,
   signal,
 }: RunDeepResearchOptions): Promise<void> => {
@@ -218,6 +236,8 @@ export const runDeepResearch = async ({
     rerankerModel: rerankerModel ?? null,
     searchSettings: searchSettings ?? null,
     publishedAfter: publishedAfter ?? null,
+    activityId: activityId ?? null,
+    usageContext: 'brief',
     handlers: {
       onPhase: (phase) => {
         const pct = PHASE_PROGRESS[phase];
@@ -285,6 +305,8 @@ export interface ResearchSectionOptions {
   // Rendered outline of the whole brief (see buildOutlineContext), so the
   // section stays in scope and doesn't duplicate other sections.
   outlineContext?: string | null;
+  // Usage-recording context (see RunDeepResearchOptions).
+  activityId?: string | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -498,6 +520,7 @@ export const researchBriefSection = ({
   publishedAfterIso,
   voiceInstructions,
   outlineContext,
+  activityId,
   handlers,
   signal,
 }: ResearchSectionOptions): Promise<void> => {
@@ -525,6 +548,7 @@ export const researchBriefSection = ({
     // filter the backend applies to the Qdrant query (belt-and-braces with the
     // prompt instruction above).
     publishedAfter: mode === 'update' ? publishedAfterIso : null,
+    activityId,
     handlers,
     signal,
   });

--- a/ui/frontend/src/utils/textHighlighting.tsx
+++ b/ui/frontend/src/utils/textHighlighting.tsx
@@ -1,11 +1,25 @@
 // Shared text highlighting and rendering utilities used by App, PDFViewer, and SearchResultCard
 import React from 'react';
 import API_BASE_URL, { API_KEY, SEARCH_SEMANTIC_HIGHLIGHTS } from '../config';
+import { getSessionId } from '../hooks/useActivityLogging';
 import { SearchResult, SummaryModelConfig } from '../types/api';
 
 const getCsrfToken = (): string | null => {
   const match = document.cookie.match(/(?:^|;\s*)evidencelab_csrf=([^;]*)/);
   return match ? decodeURIComponent(match[1]) : null;
+};
+
+// The current search's activity id, set by App after each search so semantic
+// highlight LLM calls can be usage-tracked server-side against that search
+// (module-level because the highlight call sits several layers below the
+// component that knows the search id). Callers highlighting OUTSIDE the
+// search results context (heatmap, brief citations) must pass
+// `searchIdOverride: null` to detach from it — their usage then records on
+// its own rows instead of the last search's.
+let highlightSearchId: string | null = null;
+
+export const setHighlightSearchContext = (searchId: string | null): void => {
+  highlightSearchId = searchId;
 };
 
 export interface TextMatch {
@@ -184,7 +198,10 @@ export const highlightTextWithAPI = async (
   query: string,
   highlightType: 'keyword' | 'semantic' | 'both' = 'both',
   threshold: number = 0.4,
-  semanticModelConfig?: SummaryModelConfig | null
+  semanticModelConfig?: SummaryModelConfig | null,
+  // undefined → attribute usage to the current search context; null → this
+  // call is not search-related (heatmap, brief) and records standalone.
+  searchIdOverride?: string | null
 ): Promise<any> => {
   if (!query.trim() || !text.trim()) return { highlighted_text: text, matches: [] };
 
@@ -203,7 +220,12 @@ export const highlightTextWithAPI = async (
         text: text,
         highlight_type: highlightType,
         semantic_threshold: threshold,
-        semantic_model_config: semanticModelConfig || undefined
+        semantic_model_config: semanticModelConfig || undefined,
+        // Usage-recording context (see setHighlightSearchContext).
+        search_id:
+          (searchIdOverride === undefined ? highlightSearchId : searchIdOverride) ||
+          undefined,
+        session_id: getSessionId()
       })
     });
 
@@ -420,7 +442,10 @@ export const findSemanticMatches = async (
   text: string,
   query: string,
   threshold: number = 0.4,
-  semanticModelConfig?: SummaryModelConfig | null
+  semanticModelConfig?: SummaryModelConfig | null,
+  // Forwarded to highlightTextWithAPI: pass null from non-search surfaces
+  // (heatmap, brief) so usage is not attributed to the last search.
+  searchIdOverride?: string | null
 ): Promise<TextMatch[]> => {
   if (!query.trim() || !text.trim()) return [];
 
@@ -430,7 +455,8 @@ export const findSemanticMatches = async (
     query,
     'semantic',
     threshold,
-    semanticModelConfig
+    semanticModelConfig,
+    searchIdOverride
   );
 
   if (!responseData || !responseData.matches || !Array.isArray(responseData.matches)) {

--- a/utils/llm_factory.py
+++ b/utils/llm_factory.py
@@ -247,6 +247,22 @@ def _normalize_model_key(value: Any) -> Optional[str]:
     return None
 
 
+def resolve_effective_model_key(model: Optional[str]) -> Optional[str]:
+    """Return the model key a ``get_llm(model=...)`` call actually uses.
+
+    Mirrors ``get_llm``'s own default resolution (explicit arg, then the
+    ``LLM_MODEL`` env var, then the configured default) so token-usage
+    recording can label calls with the real model even when the caller
+    passed ``model=None`` — without this, such usage rows carry no model
+    and can never be costed.
+    """
+    if model:
+        return model
+    return os.getenv("LLM_MODEL") or _normalize_model_key(
+        _load_llm_config().get("model")
+    )
+
+
 def _normalize_default_max_tokens(value: Any) -> int:
     if isinstance(value, int):
         return value


### PR DESCRIPTION
## Description

The admin Token Usage rollup previously only saw usage the **browser** echoed back after streaming search summaries and assistant chats — evaluations (LLM judge + summary calls), briefs, drill-downs, semantic highlighting, MCP/A2A assistant calls, and the ingestion pipeline all spent tokens invisibly. This PR moves recording **server-side at the source**: the backend writes (or accumulates onto) `user_activity` rows the moment an LLM call finishes, scheduled as fire-and-forget background tasks so monitoring can never add latency to or fail a product path.

**Coverage added**
- **Evaluations**: judge calls instrumented; per-case tokens/cost on `test_results` (migration `0032`); run totals in `summary_stats` + shown in the experiment UI; one `evaluation` activity row per run, attributed to the admin who clicked Run.
- **Brief**: outline, per-section deep research, and edits all accumulate onto the brief's single activity row (previously NULL tokens on every brief).
- **Search**: drill-down summaries (streaming and the non-streaming Find-out-more/Add-node flows) accumulate onto the parent search's row; the non-streaming endpoint no longer discards usage.
- **Semantic highlighting**: one accumulating `highlight` row per originating search; heatmap/brief highlighting records standalone.
- **MCP/A2A**: the usage payload the stream already emitted is now recorded (anonymous rows with the caller's real API identity in filters; the A2A branch now sets the request auth context).
- **Pipeline**: summarizer + TOC/taxonomy taggers flush one anonymous `pipeline` row per document per stage.

**Correctness/robustness** (validated by an 8-angle adversarial review; all findings fixed): owner-scoped upserts so a client-supplied id can never write into another owner's row, `FOR UPDATE` against concurrent-accumulation races, patch semantics on the activity POST (a usage-less Brief re-save no longer nulls recorded tokens), and the legacy client usage echo removed so the server is the single writer. Deliberately unmetered (documented follow-up): embeddings and rerankers — no token counts are exposed at their client boundaries today.

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Testing
- [x] Tests pass locally — full backend unit suite **1874 passed** (against the committed config; verified via a clean worktree), frontend **659 passed**, `tsc` clean, pre-commit hooks (black/isort/flake8/mypy/bandit/secrets/code-metrics) pass on every commit
- [x] New tests added — ~40 new unit tests across the recorder, pipeline collector, eval runner rollup/attribution, activity patch semantics, and format helpers
- [x] Manual testing completed — migration applied to the dev DB, API/MCP containers restarted cleanly, recorder INSERT exercised against the live schema

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review of code completed (8-angle multi-agent review; all confirmed findings fixed)
- [x] Documentation updated (`docs/admin/system-monitoring.md` — LLM Token Usage section)
- [x] No breaking changes — all API additions are optional fields; existing clients keep working

🤖 Generated with [Claude Code](https://claude.com/claude-code)