### PR TITLE
fix(ui): stop dropdown menus swallowing slow clicks

### DIFF
--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -631,12 +631,12 @@ function App() {
     setShowDomainTooltip(false);
   }, []);
 
-  const handleDomainBlur = useCallback(() => {
-    setTimeout(() => setDomainDropdownOpen(false), 200);
+  const handleCloseDomainDropdown = useCallback(() => {
+    setDomainDropdownOpen(false);
   }, []);
 
-  const handleModelBlur = useCallback(() => {
-    setTimeout(() => setModelDropdownOpen(false), 200);
+  const handleCloseModelDropdown = useCallback(() => {
+    setModelDropdownOpen(false);
   }, []);
 
   const handleSelectDomain = useCallback((domainName: string) => {
@@ -662,8 +662,8 @@ function App() {
     setModelDropdownOpen(false);
   }, [helpDropdownOpen]);
 
-  const handleHelpBlur = useCallback(() => {
-    setTimeout(() => setHelpDropdownOpen(false), 200);
+  const handleCloseHelpDropdown = useCallback(() => {
+    setHelpDropdownOpen(false);
   }, []);
 
   // Get current datasource config
@@ -2919,12 +2919,12 @@ function App() {
         onToggleModelDropdown={handleToggleModelDropdown}
         onDomainMouseEnter={handleDomainMouseEnter}
         onDomainMouseLeave={handleDomainMouseLeave}
-        onDomainBlur={handleDomainBlur}
-        onModelBlur={handleModelBlur}
+        onCloseDomainDropdown={handleCloseDomainDropdown}
+        onCloseModelDropdown={handleCloseModelDropdown}
         onSelectDomain={handleSelectDomain}
         onSelectModelCombo={handleSelectModelCombo}
         onToggleHelpDropdown={handleToggleHelpDropdown}
-        onHelpBlur={handleHelpBlur}
+        onCloseHelpDropdown={handleCloseHelpDropdown}
         onAboutClick={handleAboutClick}
         onTechClick={handleTechClick}
         onDataClick={handleDataClick}

--- a/ui/frontend/src/components/auth/UserMenu.test.tsx
+++ b/ui/frontend/src/components/auth/UserMenu.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
-
-jest.mock('axios');
-
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import axios from 'axios';
 import UserMenu from './UserMenu';
 import { AuthContext } from '../../hooks/useAuth';
 import type { AuthContextValue } from '../../types/auth';
+
+jest.mock('axios');
+
+const ALICE_EMAIL = 'alice@example.com';
+const ALICE_NAME = 'Alice Baker';
 
 const mockAuthValue = (overrides: Partial<AuthContextValue> = {}): AuthContextValue => ({
   user: null,
@@ -49,10 +52,10 @@ describe('UserMenu', () => {
         isAuthenticated: true,
         user: {
           id: '1',
-          email: 'alice@example.com',
+          email: ALICE_EMAIL,
           first_name: 'Alice',
           last_name: 'Baker',
-          display_name: 'Alice Baker',
+          display_name: ALICE_NAME,
           is_active: true,
           is_verified: true,
           is_superuser: false,
@@ -71,10 +74,10 @@ describe('UserMenu', () => {
         isAuthenticated: true,
         user: {
           id: '1',
-          email: 'alice@example.com',
+          email: ALICE_EMAIL,
           first_name: 'Alice',
           last_name: 'Baker',
-          display_name: 'Alice Baker',
+          display_name: ALICE_NAME,
           is_active: true,
           is_verified: true,
           is_superuser: false,
@@ -143,7 +146,7 @@ describe('UserMenu', () => {
         logout,
         user: {
           id: '1',
-          email: 'alice@example.com',
+          email: ALICE_EMAIL,
           first_name: 'Alice',
           last_name: null,
           display_name: 'Alice',
@@ -158,5 +161,82 @@ describe('UserMenu', () => {
     fireEvent.click(screen.getByText('A'));
     fireEvent.click(screen.getByText('Sign Out'));
     expect(logout).toHaveBeenCalled();
+  });
+
+  describe('menu item clicks survive the trigger losing focus', () => {
+    const signedInAdmin = () =>
+      mockAuthValue({
+        isAuthenticated: true,
+        user: {
+          id: '1',
+          email: ALICE_EMAIL,
+          first_name: 'Alice',
+          last_name: 'Baker',
+          display_name: ALICE_NAME,
+          is_active: true,
+          is_verified: true,
+          is_superuser: true,
+          created_at: null,
+          updated_at: null,
+        },
+      });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('opens Saved Research when the click lands long after focus left the trigger', async () => {
+      jest.useFakeTimers();
+      (axios.get as jest.Mock).mockResolvedValue({ data: [] });
+      renderWithAuth(signedInAdmin(), { onLoadResearch: jest.fn() });
+      const trigger = screen.getByText('AB');
+      fireEvent.click(trigger);
+      const item = screen.getByText('Saved Research');
+      // A real click moves focus off the trigger on mouse-down; the mouse-up
+      // (and so the click) can arrive much later on a slow click or a remote
+      // desktop. The item must still be there when it does.
+      fireEvent.mouseDown(item);
+      fireEvent.focusOut(trigger);
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      fireEvent.click(item);
+      expect(screen.getByText('Load Previous Research')).toBeInTheDocument();
+      await act(async () => {
+        for (let i = 0; i < 5; i++) await Promise.resolve();
+      });
+    });
+
+    it('opens Admin when the click lands long after focus left the trigger', () => {
+      jest.useFakeTimers();
+      const onAdminClick = jest.fn();
+      renderWithAuth(signedInAdmin(), { onAdminClick });
+      const trigger = screen.getByText('AB');
+      fireEvent.click(trigger);
+      const item = screen.getByRole('button', { name: 'Admin' });
+      fireEvent.mouseDown(item);
+      fireEvent.focusOut(trigger);
+      act(() => {
+        jest.advanceTimersByTime(1000);
+      });
+      fireEvent.click(item);
+      expect(onAdminClick).toHaveBeenCalledTimes(1);
+      expect(screen.queryByRole('button', { name: 'Admin' })).not.toBeInTheDocument();
+    });
+
+    it('closes when the user presses outside the menu', () => {
+      renderWithAuth(signedInAdmin());
+      fireEvent.click(screen.getByText('AB'));
+      expect(screen.getByText('Profile')).toBeInTheDocument();
+      fireEvent.mouseDown(document.body);
+      expect(screen.queryByText('Profile')).not.toBeInTheDocument();
+    });
+
+    it('closes on Escape', () => {
+      renderWithAuth(signedInAdmin());
+      fireEvent.click(screen.getByText('AB'));
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(screen.queryByText('Profile')).not.toBeInTheDocument();
+    });
   });
 });

--- a/ui/frontend/src/components/auth/UserMenu.tsx
+++ b/ui/frontend/src/components/auth/UserMenu.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '../../hooks/useAuth';
+import { useCloseOnOutsideClick } from '../../hooks/useCloseOnOutsideClick';
 import LoginModal from './LoginModal';
 import ProfileModal from './ProfileModal';
 import SavedResearchModal from '../SavedResearchModal';
@@ -18,6 +19,9 @@ const UserMenu: React.FC<UserMenuProps> = ({ onAdminClick, onLoadResearch }) => 
   const [showLogin, setShowLogin] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [showSavedResearch, setShowSavedResearch] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const closeMenu = useCallback(() => setMenuOpen(false), []);
+  useCloseOnOutsideClick(containerRef, menuOpen, closeMenu);
 
   // Auto-open the login modal when a verification message arrives
   useEffect(() => {
@@ -42,11 +46,6 @@ const UserMenu: React.FC<UserMenuProps> = ({ onAdminClick, onLoadResearch }) => 
         .toUpperCase()
         .slice(0, 2)
     : user?.email?.charAt(0).toUpperCase() || '?';
-
-  const handleBlur = () => {
-    // Delay to allow click events on dropdown items
-    setTimeout(() => setMenuOpen(false), 200);
-  };
 
   if (!isAuthenticated) {
     return (
@@ -73,11 +72,10 @@ const UserMenu: React.FC<UserMenuProps> = ({ onAdminClick, onLoadResearch }) => 
 
   return (
     <>
-      <div className="dropdown-container">
+      <div className="dropdown-container" ref={containerRef}>
         <button
           className="user-menu-trigger"
           onClick={() => setMenuOpen(!menuOpen)}
-          onBlur={handleBlur}
           title={user?.email || 'User menu'}
         >
           {initials}

--- a/ui/frontend/src/components/layout/NavTabs.test.tsx
+++ b/ui/frontend/src/components/layout/NavTabs.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { NavTabs } from './NavTabs';
+
+describe('NavTabs Monitor dropdown', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('still selects an item when the click lands long after the trigger lost focus', () => {
+    jest.useFakeTimers();
+    const onTabChange = jest.fn();
+    render(<NavTabs activeTab="search" onTabChange={onTabChange} />);
+    const trigger = screen.getByText('Monitor');
+    fireEvent.click(trigger);
+    const item = screen.getByText('Pipeline');
+    // A real click moves focus off the trigger on mouse-down; the mouse-up
+    // (and so the click) can arrive much later on a slow click or a remote
+    // desktop. The item must still be there when it does.
+    fireEvent.mouseDown(item);
+    fireEvent.focusOut(trigger);
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    fireEvent.click(item);
+    expect(onTabChange).toHaveBeenCalledWith('pipeline');
+    expect(screen.queryByText('Pipeline')).not.toBeInTheDocument();
+  });
+
+  it('closes when the user presses outside the dropdown', () => {
+    render(<NavTabs activeTab="search" onTabChange={jest.fn()} />);
+    fireEvent.click(screen.getByText('Monitor'));
+    expect(screen.getByText('Stats')).toBeInTheDocument();
+    fireEvent.mouseDown(document.body);
+    expect(screen.queryByText('Stats')).not.toBeInTheDocument();
+  });
+});

--- a/ui/frontend/src/components/layout/NavTabs.tsx
+++ b/ui/frontend/src/components/layout/NavTabs.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { ResolvedTab, TAB_TOOLTIPS, TabKey, resolveTabs } from './tabConfig';
+import { useCloseOnOutsideClick } from '../../hooks/useCloseOnOutsideClick';
 
 type TabName = 'search' | 'assistant' | 'brief' | 'heatmap' | 'documents' | 'pipeline' | 'processing' | 'info' | 'tech' | 'data' | 'privacy' | 'terms' | 'stats' | 'admin' | 'docs';
 
@@ -17,14 +18,13 @@ const MAIN_TABS: TabKey[] = ['search', 'assistant', 'brief', 'heatmap'];
 export const NavTabs = ({ activeTab, onTabChange, tabs }: NavTabsProps) => {
   const resolved = tabs ?? resolveTabs(undefined);
   const [monitorDropdownOpen, setMonitorDropdownOpen] = useState(false);
+  const monitorRef = useRef<HTMLDivElement>(null);
+  const closeMonitorDropdown = useCallback(() => setMonitorDropdownOpen(false), []);
+  useCloseOnOutsideClick(monitorRef, monitorDropdownOpen, closeMonitorDropdown);
   const monitorActive = activeTab === 'documents' || activeTab === 'pipeline' || activeTab === 'processing' || activeTab === 'stats';
 
   const handleToggleMonitorDropdown = () => {
     setMonitorDropdownOpen((open) => !open);
-  };
-
-  const handleMonitorBlur = () => {
-    setTimeout(() => setMonitorDropdownOpen(false), 200);
   };
 
   const handleMonitorSelect = (tab: 'documents' | 'pipeline' | 'processing' | 'stats') => {
@@ -50,11 +50,10 @@ export const NavTabs = ({ activeTab, onTabChange, tabs }: NavTabsProps) => {
           </button>
         ) : null,
       )}
-      <div className="dropdown-container nav-dropdown">
+      <div className="dropdown-container nav-dropdown" ref={monitorRef}>
         <button
           className={`nav-tab nav-tab-dropdown ${monitorActive ? ACTIVE_CLASS : ''}`}
           onClick={handleToggleMonitorDropdown}
-          onBlur={handleMonitorBlur}
         >
           <span>Monitor</span>
           <span className="dropdown-arrow">▾</span>

--- a/ui/frontend/src/components/layout/TopBar.test.tsx
+++ b/ui/frontend/src/components/layout/TopBar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 import { TopBar } from './TopBar';
 
@@ -26,12 +26,12 @@ const baseProps: any = {
   onToggleModelDropdown: noop,
   onDomainMouseEnter: noop,
   onDomainMouseLeave: noop,
-  onDomainBlur: noop,
-  onModelBlur: noop,
+  onCloseDomainDropdown: noop,
+  onCloseModelDropdown: noop,
   onSelectDomain: noop,
   onSelectModelCombo: noop,
   onToggleHelpDropdown: noop,
-  onHelpBlur: noop,
+  onCloseHelpDropdown: noop,
   onAboutClick: noop,
   onTechClick: noop,
   onDataClick: noop,
@@ -77,5 +77,34 @@ describe('TopBar brand link', () => {
 
     expect(pushState).not.toHaveBeenCalled();
     pushState.mockRestore();
+  });
+});
+
+describe('TopBar dropdown dismissal', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('closes the open Info dropdown on mouse-down outside it, but not inside it', () => {
+    const onCloseHelpDropdown = jest.fn();
+    render(<TopBar {...baseProps} helpDropdownOpen onCloseHelpDropdown={onCloseHelpDropdown} />);
+    fireEvent.mouseDown(screen.getByText('About'));
+    expect(onCloseHelpDropdown).not.toHaveBeenCalled();
+    fireEvent.mouseDown(document.body);
+    expect(onCloseHelpDropdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an Info item clickable long after the trigger lost focus', () => {
+    jest.useFakeTimers();
+    const onAboutClick = jest.fn();
+    render(<TopBar {...baseProps} helpDropdownOpen onAboutClick={onAboutClick} />);
+    const item = screen.getByText('About');
+    fireEvent.mouseDown(item);
+    fireEvent.focusOut(screen.getByText('Info'));
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    fireEvent.click(item);
+    expect(onAboutClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/frontend/src/components/layout/TopBar.tsx
+++ b/ui/frontend/src/components/layout/TopBar.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ModelComboConfig } from '../../types/api';
 import { APP_BASE_PATH, USER_MODULE } from '../../config';
 import UserMenu from '../auth/UserMenu';
 import { ModelComboPanel } from './ModelComboPanel';
+import { useCloseOnOutsideClick } from '../../hooks/useCloseOnOutsideClick';
 
 interface TopBarProps {
   selectedDomain: string;
@@ -19,12 +20,12 @@ interface TopBarProps {
   onToggleModelDropdown: () => void;
   onDomainMouseEnter: () => void;
   onDomainMouseLeave: () => void;
-  onDomainBlur: () => void;
-  onModelBlur: () => void;
+  onCloseDomainDropdown: () => void;
+  onCloseModelDropdown: () => void;
   onSelectDomain: (domainName: string) => void;
   onSelectModelCombo: (comboName: string) => void;
   onToggleHelpDropdown: () => void;
-  onHelpBlur: () => void;
+  onCloseHelpDropdown: () => void;
   onAboutClick: () => void;
   onTechClick: () => void;
   onDataClick: () => void;
@@ -49,12 +50,12 @@ export const TopBar = ({
   onToggleModelDropdown,
   onDomainMouseEnter,
   onDomainMouseLeave,
-  onDomainBlur,
-  onModelBlur,
+  onCloseDomainDropdown,
+  onCloseModelDropdown,
   onSelectDomain,
   onSelectModelCombo,
   onToggleHelpDropdown,
-  onHelpBlur,
+  onCloseHelpDropdown,
   onAboutClick,
   onTechClick,
   onDataClick,
@@ -64,6 +65,12 @@ export const TopBar = ({
   navTabs,
 }: TopBarProps) => {
   const [hoveredModelCombo, setHoveredModelCombo] = useState<string | null>(null);
+  const domainRef = useRef<HTMLDivElement>(null);
+  const modelRef = useRef<HTMLDivElement>(null);
+  const helpRef = useRef<HTMLDivElement>(null);
+  useCloseOnOutsideClick(domainRef, domainDropdownOpen, onCloseDomainDropdown);
+  useCloseOnOutsideClick(modelRef, modelDropdownOpen, onCloseModelDropdown);
+  useCloseOnOutsideClick(helpRef, helpDropdownOpen, onCloseHelpDropdown);
 
   useEffect(() => {
     if (!modelDropdownOpen) {
@@ -160,13 +167,12 @@ export const TopBar = ({
             <h1 className="app-title">Evidence Lab</h1>
           </a>
           <div className="top-bar-controls">
-            <div className="dropdown-container">
+            <div className="dropdown-container" ref={domainRef}>
             <button
               className="dropdown-trigger dropdown-trigger-domain"
               onClick={onToggleDomainDropdown}
               onMouseEnter={onDomainMouseEnter}
               onMouseLeave={onDomainMouseLeave}
-              onBlur={onDomainBlur}
               style={datasetTriggerMinWidth ? { minWidth: datasetTriggerMinWidth } : undefined}
             >
               <span className="dropdown-label">Dataset</span>
@@ -193,11 +199,10 @@ export const TopBar = ({
             )}
           </div>
 
-            <div className="dropdown-container">
+            <div className="dropdown-container" ref={modelRef}>
             <button
               className="dropdown-trigger"
               onClick={onToggleModelDropdown}
-              onBlur={onModelBlur}
               style={modelTriggerMinWidth ? { minWidth: modelTriggerMinWidth } : undefined}
             >
               <span className="dropdown-label">Models</span>
@@ -230,11 +235,10 @@ export const TopBar = ({
         </div>
 
         <div className="top-bar-right">
-          <div className="dropdown-container">
+          <div className="dropdown-container" ref={helpRef}>
             <button
               className="dropdown-trigger dropdown-trigger-help"
               onClick={onToggleHelpDropdown}
-              onBlur={onHelpBlur}
             >
               <span className="dropdown-value">Info</span>
               <span className="dropdown-arrow">▾</span>

--- a/ui/frontend/src/hooks/useCloseOnOutsideClick.ts
+++ b/ui/frontend/src/hooks/useCloseOnOutsideClick.ts
@@ -1,0 +1,45 @@
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Close an open dropdown when the user presses outside it or hits Escape.
+ *
+ * Watches `mousedown`/`touchstart` on the document rather than the
+ * trigger's `blur`. A blur-plus-timer approach loses any click whose
+ * mouse-down → mouse-up gap outlasts the timer (a slow click, a remote
+ * desktop, laggy input): the menu is unmounted before the click lands, so
+ * the item's handler never runs and nothing is reported anywhere. Watching
+ * the pointer directly has no such window — the menu only closes when the
+ * press is genuinely outside it.
+ *
+ * Listeners are registered only while `open` is true.
+ */
+export function useCloseOnOutsideClick(
+  containerRef: RefObject<HTMLElement | null>,
+  open: boolean,
+  onClose: () => void,
+): void {
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const container = containerRef.current;
+      if (container && !container.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [containerRef, open, onClose]);
+}

--- a/ui/frontend/src/index.tsx
+++ b/ui/frontend/src/index.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import { installClickDiagnostics } from './utils/clickDiagnostics';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
+// Record what happens on every mouse press so a console screenshot can
+// explain a click that did nothing (see utils/clickDiagnostics.ts).
+installClickDiagnostics();
+
 // Hide static crawler-only footer once React takes over
 document.getElementById('static-footer')?.remove();
 

--- a/ui/frontend/src/tests/useCloseOnOutsideClick.test.tsx
+++ b/ui/frontend/src/tests/useCloseOnOutsideClick.test.tsx
@@ -1,0 +1,81 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useCloseOnOutsideClick } from '../hooks/useCloseOnOutsideClick';
+
+interface HarnessProps {
+  initiallyOpen?: boolean;
+  onClose?: () => void;
+}
+
+const Harness = ({ initiallyOpen = true, onClose }: HarnessProps) => {
+  const [open, setOpen] = useState(initiallyOpen);
+  const ref = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => {
+    setOpen(false);
+    onClose?.();
+  }, [onClose]);
+  useCloseOnOutsideClick(ref, open, close);
+  return (
+    <div>
+      <button>outside</button>
+      <div ref={ref}>
+        <button>trigger</button>
+        {open && <button>inside</button>}
+      </div>
+    </div>
+  );
+};
+
+describe('useCloseOnOutsideClick', () => {
+  it('closes on mouse-down outside the container', () => {
+    const onClose = jest.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.mouseDown(screen.getByText('outside'));
+    expect(screen.queryByText('inside')).not.toBeInTheDocument();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays open on mouse-down inside the container', () => {
+    const onClose = jest.fn();
+    render(<Harness onClose={onClose} />);
+    fireEvent.mouseDown(screen.getByText('inside'));
+    fireEvent.mouseDown(screen.getByText('trigger'));
+    expect(screen.getByText('inside')).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes on touch-start outside the container', () => {
+    render(<Harness />);
+    fireEvent.touchStart(document.body);
+    expect(screen.queryByText('inside')).not.toBeInTheDocument();
+  });
+
+  it('closes on Escape', () => {
+    render(<Harness />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByText('inside')).not.toBeInTheDocument();
+  });
+
+  it('ignores other keys', () => {
+    render(<Harness />);
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(screen.getByText('inside')).toBeInTheDocument();
+  });
+
+  it('does not listen while closed', () => {
+    const onClose = jest.fn();
+    render(<Harness initiallyOpen={false} onClose={onClose} />);
+    fireEvent.mouseDown(document.body);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('removes its listeners on unmount', () => {
+    const removeSpy = jest.spyOn(document, 'removeEventListener');
+    const { unmount } = render(<Harness />);
+    unmount();
+    const removed = removeSpy.mock.calls.map(([type]) => type);
+    expect(removed).toEqual(expect.arrayContaining(['mousedown', 'touchstart', 'keydown']));
+    removeSpy.mockRestore();
+  });
+});

--- a/ui/frontend/src/utils/__tests__/clickDiagnostics.test.ts
+++ b/ui/frontend/src/utils/__tests__/clickDiagnostics.test.ts
@@ -1,0 +1,130 @@
+import { fireEvent } from '@testing-library/dom';
+import {
+  SLOW_PRESS_MS,
+  describeElement,
+  installClickDiagnostics,
+} from '../clickDiagnostics';
+
+describe('clickDiagnostics', () => {
+  let clock = 0;
+  let uninstall: () => void;
+  let debugSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let infoSpy: jest.SpyInstance;
+
+  const press = (downOn: Element, upOn: Element, heldMs: number) => {
+    fireEvent.mouseDown(downOn);
+    clock += heldMs;
+    fireEvent.mouseUp(upOn);
+  };
+
+  beforeEach(() => {
+    clock = 0;
+    document.body.innerHTML = `
+      <div id="page">
+        <button id="save" class="dropdown-item primary"><span id="save-label">Saved Research</span></button>
+        <p id="para">Some body text</p>
+      </div>`;
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    uninstall = installClickDiagnostics({ now: () => clock });
+  });
+
+  afterEach(() => {
+    uninstall();
+    debugSpy.mockRestore();
+    warnSpy.mockRestore();
+    infoSpy.mockRestore();
+    document.body.innerHTML = '';
+  });
+
+  const button = () => document.getElementById('save') as HTMLElement;
+  const label = () => document.getElementById('save-label') as HTMLElement;
+
+  it('announces itself once on install', () => {
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy.mock.calls[0][0]).toContain('diagnostics active');
+  });
+
+  it('logs a quick press released on the same control at debug level', () => {
+    press(button(), button(), 80);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy.mock.calls[0][0]).toBe(
+      '[Evidence Lab click] held 80ms on button#save.dropdown-item "Saved Research"',
+    );
+  });
+
+  it('treats a release on another part of the same control as a normal click', () => {
+    press(label(), button(), 50);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns about a slow press', () => {
+    press(button(), button(), SLOW_PRESS_MS + 1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain(`held ${SLOW_PRESS_MS + 1}ms`);
+    expect(warnSpy.mock.calls[0][0]).toContain('slow press');
+  });
+
+  it('warns when the pressed element was removed before release', () => {
+    const target = button();
+    fireEvent.mouseDown(target);
+    target.remove();
+    clock += 120;
+    fireEvent.mouseUp(document.body);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('removed from the page before the mouse was released');
+    expect(warnSpy.mock.calls[0][0]).toContain('Released over body');
+  });
+
+  it('warns when the release lands outside the pressed control', () => {
+    press(button(), document.getElementById('para') as HTMLElement, 60);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('released over p#para "Some body text"');
+    expect(warnSpy.mock.calls[0][0]).toContain('outside the pressed control');
+  });
+
+  it('does not warn for presses that did not start on a control', () => {
+    press(document.getElementById('para') as HTMLElement, document.body, 60);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a release with no matching press', () => {
+    fireEvent.mouseUp(button());
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('stops logging once uninstalled', () => {
+    uninstall();
+    press(button(), button(), 500);
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    uninstall = () => {};
+  });
+
+  describe('describeElement', () => {
+    it('shows tag, id, first class and trimmed text', () => {
+      expect(describeElement(button())).toBe('button#save.dropdown-item "Saved Research"');
+    });
+
+    it('truncates long text', () => {
+      const p = document.getElementById('para') as HTMLElement;
+      p.textContent = 'x'.repeat(60);
+      expect(describeElement(p)).toBe(`p#para "${'x'.repeat(40)}…"`);
+    });
+
+    it('describes non-elements and nothing', () => {
+      expect(describeElement(document.createTextNode('hi'))).toBe('#text');
+      expect(describeElement(null)).toBe('nothing');
+    });
+
+    it('does not quote the page body text', () => {
+      expect(describeElement(document.body)).toBe('body');
+    });
+  });
+});

--- a/ui/frontend/src/utils/clickDiagnostics.ts
+++ b/ui/frontend/src/utils/clickDiagnostics.ts
@@ -1,0 +1,103 @@
+/**
+ * Always-on click diagnostics.
+ *
+ * One user intermittently found that dropdown items did nothing when clicked,
+ * with no console errors, and could read a console but not paste code into
+ * it. This records what actually happened on every mouse press so that a
+ * screenshot of the console is enough to diagnose the next such report:
+ *
+ *  - how long the button was held (mouse-down to mouse-up),
+ *  - whether the pressed element was removed from the page before release,
+ *  - whether the release landed outside the pressed control (an overlay, or
+ *    a menu that closed under the pointer), in which case no click fires on
+ *    that control.
+ *
+ * Unremarkable presses log at `console.debug`, which Chrome hides unless the
+ * "Verbose" level is enabled. Anything that makes a click go missing logs at
+ * `console.warn`, which shows at the default console level. One
+ * `console.info` line at start-up confirms the diagnostics are running.
+ */
+
+export const SLOW_PRESS_MS = 200;
+const PREFIX = '[Evidence Lab click]';
+const TEXT_LIMIT = 40;
+const CONTROL_SELECTOR = 'button, a, input, select, textarea, label, summary, [role="button"], [role="menuitem"]';
+
+export interface ClickDiagnosticsOptions {
+  /** Document to observe. Defaults to the global document. */
+  target?: Document;
+  /** Clock in milliseconds. Defaults to `performance.now`. */
+  now?: () => number;
+}
+
+/** Short, screenshot-friendly description of an element: tag, id/class, text. */
+export function describeElement(target: EventTarget | null): string {
+  if (!(target instanceof Element)) {
+    return target instanceof Node ? target.nodeName.toLowerCase() : 'nothing';
+  }
+  const tag = target.tagName.toLowerCase();
+  const id = target.id ? `#${target.id}` : '';
+  const firstClass = target.classList.length > 0 ? `.${target.classList[0]}` : '';
+  // The page body's text is the whole page; quoting it says nothing useful.
+  const text = tag === 'body' || tag === 'html'
+    ? ''
+    : (target.textContent ?? '').replace(/\s+/g, ' ').trim();
+  const shortText = text.length > TEXT_LIMIT ? `${text.slice(0, TEXT_LIMIT)}…` : text;
+  const quotedText = shortText ? ` "${shortText}"` : '';
+  return `${tag}${id}${firstClass}${quotedText}`;
+}
+
+/** The nearest clickable control containing the pressed node, if any. */
+function controlOf(node: Node): Element | null {
+  const element = node instanceof Element ? node : node.parentElement;
+  return element ? element.closest(CONTROL_SELECTOR) : null;
+}
+
+/**
+ * Start observing mouse presses on `target`. Returns a function that stops
+ * observing again.
+ */
+export function installClickDiagnostics(options: ClickDiagnosticsOptions = {}): () => void {
+  const { target = document, now = () => performance.now() } = options;
+  let pressed: Node | null = null;
+  let pressedAt = 0;
+
+  const onMouseDown = (event: MouseEvent) => {
+    pressed = event.target instanceof Node ? event.target : null;
+    pressedAt = now();
+  };
+
+  const onMouseUp = (event: MouseEvent) => {
+    if (pressed === null) return;
+    const heldMs = Math.round(now() - pressedAt);
+    const released = event.target instanceof Node ? event.target : null;
+    const control = controlOf(pressed);
+    const summary = `${PREFIX} held ${heldMs}ms on ${describeElement(pressed)}`;
+
+    if (!target.contains(pressed)) {
+      console.warn(
+        `${summary}; that element was removed from the page before the mouse was released, ` +
+          `so the click was lost. Released over ${describeElement(released)}.`,
+      );
+    } else if (control !== null && (released === null || !control.contains(released))) {
+      console.warn(
+        `${summary}; released over ${describeElement(released)}, outside the pressed control, ` +
+          'so no click fired on it.',
+      );
+    } else if (heldMs > SLOW_PRESS_MS) {
+      console.warn(`${summary}; slow press (over ${SLOW_PRESS_MS}ms).`);
+    } else {
+      console.debug(summary);
+    }
+    pressed = null;
+  };
+
+  target.addEventListener('mousedown', onMouseDown, true);
+  target.addEventListener('mouseup', onMouseUp, true);
+  console.info(`${PREFIX} diagnostics active; presses that could lose a click are logged as warnings.`);
+
+  return () => {
+    target.removeEventListener('mousedown', onMouseDown, true);
+    target.removeEventListener('mouseup', onMouseUp, true);
+  };
+}


### PR DESCRIPTION
## Description

One user reported that items under the user icon (Saved Research, Admin, …) sometimes do nothing when clicked, with no console errors, in two browsers, in incognito, after hard refresh, and that it comes and goes.

Every top-bar dropdown (user menu, Dataset, Models, Info, Monitor) closed itself on a 200 ms timer started when its trigger lost focus. A real click moves focus on **mouse-down** and fires the handler on **mouse-up**. If those are more than 200 ms apart, the menu is unmounted in between, the click lands on nothing, and nothing is logged. This was reproduced on the running app by dispatching `focusout` on the trigger and clicking after the timer: the item was gone and its handler never ran.

What stretches this particular user's clicks past 200 ms is **not yet known** (they are not on Citrix or a remote desktop). The fix removes the timing window entirely, so it no longer matters.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Changes Made

- [x] New `useCloseOnOutsideClick` hook: closes an open menu on `mousedown`/`touchstart` outside its container or on Escape; listeners only registered while open
- [x] `UserMenu`, `NavTabs` (Monitor), and `TopBar` (Dataset, Models, Info) use the hook instead of `onBlur` + `setTimeout(…, 200)`
- [x] `App.tsx`: the three blur handlers become immediate close handlers; props renamed `on*Blur` → `onClose*Dropdown`
- [x] Side effect: keyboard users can now tab into these menus, which the blur timer also closed
- [x] Always-on click diagnostics (`utils/clickDiagnostics.ts`): plain-English console warnings for slow presses, pressed elements removed before release, and releases outside the pressed control; debug-level line for normal presses

## Testing

### Test Coverage
- [x] Tests pass locally: full frontend suite, 85 suites / 700 tests
- [x] New tests added: hook unit tests; click-diagnostics unit tests (13); regression tests where the click lands one second after focus left the trigger (user menu Admin + Saved Research, Monitor, Info); outside-press and Escape close
- [x] Manual testing completed
- [x] Type check and ESLint clean; pre-commit (incl. code-metrics) passes

### Manual Testing Steps
1. Sign in as a superuser, open the user menu.
2. Press and hold the mouse on **Admin** for a second, then release. Before: menu vanishes, nothing opens. After: Admin panel opens.
3. Same for **Saved Research** (modal opens), Monitor → Pipeline, Info → About.
4. Open any dropdown and click elsewhere on the page: it closes. Press Escape: it closes.

Verified against the local WFP stack by emulating a 2.5 s gap between focus loss and the click on the signed-in user menu: Admin rendered the panel at `/admin`, Saved Research opened its modal, and an outside press closed the menu.

## Code Quality

- [x] Pre-commit hooks pass
- [x] No new linting errors introduced (three pre-existing `import/first` errors in `UserMenu.test.tsx` fixed while there)

## Additional Notes

**Built-in click diagnostics (second commit).** The affected user can open a console but not paste code, so the diagnostics now ship in the app and run on every page load (`src/utils/clickDiagnostics.ts`, installed from `index.tsx`):

- One `console.info` line at start-up: `[Evidence Lab click] diagnostics active…`, so a screenshot with no warnings is itself evidence.
- Every mouse press is timed on `mousedown`/`mouseup`. Only presses that can lose a click are logged as **warnings**, in plain English: held longer than 200 ms; pressed element removed from the page before release; release landed outside the pressed control (an overlay, or a menu that moved).
- Unremarkable presses log at `console.debug`, which Chrome hides unless "Verbose" is enabled, so normal consoles stay quiet.

Example warnings, captured on the local stack:

```
[Evidence Lab click] held 1990ms on button.dropdown-item "About"; slow press (over 200ms).
[Evidence Lab click] held 990ms on button "Ghost item"; that element was removed from the page before the mouse was released, so the click was lost. Released over body.
```

When the user next sees a click do nothing, ask them to open the console (F12 → Console) and send a screenshot.
