### PR TITLE
feat(brief): fixes from user feedback — stop in-progress outline generation

### DIFF
--- a/docs/using-evidence-lab/brief.md
+++ b/docs/using-evidence-lab/brief.md
@@ -24,7 +24,7 @@ Click the **Brief** tab and you'll land on the start screen.
 
 You have three ways to start:
 
-- **Generate outline** — enter a **Topic** (e.g. *girls education in Kenya*), optionally add **Instructions** to steer the headings (e.g. *focus on East Africa, prioritise RCTs since 2018, structure around outcomes*), choose the **Number of sections**, and click **Generate outline**. Evidence Lab runs a deep-research survey across the document library and proposes headings grounded in what the collection actually contains.
+- **Generate outline** — enter a **Topic** (e.g. *girls education in Kenya*), optionally add **Instructions** to steer the headings (e.g. *focus on East Africa, prioritise RCTs since 2018, structure around outcomes*), choose the **Number of sections**, and click **Generate outline**. Evidence Lab runs a deep-research survey across the document library and proposes headings grounded in what the collection actually contains. While the survey runs, a *Deep research in progress* panel shows what it is searching; click the **×** at the end of that row to stop it and return to the form with your topic and instructions kept.
 - **Write my own headings** — skip the survey and start from a small set of placeholder headings you edit yourself.
 - **Load a saved brief** — reopen any brief from your history.
 

--- a/ui/frontend/src/components/brief/BriefSeed.tsx
+++ b/ui/frontend/src/components/brief/BriefSeed.tsx
@@ -17,6 +17,15 @@ export const BriefGeneratingPanel: React.FC<{ brief: UseBriefReturn }> = ({ brie
       <div className="brief-researching-head">
         <span className="brief-spinner" />
         <span className="brief-researching-label">Deep research in progress</span>
+        <button
+          type="button"
+          className="brief-generating-stop"
+          onClick={brief.stopOutline}
+          aria-label="Stop generating"
+          title="Stop generating this outline"
+        >
+          ×
+        </button>
       </div>
       <div className="brief-activity">
         {brief.generatingActivity.map((ev, i) => (

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -221,6 +221,28 @@
 .brief-generating .brief-activity {
   margin-top: 12px;
 }
+/* The x at the end of the "in progress" row that stops outline generation. */
+.brief-generating-stop {
+  margin-left: auto;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--brand-border);
+  border-radius: 50%;
+  color: var(--brand-text-tertiary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.brief-generating-stop:hover {
+  color: var(--brand-text-primary);
+  border-color: var(--brand-text-tertiary);
+  background: var(--brand-border-light);
+}
 
 /* Editable brief title in the document header */
 .brief-doc-title-input {

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -677,6 +677,13 @@ export const useBrief = ({
     }
   }, [apiBaseUrl, dataSource, query, instructions, numHeadings, assistantModelConfig]);
 
+  // Abort an in-flight outline generation and return to the seed form with the
+  // topic and instructions intact. generateOutline's own cleanup clears the
+  // loading state and suppresses the abort error.
+  const stopOutline = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
   const startManual = useCallback(() => {
     briefIdRef.current = uid();
     briefActivityIdRef.current = newActivityId();
@@ -1410,6 +1417,7 @@ export const useBrief = ({
     setSectionVoiceId: (id: string, voiceId: string | null) =>
       updateSection(id, { voiceId }),
     generateOutline,
+    stopOutline,
     startManual,
     startFromTemplate,
     openBriefById,

--- a/ui/frontend/src/tests/briefTab.test.tsx
+++ b/ui/frontend/src/tests/briefTab.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+import { BriefTab } from '../components/brief/BriefTab';
+
 // Mock config so no real API base is needed. (briefStream is mocked below, so
 // the API key is never read here — omit it to avoid a detect-secrets false hit.)
 jest.mock('../config', () => ({
@@ -26,7 +28,14 @@ jest.mock('../utils/briefStream', () => ({
   runDeepResearch: (...args: unknown[]) => mockRunDeepResearch(...args),
 }));
 
-import { BriefTab } from '../components/brief/BriefTab';
+const GENERATE_OUTLINE = 'Generate outline';
+const WRITE_OWN_HEADINGS = 'Write my own headings';
+const ADD_HEADING = 'Add heading';
+const NEW_HEADING_NAME = 'New heading name';
+const NEW_SUB_HEADING_NAME = 'New sub-heading name';
+const CASH_TRANSFERS = 'Cash transfers';
+const CASH_ASSISTANCE = 'cash assistance';
+const SCHOOL_FEEDING = 'School feeding';
 
 describe('BriefTab (Document Builder)', () => {
   beforeEach(() => {
@@ -43,19 +52,19 @@ describe('BriefTab (Document Builder)', () => {
     render(<BriefTab dataSource="wfp" />);
     expect(screen.getByText('Turn a topic into a research brief')).toBeInTheDocument();
     expect(screen.getByLabelText('Topic')).toBeInTheDocument();
-    expect(screen.getByText('Generate outline')).toBeInTheDocument();
-    expect(screen.getByText('Write my own headings')).toBeInTheDocument();
+    expect(screen.getByText(GENERATE_OUTLINE)).toBeInTheDocument();
+    expect(screen.getByText(WRITE_OWN_HEADINGS)).toBeInTheDocument();
     // The "Try a topic" examples section was removed.
     expect(screen.queryByText('Try a topic')).toBeNull();
   });
 
   test('"Write my own headings" enters the builder with starter sections, a History rail and a TOC', () => {
     render(<BriefTab dataSource="wfp" />);
-    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText(WRITE_OWN_HEADINGS));
     // Left rail is the brief History; the TOC carries the structural actions.
     expect(screen.getByText('History')).toBeInTheDocument();
     expect(screen.getByText('Contents')).toBeInTheDocument();
-    expect(screen.getByText('Add heading')).toBeInTheDocument();
+    expect(screen.getByText(ADD_HEADING)).toBeInTheDocument();
     expect(screen.getByText('Start deep research →')).toBeInTheDocument();
     const titles = screen.getAllByDisplayValue(/Background & definitions|Key findings|Recommendations/);
     expect(titles.length).toBeGreaterThanOrEqual(3);
@@ -65,20 +74,20 @@ describe('BriefTab (Document Builder)', () => {
     localStorage.setItem(
       'evidencelab_brief_history_v1',
       JSON.stringify([
-        { id: 'x1', title: 'Cash transfers', query: 'cash assistance', date: 1, sectionCount: 0, sourceCount: 0, sections: [] },
-        { id: 'x2', title: 'School feeding', query: 'nutrition', date: 2, sectionCount: 0, sourceCount: 0, sections: [] },
+        { id: 'x1', title: CASH_TRANSFERS, query: CASH_ASSISTANCE, date: 1, sectionCount: 0, sourceCount: 0, sections: [] },
+        { id: 'x2', title: SCHOOL_FEEDING, query: 'nutrition', date: 2, sectionCount: 0, sourceCount: 0, sections: [] },
       ]),
     );
     render(<BriefTab dataSource="wfp" />);
-    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText(WRITE_OWN_HEADINGS));
 
-    expect(screen.getByText('Cash transfers')).toBeInTheDocument();
-    expect(screen.getByText('School feeding')).toBeInTheDocument();
+    expect(screen.getByText(CASH_TRANSFERS)).toBeInTheDocument();
+    expect(screen.getByText(SCHOOL_FEEDING)).toBeInTheDocument();
 
     // Search filters the list.
     fireEvent.change(screen.getByLabelText('Search briefs'), { target: { value: 'feeding' } });
-    expect(screen.queryByText('Cash transfers')).toBeNull();
-    expect(screen.getByText('School feeding')).toBeInTheDocument();
+    expect(screen.queryByText(CASH_TRANSFERS)).toBeNull();
+    expect(screen.getByText(SCHOOL_FEEDING)).toBeInTheDocument();
 
     // Clone the visible brief — a "(copy)" is created and opened.
     fireEvent.click(screen.getAllByLabelText('Duplicate this brief')[0]);
@@ -87,7 +96,7 @@ describe('BriefTab (Document Builder)', () => {
 
   test('heading numbers are off by default and can be toggled on by the title-row switch', () => {
     const { container } = render(<BriefTab dataSource="wfp" />);
-    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText(WRITE_OWN_HEADINGS));
 
     const toggle = screen.getByRole('switch', { name: /number headings/i });
     expect(toggle).toHaveAttribute('aria-checked', 'false');
@@ -104,19 +113,19 @@ describe('BriefTab (Document Builder)', () => {
 
   test('adding a sub-heading prompts for a name and only adds it once entered', () => {
     render(<BriefTab dataSource="wfp" />);
-    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText(WRITE_OWN_HEADINGS));
 
     fireEvent.click(screen.getAllByLabelText('Add a sub-heading')[0]);
-    const input = screen.getByLabelText('New sub-heading name');
+    const input = screen.getByLabelText(NEW_SUB_HEADING_NAME);
     expect(input).toBeInTheDocument();
 
     // Empty + blur adds nothing.
     fireEvent.blur(input);
-    expect(screen.queryByLabelText('New sub-heading name')).toBeNull();
+    expect(screen.queryByLabelText(NEW_SUB_HEADING_NAME)).toBeNull();
 
     // Re-open, type a name, press Enter — now it's added.
     fireEvent.click(screen.getAllByLabelText('Add a sub-heading')[0]);
-    const input2 = screen.getByLabelText('New sub-heading name');
+    const input2 = screen.getByLabelText(NEW_SUB_HEADING_NAME);
     fireEvent.change(input2, { target: { value: 'Enrolment trends' } });
     fireEvent.keyDown(input2, { key: 'Enter' });
     expect(screen.getByDisplayValue('Enrolment trends')).toBeInTheDocument();
@@ -124,16 +133,16 @@ describe('BriefTab (Document Builder)', () => {
 
   test('"Add heading" prompts for a name and only adds it once entered', () => {
     render(<BriefTab dataSource="wfp" />);
-    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText(WRITE_OWN_HEADINGS));
 
-    fireEvent.click(screen.getByText('Add heading'));
-    const input = screen.getByLabelText('New heading name');
+    fireEvent.click(screen.getByText(ADD_HEADING));
+    const input = screen.getByLabelText(NEW_HEADING_NAME);
     // Empty + blur adds nothing.
     fireEvent.blur(input);
-    expect(screen.queryByLabelText('New heading name')).toBeNull();
+    expect(screen.queryByLabelText(NEW_HEADING_NAME)).toBeNull();
 
-    fireEvent.click(screen.getByText('Add heading'));
-    const input2 = screen.getByLabelText('New heading name');
+    fireEvent.click(screen.getByText(ADD_HEADING));
+    const input2 = screen.getByLabelText(NEW_HEADING_NAME);
     fireEvent.change(input2, { target: { value: 'Annexes' } });
     fireEvent.keyDown(input2, { key: 'Enter' });
     expect(screen.getByDisplayValue('Annexes')).toBeInTheDocument();
@@ -147,7 +156,7 @@ describe('BriefTab (Document Builder)', () => {
       ]),
     );
     render(<BriefTab dataSource="wfp" />);
-    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText(WRITE_OWN_HEADINGS));
     // A different (manual) brief is open, so x1 still has a delete control.
     expect(screen.getByLabelText('Delete this brief')).toBeInTheDocument();
     // Open x1 — now it is the current brief and loses its delete control.
@@ -157,24 +166,51 @@ describe('BriefTab (Document Builder)', () => {
 
   test('"Generate outline" title-cases the brief name and headings', async () => {
     mockRequestOutline.mockResolvedValue({
-      title: 'cash assistance',
+      title: CASH_ASSISTANCE,
       headings: [
         { title: 'background information', level: 1 },
         { title: 'food security', level: 2 },
       ],
     });
     render(<BriefTab dataSource="wfp" />);
-    fireEvent.change(screen.getByLabelText('Topic'), { target: { value: 'cash assistance' } });
-    fireEvent.click(screen.getByText('Generate outline'));
+    fireEvent.change(screen.getByLabelText('Topic'), { target: { value: CASH_ASSISTANCE } });
+    fireEvent.click(screen.getByText(GENERATE_OUTLINE));
 
     await waitFor(() =>
       expect(screen.getByDisplayValue('Background Information')).toBeInTheDocument(),
     );
     expect(mockRunDeepResearch).toHaveBeenCalled(); // visible deep-research survey
     expect(mockRequestOutline).toHaveBeenCalled();
-    expect(mockRequestOutline.mock.calls[0][0]).toMatchObject({ dataSource: 'wfp', topic: 'cash assistance' });
+    expect(mockRequestOutline.mock.calls[0][0]).toMatchObject({ dataSource: 'wfp', topic: CASH_ASSISTANCE });
     expect(screen.getByDisplayValue('Food Security')).toBeInTheDocument();
     // Brief name is capitalised too.
     expect(screen.getByDisplayValue('Cash Assistance')).toBeInTheDocument();
+  });
+
+  test('the outline-generation panel has an x that stops it and returns to the form', async () => {
+    // The survey hangs until aborted, as a real stream would.
+    mockRunDeepResearch.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise<void>((_, reject) => {
+          signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+        }),
+    );
+    render(<BriefTab dataSource="wfp" />);
+    fireEvent.change(screen.getByLabelText('Topic'), { target: { value: CASH_ASSISTANCE } });
+    fireEvent.click(screen.getByText(GENERATE_OUTLINE));
+    expect(await screen.findByText('Deep research in progress')).toBeInTheDocument();
+    expect(mockRunDeepResearch).toHaveBeenCalledTimes(1);
+    const { signal } = mockRunDeepResearch.mock.calls[0][0];
+
+    fireEvent.click(screen.getByRole('button', { name: 'Stop generating' }));
+
+    expect(signal.aborted).toBe(true);
+    await waitFor(() =>
+      expect(screen.getByText('Turn a topic into a research brief')).toBeInTheDocument(),
+    );
+    // The topic is kept so the user can adjust and retry, and no error is shown.
+    expect(screen.getByLabelText('Topic')).toHaveValue(CASH_ASSISTANCE);
+    expect(mockRequestOutline).not.toHaveBeenCalled();
+    expect(screen.queryByText(/could not generate|abort/i)).toBeNull();
   });
 });


### PR DESCRIPTION
## Description

Fixes to the **Brief** tab from the user feedback session. First item: **a way to stop outline generation once it is running.**

After clicking **Generate outline** (seed screen, or the logged-in *New brief* modal), the form is replaced by the *Deep research in progress* panel, which had no stop control: the only options were to wait for the survey and outline to finish, or leave the tab. Section deep research already has a **■ Stop** in the floating status bar; outline generation had nothing.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes Made

- [x] `useBrief`: new `stopOutline` action that aborts the in-flight controller. `generateOutline`'s existing cleanup clears the loading state and suppresses the abort error, so no other state handling was needed.
- [x] `BriefGeneratingPanel`: an **×** (`aria-label="Stop generating"`) at the end of the *Deep research in progress* row, wired to `stopOutline`. Stopping returns the user to the form with topic and instructions kept, with no error banner.
- [x] `brief.css`: styling for the ×, matching the modal close control.
- [x] Docs: one sentence in `docs/using-evidence-lab/brief.md`.
- [x] Pre-existing lint errors in `briefTab.test.tsx` fixed while there (imports after `jest.mock`, repeated literals).

## Testing

### Test Coverage
- [x] New test: the survey mock hangs until aborted; clicking the × aborts the signal, the seed form returns with the topic kept, the outline is never requested, and no error is shown.
- [x] Brief tab suite 9/9; type check and ESLint clean.
- [x] Manual testing completed on the local WFP stack, signed in: *New brief* → *Generate outline* → panel shows the × → click → back on Brief Central, no error; the stream request ends in `net::ERR_ABORTED`.

### Manual Testing Steps
1. Brief → **New brief** (or the anonymous seed form), enter a title, click **Generate outline**.
2. The *Deep research in progress* panel appears with an **×** at the end of the row.
3. Click it: you are back on the form / Brief Central, with the title kept and no error.

## Additional Notes

**Follow-up worth doing next: the backend keeps working after the client stops.** With the × clicked about 7 s into the survey, the API log shows the deep-research run continuing for another ~40 s, completing a full synthesis (177 sources) and persisting it:

```
17:39:19 [deepres] stream start: run_id=65a5bb1d…
17:39:2x  (client aborts; stream request ends with net::ERR_ABORTED)
17:39:55 [deepres] model-step …
17:40:07 [deepres] stream end … sources=177 · done event · persisted
```

So the × stops the UI but not the LLM spend. Cancelling the deep-research task when the streaming client disconnects is a separate backend change and a good second item for this PR or the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
