### PR TITLE
feat(map): add an × to stop heatmap generation in progress

### DIFF
--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -34,7 +34,6 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
         "@testing-library/react": "^16.3.3",
-        "@types/axios": "^0.9.36",
         "@types/file-saver": "^2.0.7",
         "@types/node": "^25.9.5",
         "@types/react": "^19.2.7",
@@ -4022,13 +4021,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/axios": {
-      "version": "0.9.36",
-      "resolved": "https://registry.npmjs.org/@types/axios/-/axios-0.9.36.tgz",
-      "integrity": "sha512-NLOpedx9o+rxo/X5ChbdiX6mS1atE4WHmEEIcR9NLenRVa5HoVjAvjafwU3FPTqnZEstpoqCaW7fagqSoTDNeg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4381,6 +4373,7 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7718,6 +7711,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d": {
@@ -14320,40 +14314,6 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
-      }
-    },
-    "node_modules/mapbox-gl": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
-      "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
-      "license": "SEE LICENSE IN LICENSE.txt",
-      "peer": true,
-      "dependencies": {
-        "@mapbox/geojson-rewind": "^0.5.2",
-        "@mapbox/geojson-types": "^1.0.2",
-        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
-        "@mapbox/mapbox-gl-supported": "^1.5.0",
-        "@mapbox/point-geometry": "^0.1.0",
-        "@mapbox/tiny-sdf": "^1.1.1",
-        "@mapbox/unitbezier": "^0.0.0",
-        "@mapbox/vector-tile": "^1.3.1",
-        "@mapbox/whoots-js": "^3.1.0",
-        "csscolorparser": "~1.0.3",
-        "earcut": "^2.2.2",
-        "geojson-vt": "^3.2.1",
-        "gl-matrix": "^3.2.1",
-        "grid-index": "^1.1.0",
-        "murmurhash-js": "^1.0.0",
-        "pbf": "^3.2.1",
-        "potpack": "^1.0.1",
-        "quickselect": "^2.0.0",
-        "rw": "^1.3.3",
-        "supercluster": "^7.1.0",
-        "tinyqueue": "^2.0.3",
-        "vt-pbf": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6.4.0"
       }
     },
     "node_modules/maplibre-gl": {

--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -4373,7 +4373,6 @@
       "version": "19.2.13",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.13.tgz",
       "integrity": "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7711,7 +7710,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d": {
@@ -14314,6 +14312,40 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/mapbox-gl": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.13.3.tgz",
+      "integrity": "sha512-p8lJFEiqmEQlyv+DQxFAOG/XPWN0Wp7j/Psq93Zywz7qt9CcUKFYDBOoOEKzqe6gudHVJY8/Bhqw6VDpX2lSBg==",
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "peer": true,
+      "dependencies": {
+        "@mapbox/geojson-rewind": "^0.5.2",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.5.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.1",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.3",
+        "earcut": "^2.2.2",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.2.1",
+        "grid-index": "^1.1.0",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.2.1",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^7.1.0",
+        "tinyqueue": "^2.0.3",
+        "vt-pbf": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/maplibre-gl": {

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -70,7 +70,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.3",
-    "@types/axios": "^0.9.36",
     "@types/file-saver": "^2.0.7",
     "@types/node": "^25.9.5",
     "@types/react": "^19.2.7",

--- a/ui/frontend/src/App.css
+++ b/ui/frontend/src/App.css
@@ -8231,6 +8231,38 @@ li.ai-fact-active::before {
   flex-shrink: 0;
 }
 
+/* The Generate button and, while it is generating, an attached × that stops it. */
+.heatmap-search-group {
+  display: inline-flex;
+  align-items: stretch;
+  flex-shrink: 0;
+}
+.heatmap-search-group-generating .heatmap-search-button {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-right: none;
+}
+.heatmap-search-stop {
+  height: 48px;
+  width: 44px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-heading);
+  font-size: 22px;
+  line-height: 1;
+  color: var(--gray-500);
+  background: #fafafa;
+  border: 1px solid rgba(91, 143, 168, 0.8);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  cursor: pointer;
+}
+.heatmap-search-stop:hover {
+  background: var(--brand-accent);
+  color: var(--white);
+}
+
 /* Heatmap mobile overrides — must appear AFTER base definitions to win specificity */
 @media (max-width: 640px) {
   .heatmap-controls-row {

--- a/ui/frontend/src/__mocks__/axios.ts
+++ b/ui/frontend/src/__mocks__/axios.ts
@@ -49,6 +49,18 @@ const makeFn = () => {
   return fn;
 };
 
+// Mirrors axios's cancellation contract: a request aborted through its
+// AbortSignal rejects with an error carrying `__CANCEL__`, which
+// `axios.isCancel` recognises.
+class CanceledError extends Error {
+  __CANCEL__ = true;
+
+  constructor(message = 'canceled') {
+    super(message);
+    this.name = 'CanceledError';
+  }
+}
+
 const axiosMock = {
   get: makeFn(),
   put: makeFn(),
@@ -65,6 +77,9 @@ const axiosMock = {
   },
   create: () => axiosMock,
   isAxiosError: () => false,
+  isCancel: (value: unknown) =>
+    !!value && (value as { __CANCEL__?: boolean }).__CANCEL__ === true,
+  CanceledError,
 };
 
 export default axiosMock;

--- a/ui/frontend/src/components/app/HeatmapTabContent.tsx
+++ b/ui/frontend/src/components/app/HeatmapTabContent.tsx
@@ -384,7 +384,9 @@ const buildSearchParams = (options: {
   return params;
 };
 
-const runTasksInBatches = async (tasks: Array<() => Promise<void>>) => {
+// Runs the cell requests a few at a time. Stops scheduling further batches
+// once `signal` is aborted (the user pressed the × on the Generate button).
+const runTasksInBatches = async (tasks: Array<() => Promise<void>>, signal?: AbortSignal) => {
   const delayBetweenBatchesMs = 500;
   const batchSize = 3;
   const sleep = (ms: number) => new Promise((resolve) => {
@@ -392,6 +394,7 @@ const runTasksInBatches = async (tasks: Array<() => Promise<void>>) => {
   });
 
   for (let i = 0; i < tasks.length; i += batchSize) {
+    if (signal?.aborted) return;
     const batch = tasks.slice(i, i + batchSize);
     await Promise.all(batch.map((task) => task()));
     if (i + batchSize < tasks.length) {
@@ -589,12 +592,14 @@ const HeatmapActionButtons = ({
   hasCompletedGridSearch,
   handleDownloadExcel,
   executeGridSearch,
+  stopGridSearch,
   gridLoading,
   hasGridSearchQuery,
 }: {
   hasCompletedGridSearch: boolean;
   handleDownloadExcel: () => void;
   executeGridSearch: () => void;
+  stopGridSearch: () => void;
   gridLoading: boolean;
   hasGridSearchQuery: boolean;
 }) => (
@@ -615,13 +620,26 @@ const HeatmapActionButtons = ({
       </span>
       Download Heatmap
     </button>
-    <button
-      className="search-button heatmap-search-button"
-      onClick={executeGridSearch}
-      disabled={gridLoading || !hasGridSearchQuery}
-    >
-      <HeatmapSearchButtonContent gridLoading={gridLoading} />
-    </button>
+    <div className={`heatmap-search-group${gridLoading ? ' heatmap-search-group-generating' : ''}`}>
+      <button
+        className="search-button heatmap-search-button"
+        onClick={executeGridSearch}
+        disabled={gridLoading || !hasGridSearchQuery}
+      >
+        <HeatmapSearchButtonContent gridLoading={gridLoading} />
+      </button>
+      {gridLoading && (
+        <button
+          type="button"
+          className="heatmap-search-stop"
+          onClick={stopGridSearch}
+          aria-label="Stop generating"
+          title="Stop generating the heatmap"
+        >
+          ×
+        </button>
+      )}
+    </div>
   </div>
 );
 
@@ -1245,6 +1263,7 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
   // --- Heatmap rating & activity logging ---
   const { isAuthenticated } = useAuth();
   const heatmapIdRef = useRef<string>('');
+  const gridAbortRef = useRef<AbortController | null>(null);
   const heatmapDurationRef = useRef<number>(0);
 
   // Heatmap filters are now completely isolated from global filters
@@ -2330,6 +2349,15 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     rowQueries, gridQuery, heatmapSelectedFilters,
   ]);
 
+  // Abort the in-flight grid search: cells already loaded stay, the rest are
+  // left unloaded, and the Generate button returns to its idle state.
+  const stopGridSearch = useCallback(() => {
+    gridAbortRef.current?.abort();
+  }, []);
+
+  // Abort any in-flight grid search when the tab unmounts.
+  useEffect(() => () => gridAbortRef.current?.abort(), []);
+
   const executeGridSearch = useCallback(async () => {
     if (filteredColumnValues.length === 0) {
       setGridResults({});
@@ -2344,6 +2372,8 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     setGridResults({});
     setCappedCells(new Set());
     userAdjustedCutoffRef.current = false;
+    const controller = new AbortController();
+    gridAbortRef.current = controller;
     const tasks: Array<() => Promise<void>> = [];
     const accumulatedResults: RawCellResults = {};
     let failedRequests = 0;
@@ -2396,7 +2426,9 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
             if (useDocSearch) {
               params.delete('limit');  // no cap for document counts
             }
-            const response = await axios.get<SearchResponse>(`${API_BASE_URL}/${endpoint}?${params}`);
+            const response = await axios.get<SearchResponse>(`${API_BASE_URL}/${endpoint}?${params}`, {
+              signal: controller.signal,
+            });
             const data = response.data as SearchResponse;
             accumulatedResults[cellKey] = data.results;
             setGridResults((prev) => ({ ...prev, [cellKey]: data.results }));
@@ -2404,6 +2436,8 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
               setCappedCells((prev) => new Set(prev).add(cellKey));
             }
           } catch (error) {
+            // Cancelled by the user's Stop: leave the cell unloaded, not failed.
+            if (axios.isCancel(error)) return;
             failedRequests += 1;
             accumulatedResults[cellKey] = [];
             setGridResults((prev) => ({ ...prev, [cellKey]: [] }));
@@ -2413,8 +2447,8 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     });
 
     try {
-      await runTasksInBatches(tasks);
-      if (failedRequests > 0) {
+      await runTasksInBatches(tasks, controller.signal);
+      if (!controller.signal.aborted && failedRequests > 0) {
         setGridError('Some grid cells failed to load.');
       }
     } catch (error) {
@@ -2893,6 +2927,7 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
                   hasCompletedGridSearch={hasCompletedGridSearch}
                   handleDownloadExcel={handleDownloadExcel}
                   executeGridSearch={executeGridSearch}
+                  stopGridSearch={stopGridSearch}
                   gridLoading={gridLoading}
                   hasGridSearchQuery={hasGridSearchQuery}
                 />

--- a/ui/frontend/src/tests/heatmapTabContent.test.tsx
+++ b/ui/frontend/src/tests/heatmapTabContent.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
 
 import { HeatmapTabContent } from '../components/app/HeatmapTabContent';
 import { Facets } from '../types/api';
@@ -84,6 +85,8 @@ const baseProps = {
   onLanguageChange: jest.fn(),
 };
 
+const GENERATE_HEATMAP = 'Generate Heatmap';
+
 describe('HeatmapTabContent', () => {
   test('renders defaults and enables Generate Heatmap for dimension rows without query', async () => {
     render(<HeatmapTabContent {...baseProps} />);
@@ -100,7 +103,7 @@ describe('HeatmapTabContent', () => {
     expect(metricSelect.value).toBe('documents');
 
     // Dimension vs dimension: button enabled even without a query
-    const searchButton = screen.getByRole('button', { name: 'Generate Heatmap' });
+    const searchButton = screen.getByRole('button', { name: GENERATE_HEATMAP });
     expect(searchButton).toBeEnabled();
   });
 
@@ -117,10 +120,54 @@ describe('HeatmapTabContent', () => {
     const rowInputs = screen.getAllByPlaceholderText('Enter your search query');
     expect(rowInputs).toHaveLength(1);
 
-    const searchButton = screen.getByRole('button', { name: 'Generate Heatmap' });
+    const searchButton = screen.getByRole('button', { name: GENERATE_HEATMAP });
     expect(searchButton).toBeDisabled();
 
     fireEvent.change(rowInputs[0], { target: { value: 'climate' } });
     expect(searchButton).toBeEnabled();
+  });
+
+  test('the Generate button gets an × while generating that stops the run', async () => {
+    const isCellRequest = (url: unknown) => /\/(doc)?search\?/.test(String(url));
+    // Cell requests only settle when their signal is aborted, like a slow backend.
+    const getSpy = jest.spyOn(axios, 'get').mockImplementation((url, config) => {
+      if (!isCellRequest(url)) return Promise.resolve({ data: [] });
+      return new Promise((_, reject) => {
+        config?.signal?.addEventListener('abort', () =>
+          reject(new axios.CanceledError('canceled')),
+        );
+      });
+    });
+    const postSpy = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} });
+    try {
+      const { container } = render(<HeatmapTabContent {...baseProps} />);
+      await waitFor(() => expect(screen.getByText('2020')).toBeInTheDocument());
+
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+
+      const stop = await screen.findByRole('button', { name: 'Stop generating' });
+      // The Generate button itself is disabled and reads "Generating..." (one
+      // animated span per character, so match its text rather than its name).
+      const generating = container.querySelector('.heatmap-search-button') as HTMLButtonElement;
+      expect(generating).toBeDisabled();
+      expect(generating.textContent).toBe('Generating...');
+      const cellCalls = getSpy.mock.calls.filter(([url]) => isCellRequest(url));
+      expect(cellCalls.length).toBeGreaterThan(0);
+      const { signal } = cellCalls[0][1] as { signal: AbortSignal };
+      expect(signal.aborted).toBe(false);
+
+      fireEvent.click(stop);
+
+      expect(signal.aborted).toBe(true);
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: GENERATE_HEATMAP })).toBeEnabled(),
+      );
+      expect(screen.queryByRole('button', { name: 'Stop generating' })).toBeNull();
+      // A stop is not a failure: no error message.
+      expect(screen.queryByText(/failed to load|search failed/i)).toBeNull();
+    } finally {
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Description

From the user feedback session: **on the Map tab, the Generate button should have an × to stop the process while it is in "Generating..." mode.**

While a heatmap generates, the Generate button reads "Generating..." and is disabled; there was no way to stop the run other than waiting for every cell request to finish. Now an × sits attached to the right edge of that button while it generates. Clicking it aborts the run: cells already loaded stay on the grid, the rest are left unloaded, the button returns to "Generate Heatmap", and no error is shown.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Changes Made

- [x] `HeatmapTabContent`: an `AbortController` per grid run; its signal is passed to every cell request and to the batch runner, which stops scheduling further batches once aborted. Cancelled requests leave their cell unloaded rather than counting as failed. New `stopGridSearch`; in-flight runs are aborted on unmount.
- [x] `HeatmapActionButtons`: the × (`aria-label="Stop generating"`) rendered next to the Generate button while `gridLoading`, styled as an attached segment of the button.
- [x] **Removed the deprecated `@types/axios` 0.9 stub from devDependencies.** Passing `signal` to axios and using `axios.isCancel` exposed that this 2016 stub shadows axios 1.x's own bundled types (errors name `AxiosXHRConfigBase`). The project type-checks cleanly against axios's real types without it. Lockfile updated.
- [x] Shared jest axios mock (`src/__mocks__/axios.ts`, auto-applied to every test) gains `isCancel` and `CanceledError`, mirroring axios's `__CANCEL__` contract.

## Testing

### Test Coverage
- [x] New test: cell requests hang until aborted; clicking the × aborts the signal, the Generate button is enabled again, the × disappears, and no error text is shown.
- [x] Full frontend suite 82 suites / 673 tests; type check and ESLint clean (including the cognitive-complexity rule); pre-commit passes.
- [x] Manual testing on the local WFP stack: Generate → "Generating..." with the × → click → button idle, 90 loaded cells retained, count stopped growing, no error.

### Manual Testing Steps
1. Map tab → **Generate Heatmap**.
2. While it reads "Generating...", an **×** is attached to its right edge.
3. Click it: the run stops, loaded cells remain, the button returns to **Generate Heatmap**.

## Additional Notes

Supersedes #456, which implemented the same idea on the wrong tab (Brief) and was closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
