### PR TITLE
ci: skip secret-dependent steps on fork pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           df -h /
 
       - name: Log in to Docker Hub
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -290,7 +291,9 @@ jobs:
           path: coverage.xml
 
   integration-tests:
-    if: github.actor != 'dependabot[bot]'
+    # Fork PRs receive no repository or environment secrets, so the compose
+    # stack cannot start; maintainers run this suite on a same-repo branch.
+    if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     needs: [tests, ui-tests]
     environment: ENV1
@@ -370,6 +373,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Log in to Docker Hub
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -436,6 +436,11 @@ The CI workflow in `.github/workflows/ci.yml` runs on push and PRs:
 Secrets and environment variables for integrations are configured in GitHub
 Actions (`HUGGINGFACE_API_KEY`, API URLs, etc.).
 
+Pull requests opened from a fork do not receive repository secrets. For those
+PRs the Docker Hub login step is skipped and `integration-tests` does not run.
+A maintainer runs the integration suite on a branch in this repository before
+merging a fork PR.
+
 ### Dependabot
 
 Dependabot is configured (`.github/dependabot.yml`) to automatically create weekly PRs for:


### PR DESCRIPTION
## Summary
- Fork PRs receive no repository or environment secrets, so `docker/login-action` failed with empty credentials in `container-scan` and `integration-tests`, and `docker compose up` then died on a missing `POSTGRES_PASSWORD`.
- Skip the Docker Hub login step when the PR head is a fork, and skip the `integration-tests` job for fork PRs. Same-repo PRs and pushes are unchanged.
- Document in CONTRIBUTING.md that maintainers run the integration suite on a same-repo branch before merging a fork PR.

## Test plan
- [ ] CI on this PR (same-repo) still runs the Docker Hub login and the full integration suite.
- [ ] Fork PRs #439 and #442 go green once this is on `rc/v1.6.1` and their branches are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)