### PR TITLE
fix(build): re-pin docx to 9.6.1 and stop Dependabot re-bumping it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,10 @@ updates:
       # Ignore major version updates (React 18/CRA5 ecosystem)
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # docx 9.7.x ships an ESM bundle that react-scripts cannot compile in the
+      # production build (#435); stay on 9.6.1 until the frontend toolchain moves.
+      - dependency-name: "docx"
+        versions: [">9.6.1"]
 
   # Docker dependencies - root directory
   - package-ecosystem: "docker"

--- a/ui/frontend/package-lock.json
+++ b/ui/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "ajv": "^8.20.0",
         "ajv-keywords": "^5.1.0",
         "axios": "^1.20.0",
-        "docx": "9.7.1",
+        "docx": "9.6.1",
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
         "pdfjs-dist": "^3.11.174",
@@ -8267,9 +8267,9 @@
       }
     },
     "node_modules/docx": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/docx/-/docx-9.7.1.tgz",
-      "integrity": "sha512-ilXFf9Moz47ABjFpDiA5s1w9lpb4EFSp7+5iiJSbfyYDM+bpZdAgLlSr7fW4aXhVe/E+F6QCv0EvRVFEd5CsWg==",
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^25.2.3",

--- a/ui/frontend/package.json
+++ b/ui/frontend/package.json
@@ -9,7 +9,7 @@
     "ajv": "^8.20.0",
     "ajv-keywords": "^5.1.0",
     "axios": "^1.20.0",
-    "docx": "9.7.1",
+    "docx": "^9.6.1",
     "file-saver": "^2.0.5",
     "html2canvas": "^1.4.1",
     "pdfjs-dist": "^3.11.174",


### PR DESCRIPTION
## Summary

**Release blocker for v1.6.1.** `rc/v1.6.1` does not compile in the production build. #435 pinned `docx` to 9.6.1 because 9.7.1's ESM bundle cannot be compiled by react-scripts' production build; Dependabot then bumped it back to 9.7.1 on 1 September (#453), and CI only runs the development build, so nothing caught it.

Reproduced with the production Dockerfile's own steps (`node:18-alpine`, `npm ci --legacy-peer-deps`, `npm run build`):

| | |
|---|---|
| `rc/v1.6.1` (docx 9.7.1) | **Failed to compile** — `SyntaxError: /app/node_modules/docx/dist/index.mjs: When using '@babel/plugin-transform-parameters', it's not possible to compile \`super()\` in an arrow function with default or rest parameters without compiling classes.` |
| this branch (docx 9.6.1) | **Compiles** — "The build folder is ready to be deployed" |

## Change

- `ui/frontend/package.json` + lockfile: docx back to **9.6.1**. Only the docx entries change in the lockfile (the two versions have identical dependency sets); nothing else is pruned.
- `.github/dependabot.yml`: ignore docx versions above 9.6.1 in the npm ecosystem, with the reason, so the bump cannot come back until the frontend toolchain moves.

## Verification

- Production build compiles (above).
- The four Word-export test suites pass against docx 9.6.1 (63 tests), as they did before #453.
- #464 adds the production-image build to the release checklist so this is checked before every release.