### PR TITLE
ci: update dependabot target-branch from rc/v1.6.1 to rc/v1.6.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "rc/v1.6.1"
+    target-branch: "rc/v1.6.2"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -21,7 +21,7 @@ updates:
   # NPM dependencies for frontend
   - package-ecosystem: "npm"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.6.1"
+    target-branch: "rc/v1.6.2"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5
@@ -40,7 +40,7 @@ updates:
   # Docker dependencies - root directory
   - package-ecosystem: "docker"
     directory: "/"
-    target-branch: "rc/v1.6.1"
+    target-branch: "rc/v1.6.2"
     schedule:
       interval: "monthly"
     labels:
@@ -53,7 +53,7 @@ updates:
   # Docker dependencies - backend
   - package-ecosystem: "docker"
     directory: "/ui/backend"
-    target-branch: "rc/v1.6.1"
+    target-branch: "rc/v1.6.2"
     schedule:
       interval: "monthly"
     labels:
@@ -66,7 +66,7 @@ updates:
   # Docker dependencies - frontend
   - package-ecosystem: "docker"
     directory: "/ui/frontend"
-    target-branch: "rc/v1.6.1"
+    target-branch: "rc/v1.6.2"
     schedule:
       interval: "monthly"
     labels:
@@ -79,7 +79,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "rc/v1.6.1"
+    target-branch: "rc/v1.6.2"
     schedule:
       interval: "monthly"
     labels:


### PR DESCRIPTION
Point all six Dependabot ecosystems (pip, npm, 3× docker, github-actions) at the new release-candidate branch `rc/v1.6.2`, following the v1.6.1 release. Same routine change as #400 / #421 for the v1.6.1 cycle; this is the `main` copy.