### PR TITLE
fix(scanner): make a re-scan safe for refreshed data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,12 @@ python scripts/sync/db/sync_backup_to_remote.py \
 - Use Conventional Commits format: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `perf:`, `ci:`, `build:`.
 
 ### Documentation
-- **All docs MUST go in `docs/` at the repo root.** The directory `ui/frontend/public/docs/` is wiped and regenerated from `docs/` at every build by `copy-docs.js`. Anything written there will be lost on the next build.
+- **`docs/` is end-user documentation only.** Everything under it is published to users: `ui/frontend/public/docs/` is wiped and regenerated from `docs/` at every build by `copy-docs.js`. Anything written there will be lost on the next build.
 - **`docs/docs.json` is the source of truth** for the docs sidebar. Add new pages here.
+- **Plans, analyses and working notes do NOT go in `docs/` and are NOT committed.** Write them to an untracked `plan.md` at the repo root, show the plan to the user, and wait for approval before starting implementation. Never open a PR for a plan.
+
+### Working Data Location
+- **All local data, parsed output and database work lives on `/Volumes/bigdisky/evidencelab/evidencelab-ai/`** (7.3 TB). The older copy on `/Volumes/disco1/data/evidencelab-ai/` is retained for reference only; do not write new trees there (it is nearly full).
 
 ### Database
 - **NEVER run ad-hoc database commands** (ALTER, UPDATE, DELETE, DROP, etc.) unless explicitly requested by the user. All schema changes MUST go through Alembic migrations. All data fixes must be scripted and reviewed.

--- a/pipeline/processors/scanning/scanner.py
+++ b/pipeline/processors/scanning/scanner.py
@@ -285,7 +285,9 @@ class ScanProcessor(ScannerMappingMixin, BaseProcessor):
             return [
                 p
                 for p in search_dir.rglob("*.json")
-                if "parsed" not in p.parts and "cache" not in p.parts
+                if "parsed" not in p.parts
+                and "cache" not in p.parts
+                and not p.name.startswith("._")
             ]
         return self._scan_metadata_files()
 
@@ -313,8 +315,12 @@ class ScanProcessor(ScannerMappingMixin, BaseProcessor):
     def _upsert_single_result(self, result: Optional[tuple]) -> None:
         if not result:
             return
-        doc_id_value, payload = result
-        self.db.upsert_document(doc_id_value, payload)
+        doc_id_value, payload = result[0], result[1]
+        is_existing = result[2] if len(result) > 2 else False
+        if is_existing:
+            self._merge_document_payload(str(doc_id_value), payload)
+        else:
+            self.db.upsert_document(doc_id_value, payload)
 
     def _resolve_doc_uuid(
         self, json_path: Path, metadata: Dict[str, Any]
@@ -356,22 +362,35 @@ class ScanProcessor(ScannerMappingMixin, BaseProcessor):
         return None
 
     def _flush_batch(self, batch: List[Any]) -> None:
-        """Helper to upsert a batch of documents."""
+        """Write a batch of scanned documents to Qdrant.
+
+        Documents that already exist are merged with ``set_payload`` rather than
+        replaced: the point also carries the document-level embedding written by
+        the indexer, the ``tag_*`` fields written by the tagger and the
+        ``is_duplicate`` flag, none of which the scanner knows about. Replacing
+        the point would silently drop them.
+        """
         if not batch:
             return
 
         points = []
-        for doc_id, payload in batch:
+        for entry in batch:
+            doc_id, payload = entry[0], entry[1]
+            is_existing = entry[2] if len(entry) > 2 else False
+            if is_existing:
+                self._merge_document_payload(doc_id, payload)
+                continue
             # Construct Qdrant Point
             points.append(
                 models.PointStruct(
                     id=doc_id,
                     payload=payload,
-                    vector={},  # Scan currently doesn't add vectors, but we must respect existing?
-                    # Upsert usually overwrites if same ID?
-                    # db.upsert_document typically uses 'Update' or 'Upload Points'
+                    vector={},
                 )
             )
+
+        if not points:
+            return
 
         # We need to access the qdrant client directly to do batch upsert
         # DB wrapper might not expose it easily, but usually self.db.client is accessible
@@ -383,13 +402,23 @@ class ScanProcessor(ScannerMappingMixin, BaseProcessor):
             logger.info("  -> Batched upsert of %s documents", len(points))
         except Exception as e:
             logger.error("Failed to upsert batch: %s", e)
-            # Fallback to single? Or just log.
-            # If batch fails, maybe try one by one.
-            for doc_id, payload in batch:
+            for point in points:
                 try:
-                    self.db.upsert_document(doc_id, payload)
+                    self.db.upsert_document(point.id, point.payload)
                 except Exception as ex:
-                    logger.error("Single upsert failed for %s: %s", doc_id, ex)
+                    logger.error("Single upsert failed for %s: %s", point.id, ex)
+
+    def _merge_document_payload(self, doc_id: str, payload: Dict[str, Any]) -> None:
+        """Merge scanned fields into an existing document point."""
+        try:
+            self.db.client.set_payload(
+                collection_name=self.db.documents_collection,
+                payload=payload,
+                points=[doc_id],
+                wait=False,
+            )
+        except Exception as exc:
+            logger.error("Failed to merge payload for %s: %s", doc_id, exc)
 
     def _scan_metadata_files(self) -> List[Path]:
         """Scan for JSON metadata files."""
@@ -405,6 +434,10 @@ class ScanProcessor(ScannerMappingMixin, BaseProcessor):
         json_files = []
         for f in base_path.rglob("*"):
             if not f.name.endswith(".json"):
+                continue
+            # macOS writes an AppleDouble sidecar next to every file on
+            # non-native filesystems (ExFAT); it is not metadata.
+            if f.name.startswith("._"):
                 continue
             if "parsed" in f.parts or "cache" in f.parts:
                 continue
@@ -791,6 +824,7 @@ class ScanProcessor(ScannerMappingMixin, BaseProcessor):
         )
 
         if should_upsert:
+            self._apply_change_side_effects(str(doc_id), change_type)
             qdrant_metadata = self._upsert_doc_payload(
                 doc_id=str(doc_id),
                 metadata=metadata,
@@ -807,9 +841,76 @@ class ScanProcessor(ScannerMappingMixin, BaseProcessor):
             if change_type:
                 logger.info("  🔄 Updated (%s): %s", change_type, file_path_display)
 
-            return (doc_id, qdrant_metadata)
+            if change_type in ("metadata", "both"):
+                self._propagate_to_chunks(str(doc_id), qdrant_metadata)
+
+            return (doc_id, qdrant_metadata, existing is not None)
 
         return None
+
+    def _apply_change_side_effects(self, doc_id: str, change_type: str) -> None:
+        """React to a document whose file content changed.
+
+        The scanner records the new checksum, but nothing downstream re-reads
+        it: the document keeps its status and its stale chunks. Reset it to
+        ``downloaded`` and clear the parsed output so the normal stage
+        collection picks it up for a fresh parse.
+        """
+        if change_type not in ("file", "both"):
+            return
+        logger.info("  ♻️  Content changed, queueing re-parse: %s", doc_id)
+        try:
+            removed = self.db.delete_document_chunks(doc_id)
+            if removed:
+                logger.info("     removed %s stale chunks", removed)
+        except Exception as exc:
+            logger.error("Failed to delete chunks for %s: %s", doc_id, exc)
+        if self.pg:
+            try:
+                self.pg.merge_doc_sys_fields(
+                    doc_id=doc_id,
+                    sys_fields={
+                        "sys_status": "downloaded",
+                        "sys_parsed_folder": None,
+                        "sys_chunk_count": 0,
+                        "sys_error_message": None,
+                    },
+                )
+            except Exception as exc:
+                logger.error("Failed to reset status for %s: %s", doc_id, exc)
+
+    def _propagate_to_chunks(
+        self, doc_id: str, qdrant_metadata: Dict[str, Any]
+    ) -> None:
+        """Push changed document fields onto the document's chunk payloads.
+
+        The indexer denormalises ``src_*``, ``map_*``, ``tag_*`` and
+        ``sys_language`` onto every chunk so search can filter without a join.
+        A metadata-only change never reaches them otherwise, leaving search
+        filters matching the old values.
+        """
+        fields = {
+            key: value
+            for key, value in qdrant_metadata.items()
+            if key.startswith(("src_", "map_")) and value is not None
+        }
+        if not fields:
+            return
+        try:
+            self.db.client.set_payload(
+                collection_name=self.db.chunks_collection,
+                payload=fields,
+                points=models.Filter(
+                    must=[
+                        models.FieldCondition(
+                            key="doc_id", match=models.MatchValue(value=doc_id)
+                        )
+                    ]
+                ),
+                wait=False,
+            )
+        except Exception as exc:
+            logger.error("Failed to propagate fields to chunks of %s: %s", doc_id, exc)
 
     def _mark_duplicates(self) -> int:
         """

--- a/tests/unit/test_scan.py
+++ b/tests/unit/test_scan.py
@@ -150,7 +150,8 @@ class TestScanProcessor:
             )
 
             assert result is not None
-            _, metadata = result
+            # (doc_id, payload, already_existed)
+            _, metadata = result[0], result[1]
             assert metadata["sys_status"] == "download_error"
 
     def test_compute_file_checksum(self):
@@ -225,7 +226,8 @@ class TestScanProcessor:
 
             # Check that upsert was called with relative path
             assert result is not None
-            _, metadata = result
+            # (doc_id, payload, already_existed)
+            _, metadata = result[0], result[1]
 
             # Should have relative path
             assert metadata["sys_filepath"].startswith("data/")

--- a/tests/unit/test_scanner_refresh.py
+++ b/tests/unit/test_scanner_refresh.py
@@ -1,0 +1,151 @@
+"""Scanner behaviour on a data refresh.
+
+A refresh re-scans a tree where some documents are unchanged, some have new
+metadata and some have new content. These tests pin the three behaviours that
+make reuse safe:
+
+  * an existing document point is merged, not replaced, so the document
+    embedding, the tagger's ``tag_*`` fields and ``is_duplicate`` survive;
+  * a metadata-only change reaches the denormalised chunk payloads;
+  * a content change queues the document for re-parsing and drops its stale
+    chunks.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipeline.processors.scanning.scanner import ScanProcessor
+
+
+@pytest.fixture
+def scanner(tmp_path):
+    processor = ScanProcessor.__new__(ScanProcessor)
+    processor.base_dir = str(tmp_path)
+    processor.batch_size = 50
+    processor.db = MagicMock()
+    processor.db.documents_collection = "documents_uneg"
+    processor.db.chunks_collection = "chunks_uneg"
+    processor.db.delete_document_chunks.return_value = 3
+    processor.pg = MagicMock()
+    return processor
+
+
+def write_document(tmp_path, name="report_1.pdf", content=b"pdf bytes", metadata=None):
+    folder = tmp_path / "FAO" / "2024"
+    folder.mkdir(parents=True, exist_ok=True)
+    doc = folder / name
+    doc.write_bytes(content)
+    meta = {"title": "A report", "agency": "FAO", "year": "2024", "country": "Kenya"}
+    meta.update(metadata or {})
+    doc.with_suffix(".json").write_text(json.dumps(meta), encoding="utf-8")
+    return doc
+
+
+# --- macOS sidecar files ---------------------------------------------------
+
+
+def test_apple_double_sidecars_are_not_scanned_as_metadata(scanner, tmp_path):
+    write_document(tmp_path)
+    (tmp_path / "FAO" / "2024" / "._report_1.json").write_bytes(
+        b"\x00\x05\x16\x07 apple double"
+    )
+
+    found = [p.name for p in scanner._scan_metadata_files()]
+
+    assert found == ["report_1.json"], "ExFAT sidecars must be ignored"
+
+
+# --- existing points are merged, not replaced ------------------------------
+
+
+def test_existing_document_payload_is_merged_not_replaced(scanner):
+    scanner._flush_batch([("doc-1", {"map_title": "New title"}, True)])
+
+    scanner.db.client.set_payload.assert_called_once()
+    kwargs = scanner.db.client.set_payload.call_args.kwargs
+    assert kwargs["collection_name"] == "documents_uneg"
+    assert kwargs["payload"] == {"map_title": "New title"}
+    assert kwargs["points"] == ["doc-1"]
+    scanner.db.client.upsert.assert_not_called(), "replacing the point would drop vector and tags"
+
+
+def test_new_document_is_upserted_as_a_point(scanner):
+    scanner._flush_batch([("doc-2", {"map_title": "Brand new"}, False)])
+
+    scanner.db.client.upsert.assert_called_once()
+    points = scanner.db.client.upsert.call_args.kwargs["points"]
+    assert len(points) == 1 and points[0].id == "doc-2"
+    scanner.db.client.set_payload.assert_not_called()
+
+
+def test_mixed_batch_splits_between_merge_and_upsert(scanner):
+    scanner._flush_batch(
+        [("old", {"map_title": "t"}, True), ("new", {"map_title": "u"}, False)]
+    )
+
+    assert scanner.db.client.set_payload.call_count == 1
+    assert len(scanner.db.client.upsert.call_args.kwargs["points"]) == 1
+
+
+# --- metadata changes reach chunk payloads ---------------------------------
+
+
+def test_metadata_change_propagates_to_chunk_payloads(scanner):
+    scanner._propagate_to_chunks(
+        "doc-3",
+        {
+            "map_country": "Kenya; Uganda",
+            "src_theme": "Nutrition",
+            "sys_status": "indexed",
+        },
+    )
+
+    kwargs = scanner.db.client.set_payload.call_args.kwargs
+    assert kwargs["collection_name"] == "chunks_uneg"
+    assert kwargs["payload"] == {
+        "map_country": "Kenya; Uganda",
+        "src_theme": "Nutrition",
+    }
+    condition = kwargs["points"].must[0]
+    assert condition.key == "doc_id" and condition.match.value == "doc-3"
+
+
+def test_propagation_skips_documents_with_no_mapped_fields(scanner):
+    scanner._propagate_to_chunks(
+        "doc-4", {"sys_status": "indexed", "is_duplicate": False}
+    )
+
+    scanner.db.client.set_payload.assert_not_called()
+
+
+# --- content changes queue a re-parse --------------------------------------
+
+
+@pytest.mark.parametrize("change_type", ["file", "both"])
+def test_content_change_clears_chunks_and_resets_status(scanner, change_type):
+    scanner._apply_change_side_effects("doc-5", change_type)
+
+    scanner.db.delete_document_chunks.assert_called_once_with("doc-5")
+    fields = scanner.pg.merge_doc_sys_fields.call_args.kwargs["sys_fields"]
+    assert fields["sys_status"] == "downloaded", "document must be re-parsed"
+    assert fields["sys_parsed_folder"] is None
+    assert fields["sys_chunk_count"] == 0
+
+
+@pytest.mark.parametrize("change_type", ["metadata", "new", "", "status_change"])
+def test_non_content_changes_keep_the_processed_output(scanner, change_type):
+    scanner._apply_change_side_effects("doc-6", change_type)
+
+    scanner.db.delete_document_chunks.assert_not_called()
+    scanner.pg.merge_doc_sys_fields.assert_not_called()
+
+
+def test_failure_to_delete_chunks_does_not_stop_the_scan(scanner):
+    scanner.db.delete_document_chunks.side_effect = RuntimeError("qdrant down")
+
+    scanner._apply_change_side_effects("doc-7", "file")
+
+    # The status reset still happens so the document is not left half-updated.
+    assert scanner.pg.merge_doc_sys_fields.called

--- a/tests/unit/test_stages.py
+++ b/tests/unit/test_stages.py
@@ -248,7 +248,8 @@ class TestScanProcessorStages:
             )
 
             assert result is not None
-            _, metadata = result
+            # (doc_id, payload, already_existed)
+            _, metadata = result[0], result[1]
 
             assert "sys_stages" in metadata
             assert "download" in metadata["sys_stages"]
@@ -298,7 +299,8 @@ class TestScanProcessorStages:
             )
 
             assert result is not None
-            _, metadata = result
+            # (doc_id, payload, already_existed)
+            _, metadata = result[0], result[1]
 
             assert "sys_stages" in metadata
             assert "download" in metadata["sys_stages"]


### PR DESCRIPTION
## Summary

Preparation for the UNEG data refresh. Re-scanning a tree whose documents have changed exposed three gaps in `ScanProcessor`, each of which silently lost data or silently skipped work. Each fix has a test that fails without it.

- **An existing document point was replaced wholesale.** The point in `documents_<source>` also carries the document-level embedding written by the indexer, the `tag_*` fields written by the tagger and the `is_duplicate` flag. A metadata-only rescan dropped all three. Existing documents are now merged with `set_payload`; new documents are still upserted as points.
- **Metadata changes never reached chunk payloads.** The indexer denormalises `src_*`, `map_*`, `tag_*` and `sys_language` onto every chunk so search can filter without a join. When a document's metadata changed, search filters kept matching the old values. Changes now propagate to the document's chunks.
- **A changed file was never re-parsed.** The scanner recorded the new checksum but left the status and the stale chunks alone, and nothing downstream consumed the change type. A content change now deletes the chunks, resets the status to `downloaded` and clears `sys_parsed_folder`, so the normal stage collection re-parses it.

Also: ignore macOS `._` AppleDouble sidecar files when scanning for metadata. On ExFAT volumes one sits next to every file and each was opened and counted as unreadable metadata.

`_process_metadata_file` now returns `(doc_id, payload, already_existed)`; the two existing tests that unpacked a pair are updated.

`CLAUDE.md` gains the working-data location and a note that plans are not committed to `docs/`.

## Test plan

- [x] `tests/unit/test_scanner_refresh.py` — 13 new tests covering merge-not-replace, chunk propagation, re-parse side effects, and sidecar filtering
- [x] `tests/unit/test_scan.py`, `test_stages.py`, `test_scanner_multivalue.py`, `test_scanner_transforms.py` — 49 passed
- [x] Pre-commit hooks pass, including the code-metrics gate
- [ ] Exercised end to end in the UNEG refresh's local ingestion run (phase 5), not yet run

🤖 Generated with [Claude Code](https://claude.com/claude-code)