### PR TITLE
fix(api): gzip large responses without buffering event streams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,13 @@ CORS_ALLOWED_ORIGINS=https://yourdomain.com
 # Content-Type,Authorization,X-API-Key,X-CSRF-Token,Accept,Accept-Language
 # CORS_ALLOWED_HEADERS=Content-Type,Authorization,X-API-Key,X-CSRF-Token,Accept,Accept-Language
 
+# API response compression (gzip). Large search/document responses exceed
+# GCP Cloud Run's 32 MiB uncompressed response limit; event streams are
+# never compressed. Set API_GZIP_ENABLED=false to turn it off.
+# API_GZIP_ENABLED=true
+# API_GZIP_MIN_BYTES=1024
+# API_GZIP_LEVEL=6
+
 # API server host binding (0.0.0.0 for Docker, 127.0.0.1 for local dev)
 API_HOST=0.0.0.0
 API_PORT=8000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ Before submitting, verify: no hardcoded secrets, input validation in place, no d
 - Connection pooling: `get_db_for_source()` and `get_pg_for_source()` in `ui/backend/utils/app_state.py` cache DB clients per data source.
 - Pydantic models for all request/response schemas with `.model_dump()`.
 - Timing instrumentation: `t0 = time.time()` ... `logger.info("[TIMING] operation: %.3fs", t1 - t0)`.
+- **NEVER run CPU-bound or blocking work synchronously on the event loop.** The API runs one uvicorn worker, so anything that blocks the loop (compression, big serialisation, file I/O, sync DB or HTTP calls, hashing, model inference) pauses every user's request, not just the caller's. Hand it to `run_in_threadpool()` (or a process pool for pure-Python CPU work that holds the GIL) and measure concurrent request latency before and after. Middleware counts too: response gzip measured 405 ms stalls for other users when done inline, 104 ms in the threadpool.
 
 ### Frontend (React/TypeScript)
 - State management: React Context + custom hooks (no Redux). See `useAuth`, `useDrilldownTree`, `useActivityLogging`.

--- a/tests/unit/test_gzip_middleware.py
+++ b/tests/unit/test_gzip_middleware.py
@@ -198,6 +198,64 @@ class TestSelectiveGZipMiddleware:
 
 
 @pytest.mark.unit
+class TestCompressionOffEventLoop:
+    """Compression must run in a worker thread so the event loop keeps serving others."""
+
+    @pytest.mark.asyncio
+    async def test_large_json_when_compressed_then_deflate_runs_off_the_loop_thread(
+        self,
+    ):
+        import threading
+        from unittest.mock import patch
+
+        from ui.backend.utils import gzip_middleware
+
+        loop_thread = threading.get_ident()
+        seen_threads = []
+        original = gzip_middleware._GZipResponder._compress
+
+        def recording_compress(responder, body, more_body):
+            seen_threads.append(threading.get_ident())
+            return original(responder, body, more_body)
+
+        with patch.object(
+            gzip_middleware._GZipResponder, "_compress", recording_compress
+        ):
+            headers, bodies = await _call_asgi(_make_app(), "/large", GZIP_REQUEST)
+
+        assert headers["content-encoding"] == "gzip"
+        assert json.loads(gzip.decompress(b"".join(bodies))) == LARGE_PAYLOAD
+        assert seen_threads, "compression never ran"
+        assert all(t != loop_thread for t in seen_threads)
+
+    @pytest.mark.asyncio
+    async def test_streamed_csv_when_compressed_then_every_chunk_deflates_off_the_loop_thread(
+        self,
+    ):
+        import threading
+        from unittest.mock import patch
+
+        from ui.backend.utils import gzip_middleware
+
+        loop_thread = threading.get_ident()
+        seen_threads = []
+        original = gzip_middleware._GZipResponder._compress
+
+        def recording_compress(responder, body, more_body):
+            seen_threads.append(threading.get_ident())
+            return original(responder, body, more_body)
+
+        with patch.object(
+            gzip_middleware._GZipResponder, "_compress", recording_compress
+        ):
+            headers, bodies = await _call_asgi(_make_app(), "/csv", GZIP_REQUEST)
+
+        assert headers["content-encoding"] == "gzip"
+        assert len(seen_threads) == len(bodies)
+        assert all(t != loop_thread for t in seen_threads)
+
+
+@pytest.mark.unit
 class TestAppRegistration:
     """The real API app registers the middleware from environment settings."""
 

--- a/tests/unit/test_gzip_middleware.py
+++ b/tests/unit/test_gzip_middleware.py
@@ -1,0 +1,241 @@
+"""Unit tests for SelectiveGZipMiddleware (API response compression)."""
+
+import asyncio
+import gzip
+import json
+import zlib
+
+import httpx
+import pytest
+from fastapi import FastAPI, Response
+from fastapi.responses import StreamingResponse
+
+from ui.backend.utils.gzip_middleware import SelectiveGZipMiddleware
+
+LARGE_PAYLOAD = {"results": [{"text": "chunk " * 50, "id": i} for i in range(200)]}
+SMALL_PAYLOAD = {"status": "ok"}
+STREAM_CHUNKS = [f"data: event {i} {'x' * 300}\n\n" for i in range(5)]
+CSV_ROWS = [f"row{i}," + "value" * 100 + "\n" for i in range(5)]
+
+
+def _make_app(minimum_size: int = 1024, compresslevel: int = 6) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/large")
+    async def large():
+        return LARGE_PAYLOAD
+
+    @app.get("/small")
+    async def small():
+        return SMALL_PAYLOAD
+
+    @app.get("/sse")
+    async def sse():
+        async def gen():
+            for chunk in STREAM_CHUNKS:
+                yield chunk
+                await asyncio.sleep(0)
+
+        return StreamingResponse(gen(), media_type="text/event-stream")
+
+    @app.get("/csv")
+    async def csv():
+        async def gen():
+            for row in CSV_ROWS:
+                yield row
+
+        return StreamingResponse(gen(), media_type="text/csv")
+
+    @app.get("/pre-encoded")
+    async def pre_encoded():
+        body = gzip.compress(b"already compressed " * 200)
+        return Response(
+            content=body,
+            media_type="application/octet-stream",
+            headers={"Content-Encoding": "gzip"},
+        )
+
+    app.add_middleware(
+        SelectiveGZipMiddleware, minimum_size=minimum_size, compresslevel=compresslevel
+    )
+    return app
+
+
+def _client(app: FastAPI) -> httpx.AsyncClient:
+    transport = httpx.ASGITransport(app=app)
+    return httpx.AsyncClient(transport=transport, base_url="http://testserver")
+
+
+async def _call_asgi(app: FastAPI, path: str, request_headers: list) -> tuple:
+    """Drive the app at the ASGI level and capture the exact messages sent.
+
+    Returns ``(response_headers, body_messages)`` where ``body_messages`` is
+    the list of raw ``body`` bytes for every ``http.response.body`` message,
+    in the order the middleware emitted them.
+    """
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": request_headers,
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("client", 1),
+    }
+    request_delivered = False
+
+    async def receive():
+        nonlocal request_delivered
+        if not request_delivered:
+            request_delivered = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await asyncio.Event().wait()
+
+    headers: dict = {}
+    bodies: list = []
+
+    async def send(message):
+        if message["type"] == "http.response.start":
+            headers.update({k.decode(): v.decode() for k, v in message["headers"]})
+        elif message["type"] == "http.response.body":
+            bodies.append(message.get("body", b""))
+
+    await app(scope, receive, send)
+    return headers, bodies
+
+
+GZIP_REQUEST = [(b"accept-encoding", b"gzip, deflate, br"), (b"host", b"testserver")]
+PLAIN_REQUEST = [(b"host", b"testserver")]
+
+
+@pytest.mark.unit
+class TestSelectiveGZipMiddleware:
+    @pytest.mark.asyncio
+    async def test_large_json_when_gzip_accepted_then_compressed_and_decodable(self):
+        headers, bodies = await _call_asgi(_make_app(), "/large", GZIP_REQUEST)
+        assert headers["content-encoding"] == "gzip"
+        assert "Accept-Encoding" in headers["vary"]
+        wire = b"".join(bodies)
+        assert int(headers["content-length"]) == len(wire)
+        assert json.loads(gzip.decompress(wire)) == LARGE_PAYLOAD
+        assert len(wire) < len(json.dumps(LARGE_PAYLOAD))
+
+    @pytest.mark.asyncio
+    async def test_large_json_when_fetched_via_client_then_transparently_decoded(self):
+        async with _client(_make_app()) as client:
+            response = await client.get("/large", headers={"Accept-Encoding": "gzip"})
+        assert response.status_code == 200
+        assert response.headers["content-encoding"] == "gzip"
+        assert response.json() == LARGE_PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_small_json_when_under_minimum_size_then_untouched(self):
+        headers, bodies = await _call_asgi(_make_app(), "/small", GZIP_REQUEST)
+        assert "content-encoding" not in headers
+        assert json.loads(b"".join(bodies)) == SMALL_PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_large_json_when_client_does_not_accept_gzip_then_untouched(self):
+        headers, bodies = await _call_asgi(_make_app(), "/large", PLAIN_REQUEST)
+        assert "content-encoding" not in headers
+        assert json.loads(b"".join(bodies)) == LARGE_PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_event_stream_when_gzip_accepted_then_each_event_passes_through_intact(
+        self,
+    ):
+        headers, bodies = await _call_asgi(_make_app(), "/sse", GZIP_REQUEST)
+        assert "content-encoding" not in headers
+        assert headers["content-type"].startswith("text/event-stream")
+        # Every event must leave the middleware as its own, unmodified message;
+        # buffering them until the stream closes is exactly the bug this guards.
+        emitted = [b.decode() for b in bodies if b]
+        assert emitted == STREAM_CHUNKS
+
+    @pytest.mark.asyncio
+    async def test_streamed_csv_when_gzip_accepted_then_each_chunk_flushed_promptly(
+        self,
+    ):
+        headers, bodies = await _call_asgi(_make_app(), "/csv", GZIP_REQUEST)
+        assert headers["content-encoding"] == "gzip"
+        assert "content-length" not in headers
+        # Each row is one body message with more_body=True; a sync flush per
+        # chunk means none of them arrives empty (which would signal buffering).
+        row_messages = bodies[: len(CSV_ROWS)]
+        assert all(len(b) > 0 for b in row_messages)
+        decoder = zlib.decompressobj(16 + zlib.MAX_WBITS)
+        assert decoder.decompress(b"".join(bodies)).decode() == "".join(CSV_ROWS)
+
+    @pytest.mark.asyncio
+    async def test_already_encoded_response_when_gzip_accepted_then_not_double_compressed(
+        self,
+    ):
+        headers, bodies = await _call_asgi(_make_app(), "/pre-encoded", GZIP_REQUEST)
+        assert headers["content-encoding"] == "gzip"
+        assert gzip.decompress(b"".join(bodies)) == b"already compressed " * 200
+
+    @pytest.mark.asyncio
+    async def test_non_http_scope_when_called_then_passed_straight_to_app(self):
+        seen = []
+
+        async def inner(scope, receive, send):
+            seen.append(scope["type"])
+
+        middleware = SelectiveGZipMiddleware(inner)
+        await middleware({"type": "lifespan"}, None, None)
+        assert seen == ["lifespan"]
+
+    def test_init_when_compresslevel_out_of_range_then_raises(self):
+        with pytest.raises(ValueError):
+            SelectiveGZipMiddleware(lambda *a: None, compresslevel=10)
+
+    def test_init_when_minimum_size_negative_then_raises(self):
+        with pytest.raises(ValueError):
+            SelectiveGZipMiddleware(lambda *a: None, minimum_size=-1)
+
+
+@pytest.mark.unit
+class TestAppRegistration:
+    """The real API app registers the middleware from environment settings."""
+
+    @staticmethod
+    def _reload_main(extra_env: dict):
+        import importlib
+        import os
+        from unittest.mock import patch
+
+        env = {k: v for k, v in os.environ.items() if not k.startswith("API_GZIP_")}
+        env["API_SECRET_KEY"] = ""
+        env.update(extra_env)
+        with patch.dict(os.environ, env, clear=True):
+            import ui.backend.main as main_module
+
+            return importlib.reload(main_module)
+
+    @staticmethod
+    def _gzip_entries(main_module):
+        return [
+            m
+            for m in main_module.app.user_middleware
+            if m.cls is SelectiveGZipMiddleware
+        ]
+
+    def test_app_when_env_unset_then_gzip_registered_with_defaults(self):
+        main_module = self._reload_main({})
+        entries = self._gzip_entries(main_module)
+        assert len(entries) == 1
+        assert entries[0].kwargs == {"minimum_size": 1024, "compresslevel": 6}
+
+    def test_app_when_env_overrides_then_gzip_uses_them(self):
+        main_module = self._reload_main(
+            {"API_GZIP_MIN_BYTES": "4096", "API_GZIP_LEVEL": "3"}
+        )
+        entries = self._gzip_entries(main_module)
+        assert entries[0].kwargs == {"minimum_size": 4096, "compresslevel": 3}
+
+    def test_app_when_disabled_then_gzip_not_registered(self):
+        main_module = self._reload_main({"API_GZIP_ENABLED": "false"})
+        assert self._gzip_entries(main_module) == []

--- a/tests/unit/test_requirements_consistency.py
+++ b/tests/unit/test_requirements_consistency.py
@@ -1,0 +1,54 @@
+"""Guard against ui/backend/requirements.txt downgrading the root requirements.
+
+The Docker image installs the root requirements first and the backend file
+second, so a package pinned in both files must carry the same version or pip
+silently replaces the root version with the backend one.
+"""
+
+import re
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ROOT_REQUIREMENTS = REPO_ROOT / "requirements.txt"
+BACKEND_REQUIREMENTS = REPO_ROOT / "ui" / "backend" / "requirements.txt"
+
+_PIN_PATTERN = re.compile(r"^([A-Za-z0-9_.\-]+)(?:\[[^\]]*\])?==([^\s;#]+)")
+
+
+def parse_exact_pins(path: Path) -> Dict[str, str]:
+    """Return {package_name: version} for every ``name==version`` line in a requirements file."""
+    pins: Dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        match = _PIN_PATTERN.match(line)
+        if match:
+            pins[match.group(1).lower().replace("_", "-")] = match.group(2)
+    return pins
+
+
+@pytest.mark.unit
+class TestBackendRequirementsMatchRoot:
+    def test_parse_exact_pins_when_extras_and_comments_then_only_exact_pins_kept(
+        self, tmp_path
+    ):
+        sample = tmp_path / "req.txt"
+        sample.write_text(
+            "fastapi==1.2.3  # comment\nuvicorn[standard]==0.4.0\npydantic>=2.0\n# only a comment\n"
+        )
+        assert parse_exact_pins(sample) == {"fastapi": "1.2.3", "uvicorn": "0.4.0"}
+
+    def test_backend_pins_when_also_pinned_in_root_then_versions_match(self):
+        root = parse_exact_pins(ROOT_REQUIREMENTS)
+        backend = parse_exact_pins(BACKEND_REQUIREMENTS)
+        shared = {name: (backend[name], root[name]) for name in backend if name in root}
+        assert shared, "expected at least one package pinned in both files"
+        mismatched = {
+            name: f"backend={b} root={r}" for name, (b, r) in shared.items() if b != r
+        }
+        assert not mismatched, (
+            "ui/backend/requirements.txt is installed after requirements.txt in the "
+            f"Docker image and would downgrade these packages: {mismatched}"
+        )

--- a/ui/backend/main.py
+++ b/ui/backend/main.py
@@ -189,6 +189,18 @@ MAX_REQUEST_BODY_BYTES = int(
     os.environ.get("MAX_REQUEST_BODY_BYTES", str(2 * 1024 * 1024))  # 2 MB
 )
 
+# Response compression. Cloud Run rejects uncompressed HTTP/1 responses
+# above 32 MiB, and nginx only gzips proxied responses that carry cache
+# headers, so the API compresses its own JSON. Event streams are excluded
+# (see ui/backend/utils/gzip_middleware.py).
+API_GZIP_ENABLED = os.environ.get("API_GZIP_ENABLED", "true").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+API_GZIP_MIN_BYTES = int(os.environ.get("API_GZIP_MIN_BYTES", "1024"))
+API_GZIP_LEVEL = int(os.environ.get("API_GZIP_LEVEL", "6"))
+
 _main_logger = logging.getLogger(__name__)
 
 # Debug flag — when true, exception handlers return full error details.
@@ -671,6 +683,17 @@ if not CORS_HEADERS:
         "Accept",
         "Accept-Language",
     ]
+
+# Innermost middleware: compresses route responses; outer middlewares only
+# add headers or reject requests, and their own bodies are small.
+if API_GZIP_ENABLED:
+    from ui.backend.utils.gzip_middleware import SelectiveGZipMiddleware  # noqa: E402
+
+    app.add_middleware(
+        SelectiveGZipMiddleware,
+        minimum_size=API_GZIP_MIN_BYTES,
+        compresslevel=API_GZIP_LEVEL,
+    )
 
 app.add_middleware(
     CORSMiddleware,

--- a/ui/backend/requirements.txt
+++ b/ui/backend/requirements.txt
@@ -1,5 +1,9 @@
-fastapi==0.115.6
-uvicorn[standard]==0.24.0
+# Installed AFTER the root requirements.txt in Dockerfile / Dockerfile.base.
+# Any package pinned here MUST carry the same version as the root file, or pip
+# downgrades what the root file installed (this once left the API image on
+# FastAPI 0.115.6 / Starlette 0.41.3 while CI tested 0.135.1 / 0.52.1).
+fastapi==0.135.1
+uvicorn[standard]==0.49.0
 pydantic>=2.10.0
 pydantic-settings>=2.6.0
 python-multipart==0.0.22
@@ -12,9 +16,9 @@ deep-translator>=1.11.4
 cohere>=5.14.0
 
 # User module (auth & permissions) — only needed when USER_MODULE=true
-fastapi-users[sqlalchemy,oauth]==15.0.4
+fastapi-users[sqlalchemy,oauth]==15.0.5
 httpx-oauth==0.16.1
-sqlalchemy[asyncio]==2.0.36
+sqlalchemy[asyncio]==2.0.49
 asyncpg==0.31.0
 aiosmtplib==5.1.2
 openpyxl>=3.1.0

--- a/ui/backend/utils/gzip_middleware.py
+++ b/ui/backend/utils/gzip_middleware.py
@@ -1,0 +1,135 @@
+"""Gzip response compression that leaves event streams alone.
+
+Why this exists instead of Starlette's ``GZipMiddleware``: the Starlette
+version pinned by ``ui/backend/requirements.txt`` (0.41) compresses every
+response, including ``text/event-stream``. Gzip holds streamed bytes in its
+internal buffer until the stream closes, so the assistant and AI summary
+streams would reach the browser all at once at the very end instead of
+token by token. Starlette 0.52 skips event streams itself, but the API
+image does not run that version.
+
+Behaviour:
+
+- Responses are compressed only when the client sends ``Accept-Encoding``
+  containing ``gzip``.
+- Bodies smaller than ``minimum_size`` are sent as-is.
+- Responses whose ``Content-Type`` starts with one of
+  ``EXCLUDED_CONTENT_TYPES``, or that already carry ``Content-Encoding``,
+  are passed through untouched.
+- Streamed responses (more than one body message) are compressed chunk by
+  chunk with a sync flush after each chunk, so downloads still progress as
+  the server produces them.
+"""
+
+import zlib
+from typing import Optional
+
+from starlette.datastructures import Headers, MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+EXCLUDED_CONTENT_TYPES = ("text/event-stream",)
+
+# 16 + MAX_WBITS asks zlib for a gzip container rather than a raw deflate
+# stream, which is what browsers expect for ``Content-Encoding: gzip``.
+_GZIP_WBITS = 16 + zlib.MAX_WBITS
+
+
+class SelectiveGZipMiddleware:
+    """Pure-ASGI middleware: gzip responses except event streams."""
+
+    def __init__(self, app: ASGIApp, minimum_size: int = 1024, compresslevel: int = 6):
+        if not 0 <= compresslevel <= 9:
+            raise ValueError(f"compresslevel must be 0..9, got {compresslevel}")
+        if minimum_size < 0:
+            raise ValueError(f"minimum_size must be >= 0, got {minimum_size}")
+        self.app = app
+        self.minimum_size = minimum_size
+        self.compresslevel = compresslevel
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        accept_encoding = Headers(scope=scope).get("accept-encoding", "")
+        if "gzip" not in accept_encoding:
+            await self.app(scope, receive, send)
+            return
+        responder = _GZipResponder(send, self.minimum_size, self.compresslevel)
+        await self.app(scope, receive, responder.send)
+
+
+class _GZipResponder:
+    """Wraps one response's ``send`` and decides per response what to do."""
+
+    def __init__(self, send: Send, minimum_size: int, compresslevel: int):
+        self._send = send
+        self._minimum_size = minimum_size
+        self._compresslevel = compresslevel
+        self._start_message: Optional[Message] = None
+        self._passthrough = False
+        self._body_started = False
+        self._compressor: Optional["zlib._Compress"] = None
+
+    async def send(self, message: Message) -> None:
+        kind = message["type"]
+        if kind == "http.response.start":
+            self._remember_start(message)
+        elif kind == "http.response.body" and not self._passthrough:
+            await self._send_body(message)
+        else:
+            # Excluded content, already-encoded responses and non-body
+            # messages such as ``http.response.pathsend`` go through as-is.
+            await self._send_start_once()
+            await self._send(message)
+
+    def _remember_start(self, message: Message) -> None:
+        # Headers cannot be finalised until the first body message shows
+        # whether the response is small, single-shot, or streamed.
+        self._start_message = message
+        headers = Headers(raw=message["headers"])
+        content_type = headers.get("content-type", "")
+        self._passthrough = "content-encoding" in headers or content_type.startswith(
+            EXCLUDED_CONTENT_TYPES
+        )
+
+    async def _send_start_once(self) -> None:
+        if self._start_message is not None:
+            start, self._start_message = self._start_message, None
+            await self._send(start)
+
+    async def _send_body(self, message: Message) -> None:
+        body = message.get("body", b"")
+        more_body = message.get("more_body", False)
+        if self._body_started:
+            message["body"] = self._compress(body, more_body)
+            await self._send(message)
+            return
+
+        self._body_started = True
+        if not more_body and len(body) < self._minimum_size:
+            await self._send_start_once()
+            await self._send(message)
+            return
+
+        if self._start_message is None:
+            raise RuntimeError("http.response.body received before http.response.start")
+        headers = MutableHeaders(raw=self._start_message["headers"])
+        headers["Content-Encoding"] = "gzip"
+        headers.add_vary_header("Accept-Encoding")
+        self._compressor = zlib.compressobj(
+            self._compresslevel, zlib.DEFLATED, _GZIP_WBITS
+        )
+        message["body"] = self._compress(body, more_body)
+        if more_body:
+            del headers["Content-Length"]
+        else:
+            headers["Content-Length"] = str(len(message["body"]))
+        await self._send_start_once()
+        await self._send(message)
+
+    def _compress(self, body: bytes, more_body: bool) -> bytes:
+        if self._compressor is None:
+            raise RuntimeError("compressor used before the response started")
+        out = self._compressor.compress(body)
+        flush_mode = zlib.Z_SYNC_FLUSH if more_body else zlib.Z_FINISH
+        return out + self._compressor.flush(flush_mode)

--- a/ui/backend/utils/gzip_middleware.py
+++ b/ui/backend/utils/gzip_middleware.py
@@ -19,11 +19,15 @@ Behaviour:
 - Streamed responses (more than one body message) are compressed chunk by
   chunk with a sync flush after each chunk, so downloads still progress as
   the server produces them.
+- Compression runs in the threadpool, not on the event loop. zlib releases
+  the interpreter lock while deflating, so a 16 MB page (about 275 ms at
+  level 6) no longer stalls every other request on the worker.
 """
 
 import zlib
 from typing import Optional
 
+from starlette.concurrency import run_in_threadpool
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -101,7 +105,7 @@ class _GZipResponder:
         body = message.get("body", b"")
         more_body = message.get("more_body", False)
         if self._body_started:
-            message["body"] = self._compress(body, more_body)
+            message["body"] = await run_in_threadpool(self._compress, body, more_body)
             await self._send(message)
             return
 
@@ -119,7 +123,7 @@ class _GZipResponder:
         self._compressor = zlib.compressobj(
             self._compresslevel, zlib.DEFLATED, _GZIP_WBITS
         )
-        message["body"] = self._compress(body, more_body)
+        message["body"] = await run_in_threadpool(self._compress, body, more_body)
         if more_body:
             del headers["Content-Length"]
         else:


### PR DESCRIPTION
## Summary

After the GCP deploy, Search and Documents failed with payload-too-big errors. Cloud Run rejects HTTP/1 responses above 32 MiB unless they are chunked or compressed, and the nginx in front of the API only gzips proxied responses that carry cache-control headers (`gzip_proxied expired no-cache no-store private auth`), so API JSON left uncompressed. WFP worked around it locally with Starlette's `GZipMiddleware`; this PR brings compression upstream in a form that is safe for the streaming endpoints.

## Why not the two-line `GZipMiddleware` version

The API image installs `ui/backend/requirements.txt` last, which pins FastAPI 0.115.6 and therefore Starlette 0.41.3. That version's `GZipMiddleware` compresses `text/event-stream` too, and gzip holds streamed bytes until the stream closes. Measured at the ASGI layer with five events sent 200 ms apart:

| Starlette | Body messages emitted while streaming | Data delivered |
|---|---|---|
| 0.41.3 (API image) | 10-byte gzip header, then 0, 0, 0, 0 bytes | all 65 bytes at stream close |
| 0.52.1 (root requirements) | 316, 316, 316, 316, 316 bytes | as produced |

So with the two-line version the assistant and AI summary streams would appear frozen and then dump everything at the end.

## Change

- `ui/backend/utils/gzip_middleware.py`: `SelectiveGZipMiddleware`, pure ASGI. Compresses when the client accepts gzip and the body is at least `minimum_size`. Passes `text/event-stream` and already-encoded responses through untouched. Streamed non-SSE responses (CSV exports, files) are compressed with a sync flush per chunk so they still progress.
- `ui/backend/main.py`: registers it as the innermost middleware. Settings: `API_GZIP_ENABLED` (default true), `API_GZIP_MIN_BYTES` (1024), `API_GZIP_LEVEL` (6).
- `.env.example`: documents the three settings.
- `tests/unit/test_gzip_middleware.py`: 13 tests, including the SSE pass-through and per-chunk flush cases, and app registration from env.

## Verification

- Unit tests pass under both Starlette 0.41.3 (inside the API image) and 0.52.1 (venv, matching CI).
- Real app from this branch run in a one-off container: `/openapi.json` went from 172,859 bytes to 20,695 bytes on the wire and decoded identically; a small `/search` response was left untouched; a real `/assistant/chat/stream` answer arrived as 9 separate events over 13 s with no `Content-Encoding` header.
- Pre-commit hooks including code-metrics pass.

## Not verified

- Not tested on GCP. The 32 MiB response itself could not be reproduced locally (empty local data source), so which endpoint produces it, and how far under the limit it lands after compression, is still unmeasured. A 32 MiB JSON body is worth looking at on its own; compression buys headroom, it does not remove the cause.
- WFP's Azure branch (`rc/v1.6.2`, commit c8876f11) should drop its local two `GZipMiddleware` lines when it takes this, otherwise their SSE streams stay buffered.

## Also in this PR: stop the image downgrading FastAPI

`Dockerfile` / `Dockerfile.base` install `requirements.txt` and then `ui/backend/requirements.txt`. The backend file pinned `fastapi==0.115.6`, `uvicorn==0.24.0`, `fastapi-users==15.0.4`, `sqlalchemy==2.0.36`, so pip replaced the root versions and the API image ran FastAPI 0.115.6 / Starlette 0.41.3 while CI tested 0.135.1 / 0.52.1. The four pins now match the root file, and `tests/unit/test_requirements_consistency.py` fails if a package pinned in both files ever differs again. Rebuilt image measured at fastapi 0.135.1, uvicorn 0.49.0, sqlalchemy 2.0.49, starlette 1.6.0 (root does not pin starlette); the full unit suite passes inside it.

## Measured on real data (333-document WFP set, rebuilt image)

| Endpoint | Uncompressed | Gzip level 6 | Transfer |
|---|---|---|---|
| `/documents` page of 100 | 16.3 MB | 3.5 MB | Content-Length, not chunked |
| `/search` limit 50, no rerank | 9.8 MB | 2.2 MB | Content-Length |

Compression cost (CPU inside the container; it runs in the threadpool, see below):

| Body | level 1 | level 3 | level 6 (default) | level 9 |
|---|---|---|---|---|
| 16.3 MB documents | 86 ms → 4.65 MB | 117 ms → 4.17 MB | 275 ms → 3.51 MB | 409 ms → 3.48 MB |
| 9.8 MB search | 52 ms → 2.87 MB | 71 ms → 2.58 MB | 164 ms → 2.21 MB | 246 ms → 2.19 MB |

End-to-end on localhost, median of 5: documents 162 ms → 457 ms, search 73 ms → 239 ms with gzip. Compression is handed to `run_in_threadpool`; zlib releases the interpreter lock while deflating, so the event loop keeps serving other users. Measured: with the deflate call inline, concurrent `/health` requests stalled up to 405 ms while a 16 MB response compressed; in the threadpool the peak is 104 ms, the same as with compression off (136 ms). On any real network link the transfer saving dwarfs this; `API_GZIP_LEVEL=1` cuts the CPU cost by about 3x for a 30% larger body if latency under load matters more than bandwidth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


