### PR TITLE
feat(brief): add single-per-document reference grouping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ python scripts/sync/db/sync_backup_to_remote.py \
 
 ### Code Quality
 - **NEVER use `noqa`, `type: ignore`, or similar suppressions to bypass pre-commit hooks or linters.** Fix the actual issue instead. Only use suppressions if explicitly requested by the user.
+- **NEVER suppress, demote, or hide type or lint errors in tooling or environment config either** — no `TSC_COMPILE_ON_ERROR`, `ESLINT_NO_DEV_ERRORS`, `DISABLE_ESLINT_PLUGIN`, closing a compile-error overlay and carrying on, or any equivalent, not even for a throwaway local dev server. Find the cause (a stale package, a wrong config) and fix that.
 - **NEVER code fallbacks or graceful degradation unless explicitly requested.** If a dependency or feature is required, fail hard and loud. Silent fallbacks hide bugs.
 - **NEVER install packages ad-hoc.** New dependencies MUST be added to `requirements.txt` (root) and/or `ui/backend/requirements.txt` so they are part of the build environment. Both CI and Docker must pick them up.
 - **NEVER use deprecated APIs or methods.** Check library documentation for current recommended usage before implementing.

--- a/docs/using-evidence-lab/brief.md
+++ b/docs/using-evidence-lab/brief.md
@@ -68,7 +68,7 @@ For each completed section you can:
 - **Edit text** — tweak the generated prose by hand.
 - **Regenerate** — re-run the research, optionally with new guidance.
 
-Citations work like the rest of Evidence Lab: inline number badges link to the source document and page, an expandable **Evidence** panel lists the supporting documents for that section, and a compiled **References** list appears at the end of the brief. Citation numbers are renumbered consecutively across the whole brief, one number per cited passage — the same numbering the Research Assistant uses, so a document cited from three pages carries three numbers.
+Citations work like the rest of Evidence Lab: inline number badges link to the source document and page, an expandable **Evidence** panel lists the supporting documents for that section, and a compiled **References** list appears at the end of the brief. Citation numbers are renumbered consecutively across the whole brief. By default there is one number per cited passage — the same numbering the Research Assistant uses, so a document cited from three pages carries three numbers. Two **Group by document** checkboxes above the References list change how the list is laid out, and the single-per-document option also changes the numbering itself (see [Export to Word](#5-export-to-word) below).
 
 ---
 
@@ -86,7 +86,11 @@ From a card you can **open**, **share** or **delete** a brief. **New brief** sta
 
 When your brief is ready, click **Export to Word** at the top right.
 
-The exported document mirrors what you see on screen: inline `[n]` citation numbers in the prose and a compiled **References** list at the end, laid out according to the **Group by document** checkbox above that list. Leave it off for one line per citation; tick it to collapse the list to one line per document — `Title, [1] p. 32, [2] p. 56` — which is more compact when a brief leans on a handful of reports.
+The exported document mirrors what you see on screen: inline `[n]` citation numbers in the prose and a compiled **References** list at the end, laid out according to the **Group by document** checkboxes above that list (tick at most one):
+
+- **Neither ticked** — one line per citation, with its page: `[1] Title, p.32`.
+- **Group by document (multiple per document)** — one line per document listing each of its citation numbers with the page it points at: `Title, [1] p. 32, [2] p. 56`. The numbering is unchanged, so this is more compact when a brief leans on a handful of reports.
+- **Group by document (single per document)** — one number per document and no page numbers: `[1] Title`. Every passage cited from the same document shares that number, so the prose is renumbered too — `A fact happened. [1][3]` becomes `A fact happened. [1]` when both citations came from the same report. Clicking an inline number still opens the document at the passage it was cited from.
 
 ![Export to Word button](/docs/images/brief/brief-export-button.png)
 

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { SearchResult, SourceReference } from '../../types/api';
-import {
-  CitedMarkdown,
-  CitedReferences,
-  extractCitedNumbers,
-} from '../citations/CitedContent';
+import { CitedMarkdown, CitedReferences } from '../citations/CitedContent';
 import { buildGlobalCitations, SectionDisplay } from './briefCitations';
 import {
   IconClock,
@@ -15,6 +11,7 @@ import {
   IconShare,
   IconSparkle,
 } from './BriefIcons';
+import { BriefReferences } from './BriefReferences';
 import { BriefToc } from './BriefToc';
 import { BriefSelection } from './BriefSelectionMenu';
 import { BUBBLE_CLASS, CommentMark, MARK_CLASS, paintCommentMarks } from './briefCommentMarks';
@@ -102,60 +99,6 @@ const AiInstructionPanel: React.FC<{
     </div>
   </div>
 );
-
-// One row per document: its title, then each citation number pointing into it
-// with that number's page — "Title, [1] p. 32, [2] p. 56". No excerpts.
-const groupReferencesByDoc = (
-  refs: Array<{ n: number; title: string; page?: number; source: SourceReference }>,
-): Array<{
-  key: string;
-  title: string;
-  cites: Array<{ n: number; page: number; source: SourceReference }>;
-}> => {
-  const byDoc = new Map<
-    string,
-    {
-      key: string;
-      title: string;
-      cites: Array<{ n: number; page: number; source: SourceReference }>;
-    }
-  >();
-  // Numbers are per cited passage, so a document collects each of its own
-  // numbers with the page that number points at.
-  for (const r of refs) {
-    const key = r.source.docId || r.title;
-    const cite = { n: r.n, page: r.page ?? 0, source: r.source };
-    const found = byDoc.get(key);
-    if (found) found.cites.push(cite);
-    else byDoc.set(key, { key, title: r.title, cites: [cite] });
-  }
-  byDoc.forEach((g) => g.cites.sort((a, b) => a.page - b.page || a.n - b.n));
-  return Array.from(byDoc.values());
-};
-
-/**
- * Every cited chunk of each document, as the page and the source behind it.
- * The grouped references row lists these after the title, each labelled with
- * the citation number that appears inline in the prose.
- */
-const citedPagesByDoc = (
-  sections: BriefSection[],
-): Map<string, Array<{ page: number; source: SourceReference }>> => {
-  const map = new Map<string, Array<{ page: number; source: SourceReference }>>();
-  sections.forEach((s) => {
-    if (!(s.status === 'done' || s.revising) || !s.content) return;
-    const cited = new Set(extractCitedNumbers(s.content));
-    s.sources.forEach((src) => {
-      if (src.index == null || !cited.has(src.index) || src.page == null) return;
-      const key = src.docId || src.title;
-      const hits = map.get(key) || [];
-      if (!hits.some((h) => h.page === src.page)) hits.push({ page: src.page, source: src });
-      map.set(key, hits);
-    });
-  });
-  map.forEach((hits) => hits.sort((a, b) => a.page - b.page));
-  return map;
-};
 
 interface SectionViewProps {
   section: BriefSection;
@@ -452,6 +395,7 @@ const SectionDoneBody: React.FC<{
         collapsible
         labelPrefix="Evidence"
         className="brief-evidence"
+        hidePages={brief.referenceGrouping === 'document-single'}
       />
     </>
   );
@@ -616,7 +560,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
 };
 
 // "Export to Word": one button. The document mirrors the on-screen
-// references, so its layout follows the "Group by document" toggle.
+// references, so its layout follows the "Group by document" toggles.
 const ExportButton: React.FC<{
   disabled: boolean;
   busy: boolean;
@@ -791,7 +735,10 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
   const [logOpen, setLogOpen] = useState(false);
   const titleRef = useRef<HTMLTextAreaElement>(null);
   const hasOutlineLog = brief.generatingActivity.length > 0;
-  const { refs: references, display } = useMemo(() => buildGlobalCitations(sections), [sections]);
+  const { refs: references, display } = useMemo(
+    () => buildGlobalCitations(sections, brief.referenceGrouping),
+    [sections, brief.referenceGrouping],
+  );
 
   useEffect(() => autoSizeTitle(titleRef.current), [brief.briefTitle]);
 
@@ -987,82 +934,12 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
         </div>
       )}
 
-      {references.length > 0 && (
-        <section className="brief-footnotes">
-          <div className="brief-footnotes-head">
-            <h2 className="brief-footnotes-title">References</h2>
-            <label className="brief-footnotes-group-toggle">
-              <input
-                type="checkbox"
-                checked={brief.groupReferences}
-                onChange={(e) => brief.setGroupReferences(e.target.checked)}
-              />
-              Group by document
-            </label>
-          </div>
-          <div className="brief-footnotes-list">
-            {brief.groupReferences
-              ? groupReferencesByDoc(references).map((g) => (
-                  <div className="brief-footnote-group" key={g.key}>
-                    <span className="brief-footnote-text">{g.title}</span>
-                    {g.cites.map((c, i) => (
-                      <span className="brief-footnote-cite" key={`${c.n}-${c.page}-${i}`}>
-                        {/* The number is shown once per run of the same
-                            citation, so a document cited from many pages reads
-                            "[1] p. 9, p. 11" rather than repeating "[1]". */}
-                        {(i === 0 || g.cites[i - 1].n !== c.n) && (
-                          <span className="citation-doc-group">
-                            <a
-                              href="#"
-                              className="ai-summary-citation"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                handleSourceClick(c.source);
-                              }}
-                            >
-                              {c.n}
-                            </a>
-                          </span>
-                        )}
-                        {c.page ? (
-                          <a
-                            href="#"
-                            className="brief-footnote-page-link"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              handleSourceClick(c.source);
-                            }}
-                          >
-                            {` p. ${c.page}`}
-                          </a>
-                        ) : null}
-                      </span>
-                    ))}
-                  </div>
-                ))
-              : references.map((r) => (
-                  <div className="brief-footnote-row" key={r.n}>
-                    <a
-                      href="#"
-                      className="brief-footnote-link"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        handleSourceClick(r.source);
-                      }}
-                    >
-                      <span className="citation-doc-group">
-                        <span className="ai-summary-citation">{r.n}</span>
-                      </span>
-                      <span className="brief-footnote-text">
-                        {r.title}
-                        {r.page ? `, p.${r.page}` : ''}
-                      </span>
-                    </a>
-                  </div>
-                ))}
-          </div>
-        </section>
-      )}
+      <BriefReferences
+        references={references}
+        grouping={brief.referenceGrouping}
+        onGroupingChange={brief.setReferenceGrouping}
+        onSourceClick={handleSourceClick}
+      />
 
       <ResearchStatusBar brief={brief} />
     </div>

--- a/ui/frontend/src/components/brief/BriefReferences.tsx
+++ b/ui/frontend/src/components/brief/BriefReferences.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { SourceReference } from '../../types/api';
+import { GlobalRef } from './briefCitations';
+import { ReferenceGrouping } from './briefTypes';
+
+// The two "Group by document" options offered above the References list. They
+// are exclusive: ticking one clears the other, and clearing both returns to
+// one row per cited passage.
+export const REFERENCE_GROUPING_LABELS: Record<
+  Exclude<ReferenceGrouping, 'passage'>,
+  string
+> = {
+  'document-multiple': 'Group by document (multiple per document)',
+  'document-single': 'Group by document (single per document)',
+};
+
+const GROUPING_OPTIONS = Object.keys(REFERENCE_GROUPING_LABELS) as Array<
+  keyof typeof REFERENCE_GROUPING_LABELS
+>;
+
+interface DocCite {
+  n: number;
+  page: number;
+  source: SourceReference;
+}
+
+interface DocGroup {
+  key: string;
+  title: string;
+  cites: DocCite[];
+}
+
+// One row per document: its title, then each citation number pointing into it
+// with that number's page — "Title, [1] p. 32, [2] p. 56". No excerpts.
+export const groupReferencesByDoc = (refs: GlobalRef[]): DocGroup[] => {
+  const byDoc = new Map<string, DocGroup>();
+  // Numbers are per cited passage, so a document collects each of its own
+  // numbers with the page that number points at.
+  for (const r of refs) {
+    const key = r.source.docId || r.title;
+    const cite = { n: r.n, page: r.page ?? 0, source: r.source };
+    const found = byDoc.get(key);
+    if (found) found.cites.push(cite);
+    else byDoc.set(key, { key, title: r.title, cites: [cite] });
+  }
+  byDoc.forEach((g) => g.cites.sort((a, b) => a.page - b.page || a.n - b.n));
+  return Array.from(byDoc.values());
+};
+
+type SourceClick = (source: SourceReference) => void;
+
+const clickSource = (onSourceClick: SourceClick, source: SourceReference) =>
+  (e: React.MouseEvent) => {
+    e.preventDefault();
+    onSourceClick(source);
+  };
+
+// "[1] Title, p.32" — or just "[1] Title" for a document-level reference.
+const FlatRow: React.FC<{ reference: GlobalRef; onSourceClick: SourceClick }> = ({
+  reference: r,
+  onSourceClick,
+}) => (
+  <div className="brief-footnote-row">
+    <a href="#" className="brief-footnote-link" onClick={clickSource(onSourceClick, r.source)}>
+      <span className="citation-doc-group">
+        <span className="ai-summary-citation">{r.n}</span>
+      </span>
+      <span className="brief-footnote-text">
+        {r.title}
+        {r.page ? `, p.${r.page}` : ''}
+      </span>
+    </a>
+  </div>
+);
+
+// "Title, [1] p. 32, [2] p. 56": the document once, then each of its numbers.
+const GroupedRow: React.FC<{ group: DocGroup; onSourceClick: SourceClick }> = ({
+  group: g,
+  onSourceClick,
+}) => (
+  <div className="brief-footnote-group">
+    <span className="brief-footnote-text">{g.title}</span>
+    {g.cites.map((c, i) => (
+      <span className="brief-footnote-cite" key={`${c.n}-${c.page}-${i}`}>
+        {/* The number is shown once per run of the same citation, so a
+            document cited from many pages reads "[1] p. 9, p. 11" rather
+            than repeating "[1]". */}
+        {(i === 0 || g.cites[i - 1].n !== c.n) && (
+          <span className="citation-doc-group">
+            <a
+              href="#"
+              className="ai-summary-citation"
+              onClick={clickSource(onSourceClick, c.source)}
+            >
+              {c.n}
+            </a>
+          </span>
+        )}
+        {c.page ? (
+          <a
+            href="#"
+            className="brief-footnote-page-link"
+            onClick={clickSource(onSourceClick, c.source)}
+          >
+            {` p. ${c.page}`}
+          </a>
+        ) : null}
+      </span>
+    ))}
+  </div>
+);
+
+/**
+ * The compiled References list at the end of a brief, with the grouping
+ * toggles. The grouping also decides the citation numbering (see
+ * buildGlobalCitations), so switching it renumbers the inline `[n]` markers
+ * as well as this list.
+ */
+export const BriefReferences: React.FC<{
+  references: GlobalRef[];
+  grouping: ReferenceGrouping;
+  onGroupingChange: (grouping: ReferenceGrouping) => void;
+  onSourceClick: SourceClick;
+}> = ({ references, grouping, onGroupingChange, onSourceClick }) => {
+  if (references.length === 0) return null;
+  return (
+    <section className="brief-footnotes">
+      <div className="brief-footnotes-head">
+        <h2 className="brief-footnotes-title">References</h2>
+        <div className="brief-footnotes-group-toggles">
+          {GROUPING_OPTIONS.map((option) => (
+            <label className="brief-footnotes-group-toggle" key={option}>
+              <input
+                type="checkbox"
+                checked={grouping === option}
+                onChange={(e) => onGroupingChange(e.target.checked ? option : 'passage')}
+              />
+              {REFERENCE_GROUPING_LABELS[option]}
+            </label>
+          ))}
+        </div>
+      </div>
+      <div className="brief-footnotes-list">
+        {grouping === 'document-multiple'
+          ? groupReferencesByDoc(references).map((g) => (
+              <GroupedRow key={g.key} group={g} onSourceClick={onSourceClick} />
+            ))
+          : references.map((r) => (
+              <FlatRow key={r.n} reference={r} onSourceClick={onSourceClick} />
+            ))}
+      </div>
+    </section>
+  );
+};

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -4,11 +4,9 @@ import API_BASE_URL, { APP_BASE_PATH, USER_MODULE } from '../../config';
 import { useAuth } from '../../hooks/useAuth';
 import { SearchResult, SourceReference, SummaryModelConfig } from '../../types/api';
 import { SearchSettings } from '../../types/auth';
-import {
-  buildExportFilename,
-  exportResultsToDocxBlob,
-} from '../../utils/exportResultsToDocx';
+import { buildExportFilename, exportResultsToDocxBlob, ReferenceListLayout } from '../../utils/exportResultsToDocx';
 import { buildGlobalCitations } from './briefCitations';
+import { ReferenceGrouping } from './briefTypes';
 import { BriefCentral } from './BriefCentral';
 import {
   BriefRegenAllModal,
@@ -70,9 +68,9 @@ export const sourceToResult = (src: SourceReference, dataSource: string): Search
 /**
  * Flatten the brief into one Markdown body + a global SearchResult[] so it can
  * reuse the search summary's .docx exporter. Uses the same global citation
- * model as the on-screen render (combined by document), so `[n]` in the body
- * lines up with the references list and citations link to the source document
- * at the cited page.
+ * model (and the same reference grouping) as the on-screen render, so `[n]` in
+ * the body lines up with the references list and citations link to the source
+ * document at the cited page.
  */
 // Shown as a call-out box on the exported Word cover so readers treat the
 // AI-generated content as a draft to verify, not a finished product.
@@ -81,11 +79,18 @@ const BRIEF_DISCLAIMER =
   'Please verify any factual claims closely, and review for coverage and accuracy. ' +
   'This is meant as a guide for humans as part of the writing process, not as a final product.';
 
+// The Word export's references layout for each on-screen grouping.
+const REFERENCE_LIST_LAYOUT: Record<ReferenceGrouping, ReferenceListLayout> = {
+  passage: 'flat',
+  'document-multiple': 'grouped',
+  'document-single': 'document',
+};
+
 const assembleBriefForExport = (
   brief: ReturnType<typeof useBrief>,
   dataSource: string,
 ): { summary: string; results: SearchResult[] } => {
-  const { refs, display } = buildGlobalCitations(brief.sections);
+  const { refs, display } = buildGlobalCitations(brief.sections, brief.referenceGrouping);
   const lines: string[] = [];
   brief.sections.forEach((s, i) => {
     // The summary section's own H1 is the brief topic; sections sit one level
@@ -405,10 +410,9 @@ export const BriefTab: React.FC<BriefTabProps> = ({
           tableOfContents: true,
           resultsSectionTitle: 'References',
           // The document mirrors the on-screen References section: inline [n]
-          // citations and a compact list, grouped by document when the reader
-          // has that turned on.
+          // citations and a compact list laid out per the reader's grouping.
           citationStyle: 'links',
-          referenceList: brief.groupReferences ? 'grouped' : 'flat',
+          referenceList: REFERENCE_LIST_LAYOUT[brief.referenceGrouping],
           siteOrigin:
             typeof window !== 'undefined' && window.location ? window.location.origin : undefined,
           // Same API base the on-screen cards use to load table/figure

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -2522,6 +2522,12 @@
   flex-wrap: wrap;
   gap: 10px;
 }
+.brief-footnotes-group-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 16px;
+}
 .brief-footnotes-group-toggle {
   display: inline-flex;
   align-items: center;
@@ -2536,9 +2542,10 @@
   height: 15px;
   cursor: pointer;
 }
-/* Grouped view: one document per row, with its citation numbers. */
-/* "Title, [1] p. 32, [2] p. 56" — the title then each inline citation with
-   the page it points at. */
+/* Grouped view (multiple per document): one document per row, with its
+   citation numbers — "Title, [1] p. 32, [2] p. 56", the title then each inline
+   citation with the page it points at. The single-per-document view reuses the
+   flat rows: "[1] Title", one number per document and no pages. */
 .brief-footnote-group {
   display: block;
   padding: 3px 0;

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -75,11 +75,17 @@
   flex-wrap: wrap;
   align-items: center;
 }
-/* The three buttons flow left and wrap left. "Load a saved brief" used to
-   carry margin-left: auto to sit apart on the right, but the card is capped at
-   720px (676px inside) and the buttons need about 675px, so the row only ever
-   fit on one line by a pixel; on any narrower window it wrapped and the auto
-   margin stranded that button alone on the right of its own line. */
+/* The three buttons share the row: at the card's full width (720px, 676px
+   inside) they sit on one line, and on a narrower window they wrap and each
+   line's buttons grow to fill it, so no button is ever stranded alone on the
+   right. Slightly tighter padding than the default button keeps the three
+   comfortably on one line at full width. */
+.brief-seed-actions .brief-btn {
+  flex: 1 1 auto;
+  padding-left: 18px;
+  padding-right: 18px;
+  white-space: nowrap;
+}
 
 /* ---------- buttons ---------- */
 .brief-btn {

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -75,9 +75,11 @@
   flex-wrap: wrap;
   align-items: center;
 }
-.brief-seed-load {
-  margin-left: auto;
-}
+/* The three buttons flow left and wrap left. "Load a saved brief" used to
+   carry margin-left: auto to sit apart on the right, but the card is capped at
+   720px (676px inside) and the buttons need about 675px, so the row only ever
+   fit on one line by a pixel; on any narrower window it wrapped and the auto
+   margin stranded that button alone on the right of its own line. */
 
 /* ---------- buttons ---------- */
 .brief-btn {

--- a/ui/frontend/src/components/brief/briefCitations.ts
+++ b/ui/frontend/src/components/brief/briefCitations.ts
@@ -1,8 +1,22 @@
 import { SourceReference } from '../../types/api';
 import { extractCitedNumbers } from '../citations/CitedContent';
-import { BriefSection } from './briefTypes';
+import { BriefSection, ReferenceGrouping } from './briefTypes';
 
 const CITATION_RE = /\[(\d+(?:,\s*\d+)*)\]/g;
+// Two markers side by side that carry the same number(s) — `[1][1]`, `[1] [1]`.
+// Combining citations by document produces these wherever the model cited two
+// passages of one report back to back, and the reader should see `[1]` once.
+const ADJACENT_DUPLICATE_RE = /\[(\d+(?:, \d+)*)\]\s*\[\1\]/g;
+
+const collapseAdjacentDuplicates = (content: string): string => {
+  let out = content;
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(ADJACENT_DUPLICATE_RE, '[$1]');
+  } while (out !== prev);
+  return out;
+};
 
 // Normalise a line to compare it against a heading title: drop markdown heading
 // hashes, leading "1." / "2.1" numbering, and emphasis markers.
@@ -46,24 +60,34 @@ export interface SectionDisplay {
   sources: SourceReference[];
 }
 
+/** The identity a citation number is assigned to: the cited passage (chunk),
+ *  or — for single-per-document grouping — the document itself. */
+const citationKey = (src: SourceReference, grouping: ReferenceGrouping): string =>
+  grouping === 'document-single'
+    ? `doc:${src.docId || src.title}`
+    : src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
+
 /**
- * Renumber citations across the whole brief into one consecutive sequence,
- * combined by document: every section's per-section `[n]` markers are remapped
- * to a global number (same document → same number everywhere), and the compiled
- * References list is built from the same global registry. Used for both the
- * on-screen render (inline citations, per-section Evidence panels, References)
- * and the Word export, so all three stay in sync as sections are researched.
+ * Renumber citations across the whole brief into one consecutive sequence:
+ * every section's per-section `[n]` markers are remapped to a global number,
+ * and the compiled References list is built from the same global registry.
+ * Used for both the on-screen render (inline citations, per-section Evidence
+ * panels, References) and the Word export, so all three stay in sync as
+ * sections are researched.
+ *
+ * With the default grouping there is one number per cited passage, exactly as
+ * the AI summary numbers its sources (assistant_graph assigns global_index per
+ * chunk): a report cited from p.32 and p.56 gets two numbers, and the reader
+ * can see which page each claim came from. With 'document-single' grouping
+ * every passage of a document shares one number and the reference carries no
+ * page, so the list reads at the document level only.
  */
 export const buildGlobalCitations = (
   sections: BriefSection[],
+  grouping: ReferenceGrouping = 'passage',
 ): { refs: GlobalRef[]; display: Map<string, SectionDisplay> } => {
-  // One citation number per cited passage, exactly as the AI summary numbers
-  // its sources (assistant_graph assigns global_index per chunk). A report
-  // cited from p.32 and p.56 therefore gets two numbers, and the reader can
-  // see which page each claim came from.
-  const chunkKey = (src: SourceReference): string =>
-    src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
-  const chunkToGlobal = new Map<string, number>();
+  const perDocument = grouping === 'document-single';
+  const keyToGlobal = new Map<string, number>();
   const refs: GlobalRef[] = [];
   // A section mid-Edit/Update (revising) keeps its old content on screen, so
   // it stays in the numbering — otherwise citations would jump twice per run.
@@ -74,10 +98,12 @@ export const buildGlobalCitations = (
     if (!isVisible(s)) return;
     extractCitedNumbers(s.content).forEach((localN) => {
       const src = s.sources.find((x) => x.index === localN);
-      if (!src || chunkToGlobal.has(chunkKey(src))) return;
+      if (!src || keyToGlobal.has(citationKey(src, grouping))) return;
       const n = refs.length + 1;
-      chunkToGlobal.set(chunkKey(src), n);
-      refs.push({ n, title: src.title, page: src.page, source: src });
+      keyToGlobal.set(citationKey(src, grouping), n);
+      // A document-level reference has no page; its source is the first cited
+      // passage, so clicking the reference still opens the document.
+      refs.push({ n, title: src.title, page: perDocument ? undefined : src.page, source: src });
     });
   });
   // Build per-section display content + sources keyed by the global number.
@@ -86,29 +112,41 @@ export const buildGlobalCitations = (
     if (!isVisible(s)) return;
     const localToGlobal = new Map<number, number>();
     const sources: SourceReference[] = [];
-    const seen = new Set<number>();
+    const byGlobal = new Map<number, SourceReference>();
     s.sources.forEach((src) => {
       if (src.index == null) return;
-      const g = chunkToGlobal.get(chunkKey(src));
+      const g = keyToGlobal.get(citationKey(src, grouping));
       if (g == null) return;
       localToGlobal.set(src.index, g);
-      // Each number belongs to one passage, so there is nothing to merge.
-      if (seen.has(g)) return;
-      seen.add(g);
-      sources.push({ ...src, index: g });
+      const existing = byGlobal.get(g);
+      if (!existing) {
+        const entry = { ...src, index: g };
+        byGlobal.set(g, entry);
+        sources.push(entry);
+        return;
+      }
+      // Per passage, each number belongs to one passage, so there is nothing to
+      // merge. Per document, the other passages ride along as variants so the
+      // hover card can still show the passage that supports the hovered claim.
+      if (perDocument && src.chunkId !== existing.chunkId) {
+        existing.variants = [...(existing.variants || []), src];
+      }
     });
-    const content = stripLeadingTitle(s.content, s.title).replace(CITATION_RE, (_m, nums: string) => {
-      const mapped = Array.from(
-        new Set(
-          nums
-            .split(',')
-            .map((x) => localToGlobal.get(parseInt(x.trim(), 10)))
-            .filter((g): g is number => g != null),
-        ),
-      );
-      return mapped.length ? `[${mapped.join(', ')}]` : '';
-    });
-    display.set(s.id, { content, sources });
+    const renumbered = stripLeadingTitle(s.content, s.title).replace(
+      CITATION_RE,
+      (_m, nums: string) => {
+        const mapped = Array.from(
+          new Set(
+            nums
+              .split(',')
+              .map((x) => localToGlobal.get(parseInt(x.trim(), 10)))
+              .filter((g): g is number => g != null),
+          ),
+        );
+        return mapped.length ? `[${mapped.join(', ')}]` : '';
+      },
+    );
+    display.set(s.id, { content: collapseAdjacentDuplicates(renumbered), sources });
   });
   return { refs, display };
 };

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -2,6 +2,15 @@ import { SourceReference } from '../../types/api';
 import { BriefActivityEvent } from '../../utils/briefStream';
 
 export type BriefStage = 'seed' | 'outline' | 'research' | 'done';
+
+// How the compiled References list is laid out — and, because the list and the
+// inline `[n]` markers share one numbering, how citations are numbered:
+//   'passage'           one number per cited passage; one row per number.
+//   'document-multiple' one number per cited passage; rows collapsed to one per
+//                       document, each number shown with its page.
+//   'document-single'   one number per document, no page numbers: every passage
+//                       of a document cites the same `[n]`.
+export type ReferenceGrouping = 'passage' | 'document-multiple' | 'document-single';
 export type SectionStatus = 'pending' | 'researching' | 'done';
 
 // What kind of AI operation produced a version of a section. `generate` is the
@@ -62,14 +71,6 @@ export interface BriefSection {
   guidance?: string;
   // Voice & tone profile override for this section (null/absent = brief default).
   voiceId?: string | null;
-}
-
-export interface BriefReference {
-  n: number;
-  title: string;
-  page?: number;
-  section: string;
-  source: SourceReference; // for click-through to the document preview
 }
 
 export interface SavedBriefSection {

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -16,10 +16,10 @@ import {
 } from '../../utils/briefStream';
 import {
   BRIEF_HISTORY_KEY,
-  BriefReference,
   BriefSection,
   BriefStage,
   DEFAULT_BRIEF_TITLE,
+  ReferenceGrouping,
   SavedBrief,
   SectionAuditEntry,
   VoiceProfile,
@@ -163,35 +163,6 @@ const computeNumbers = (sections: BriefSection[]): string[] => {
   });
 };
 
-// Compiled footnotes: the actually-cited sources across done sections, one
-// entry per document (grouped/deduped), like the search summary's references.
-const computeReferences = (sections: BriefSection[]): BriefReference[] => {
-  const seen = new Set<string>();
-  const refs: BriefReference[] = [];
-  sections.forEach((s) => {
-    // Sections mid-Edit/Update keep their (old) content on screen, so they
-    // keep their footnotes too — no renumbering while a revise runs.
-    if (s.status !== 'done' && !s.revising) return;
-    const cited = new Set(extractCitedNumbers(s.content));
-    s.sources.forEach((src: SourceReference) => {
-      if (src.index == null || !cited.has(src.index)) return;
-      // One entry per cited passage, matching the numbering in
-      // buildGlobalCitations (and the AI summary), not one per document.
-      const key = src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
-      if (seen.has(key)) return;
-      seen.add(key);
-      refs.push({
-        n: refs.length + 1,
-        title: src.title,
-        page: src.page,
-        section: s.title,
-        source: src,
-      });
-    });
-  });
-  return refs;
-};
-
 export const useBrief = ({
   apiBaseUrl,
   dataSource,
@@ -211,9 +182,10 @@ export const useBrief = ({
   const [query, setQuery] = useState(''); // the brief topic
   const [instructions, setInstructions] = useState('');
   const [numHeadings, setNumHeadings] = useState(6);
-  // References list: one row per document (off) vs grouped by document (on).
-  // Also chooses how the Word export lays its references out.
-  const [groupReferences, setGroupReferences] = useState(false);
+  // How the References list is laid out and how citations are numbered (one
+  // number per passage or per document) — see ReferenceGrouping. Drives the
+  // inline [n] markers, the References list and the Word export together.
+  const [referenceGrouping, setReferenceGrouping] = useState<ReferenceGrouping>('passage');
   const [newHeading, setNewHeading] = useState('');
   const [regenFor, setRegenFor] = useState<string | null>(null);
   const [regenText, setRegenText] = useState('');
@@ -1354,7 +1326,6 @@ export const useBrief = ({
 
   // ---- derived ----
   const numbers = useMemo(() => computeNumbers(sections), [sections]);
-  const references = useMemo(() => computeReferences(sections), [sections]);
   const doneCount = sections.filter((s) => s.status === 'done').length;
   const totalProgress = sections.length
     ? Math.round(
@@ -1371,7 +1342,6 @@ export const useBrief = ({
     currentBriefId: briefIdRef.current,
     sections,
     numbers,
-    references,
     query,
     instructions,
     numHeadings,
@@ -1403,8 +1373,8 @@ export const useBrief = ({
     setError,
     setHistoryOpen,
     setBriefVoiceId,
-    groupReferences,
-    setGroupReferences,
+    referenceGrouping,
+    setReferenceGrouping,
     requestSourceHighlight,
     setSectionGuidance: (id: string, guidance: string) => updateSection(id, { guidance }),
     setSectionVoiceId: (id: string, voiceId: string | null) =>

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -416,7 +416,8 @@ const RefGroupLinks: React.FC<{
   group: DocGroup;
   sources: SourceReference[];
   onSourceClick?: (source: SourceReference) => void;
-}> = ({ group, sources, onSourceClick }) => (
+  hidePages?: boolean;
+}> = ({ group, sources, onSourceClick, hidePages }) => (
   <div className="ai-summary-ref-group">
     {group.title}
     {' | '}
@@ -435,7 +436,7 @@ const RefGroupLinks: React.FC<{
           <span className="citation-doc-group">
             <span className="ai-summary-citation">{idx}</span>
           </span>
-          {group.page ? ` p.${group.page}` : ''}
+          {!hidePages && group.page ? ` p.${group.page}` : ''}
         </a>
       </React.Fragment>
     ))}
@@ -450,6 +451,9 @@ export const CitedReferences: React.FC<{
   collapsible?: boolean;
   labelPrefix?: string;
   className?: string;
+  // Document-level citations (one number per document): list the documents
+  // without page numbers.
+  hidePages?: boolean;
 }> = ({
   content,
   sources,
@@ -457,6 +461,7 @@ export const CitedReferences: React.FC<{
   collapsible = true,
   labelPrefix = 'References',
   className = '',
+  hidePages = false,
 }) => {
   const [expanded, setExpanded] = useState(!collapsible);
   const groups = useMemo(() => groupCitedSourcesByDoc(content, sources), [content, sources]);
@@ -473,6 +478,7 @@ export const CitedReferences: React.FC<{
           group={group}
           sources={sources}
           onSourceClick={onSourceClick}
+          hidePages={hidePages}
         />
       ))}
     </div>

--- a/ui/frontend/src/tests/briefCitations.test.ts
+++ b/ui/frontend/src/tests/briefCitations.test.ts
@@ -189,3 +189,106 @@ describe('footnotes react to citation changes', () => {
     expect(display.get('a')?.content).toBe('Still on screen [1].');
   });
 });
+
+describe('buildGlobalCitations with single-per-document grouping', () => {
+  // Doc One is cited from three pages, Doc Two and Doc Three once each.
+  const sections: BriefSection[] = [
+    section({
+      id: 'a',
+      content: 'A fact happened. [1][3] Then something else [2][4][5]',
+      sources: [
+        src({ index: 1, docId: 'doc1', title: 'Doc One', page: 10 }),
+        src({ index: 2, docId: 'doc2', title: 'Doc Two', page: 4 }),
+        src({ index: 3, docId: 'doc1', title: 'Doc One', page: 20 }),
+        src({ index: 4, docId: 'doc3', title: 'Doc Three', page: 7 }),
+        src({ index: 5, docId: 'doc1', title: 'Doc One', page: 30 }),
+      ],
+    }),
+  ];
+
+  test('per passage (default): one number per page, references carry pages', () => {
+    const { refs, display } = buildGlobalCitations(sections, 'passage');
+    expect(refs.map((r) => [r.n, r.title, r.page])).toEqual([
+      [1, 'Doc One', 10],
+      [2, 'Doc Two', 4],
+      [3, 'Doc One', 20],
+      [4, 'Doc Three', 7],
+      [5, 'Doc One', 30],
+    ]);
+    expect(display.get('a')?.content).toBe(
+      'A fact happened. [1][3] Then something else [2][4][5]',
+    );
+  });
+
+  test('per document: one number per document, no pages, prose renumbered', () => {
+    const { refs, display } = buildGlobalCitations(sections, 'document-single');
+    expect(refs.map((r) => [r.n, r.title, r.page])).toEqual([
+      [1, 'Doc One', undefined],
+      [2, 'Doc Two', undefined],
+      [3, 'Doc Three', undefined],
+    ]);
+    // [1][3] were both Doc One, so they collapse to a single [1]; [5] is
+    // Doc One again and keeps that number.
+    expect(display.get('a')?.content).toBe('A fact happened. [1] Then something else [2][3][1]');
+  });
+
+  test('per document: the reference opens the first cited passage of the document', () => {
+    const { refs } = buildGlobalCitations(sections, 'document-single');
+    expect(refs[0].source.page).toBe(10);
+    expect(refs[0].source.docId).toBe('doc1');
+  });
+
+  test('per document: the other passages ride along as variants of the display source', () => {
+    const { display } = buildGlobalCitations(sections, 'document-single');
+    const sources = display.get('a')!.sources;
+    expect(sources.map((x) => x.index)).toEqual([1, 2, 3]);
+    const docOne = sources.find((x) => x.index === 1)!;
+    expect(docOne.page).toBe(10);
+    expect((docOne.variants || []).map((v) => v.page)).toEqual([20, 30]);
+    // Single-passage documents carry no variants.
+    expect(sources.find((x) => x.index === 2)!.variants).toBeUndefined();
+  });
+
+  test('per document: one number for a document cited across sections', () => {
+    const two: BriefSection[] = [
+      section({
+        id: 'a',
+        content: 'First [1].',
+        sources: [src({ index: 1, docId: 'doc1', title: 'Doc One', page: 1 })],
+      }),
+      section({
+        id: 'b',
+        content: 'Second [7] and [8].',
+        sources: [
+          src({ index: 7, docId: 'doc2', title: 'Doc Two', page: 2 }),
+          src({ index: 8, docId: 'doc1', title: 'Doc One', page: 9 }),
+        ],
+      }),
+    ];
+    const { refs, display } = buildGlobalCitations(two, 'document-single');
+    expect(refs.map((r) => r.title)).toEqual(['Doc One', 'Doc Two']);
+    expect(display.get('b')?.content).toBe('Second [2] and [1].');
+  });
+
+  test('per document: a combined marker citing one document twice reads once', () => {
+    const one: BriefSection[] = [
+      section({
+        id: 'a',
+        content: 'Claim [1, 2].',
+        sources: [
+          src({ index: 1, docId: 'doc1', title: 'Doc One', page: 1 }),
+          src({ index: 2, docId: 'doc1', title: 'Doc One', page: 5 }),
+        ],
+      }),
+    ];
+    expect(buildGlobalCitations(one, 'document-single').display.get('a')?.content).toBe(
+      'Claim [1].',
+    );
+  });
+
+  test('multiple-per-document grouping numbers exactly like per passage', () => {
+    expect(buildGlobalCitations(sections, 'document-multiple')).toEqual(
+      buildGlobalCitations(sections, 'passage'),
+    );
+  });
+});

--- a/ui/frontend/src/tests/briefReferences.test.tsx
+++ b/ui/frontend/src/tests/briefReferences.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BriefReferences } from '../components/brief/BriefReferences';
+import { GlobalRef } from '../components/brief/briefCitations';
+import { SourceReference } from '../types/api';
+
+const MULTIPLE = 'Group by document (multiple per document)';
+const SINGLE = 'Group by document (single per document)';
+
+const src = (docId: string, title: string, page: number): SourceReference => ({
+  chunkId: `${docId}-${page}`,
+  docId,
+  title,
+  text: '',
+  score: 0,
+  page,
+});
+
+// Per-passage numbering: Doc One cited from p.32 and p.56, Doc Two from p.4.
+const PER_PASSAGE: GlobalRef[] = [
+  { n: 1, title: 'Doc One', page: 32, source: src('d1', 'Doc One', 32) },
+  { n: 2, title: 'Doc Two', page: 4, source: src('d2', 'Doc Two', 4) },
+  { n: 3, title: 'Doc One', page: 56, source: src('d1', 'Doc One', 56) },
+];
+
+// Per-document numbering: no pages on the references.
+const PER_DOCUMENT: GlobalRef[] = [
+  { n: 1, title: 'Doc One', source: src('d1', 'Doc One', 32) },
+  { n: 2, title: 'Doc Two', source: src('d2', 'Doc Two', 4) },
+];
+
+describe('BriefReferences', () => {
+  test('offers both grouping checkboxes, unticked by default', () => {
+    render(
+      <BriefReferences references={PER_PASSAGE} grouping="passage" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    expect(screen.getByRole('checkbox', { name: MULTIPLE })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: SINGLE })).not.toBeChecked();
+  });
+
+  test('renders nothing when there are no references', () => {
+    const view = render(
+      <BriefReferences references={[]} grouping="passage" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    expect(view.container).toBeEmptyDOMElement();
+  });
+
+  test('ticking a checkbox selects that grouping; unticking returns to per passage', () => {
+    const onChange = jest.fn();
+    const view = render(
+      <BriefReferences references={PER_PASSAGE} grouping="passage" onGroupingChange={onChange} onSourceClick={jest.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: SINGLE }));
+    expect(onChange).toHaveBeenLastCalledWith('document-single');
+
+    view.rerender(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={onChange} onSourceClick={jest.fn()} />,
+    );
+    expect(screen.getByRole('checkbox', { name: SINGLE })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: MULTIPLE })).not.toBeChecked();
+    fireEvent.click(screen.getByRole('checkbox', { name: SINGLE }));
+    expect(onChange).toHaveBeenLastCalledWith('passage');
+  });
+
+  test('the two groupings are exclusive: ticking one replaces the other', () => {
+    const onChange = jest.fn();
+    render(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={onChange} onSourceClick={jest.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: MULTIPLE }));
+    expect(onChange).toHaveBeenLastCalledWith('document-multiple');
+  });
+
+  test('per passage: one row per citation with its page', () => {
+    render(
+      <BriefReferences references={PER_PASSAGE} grouping="passage" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    const rows = document.querySelectorAll('.brief-footnote-row');
+    expect(Array.from(rows).map((r) => r.textContent)).toEqual([
+      '1Doc One, p.32',
+      '2Doc Two, p.4',
+      '3Doc One, p.56',
+    ]);
+  });
+
+  test('multiple per document: one row per document with each number and page', () => {
+    render(
+      <BriefReferences references={PER_PASSAGE} grouping="document-multiple" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    const rows = document.querySelectorAll('.brief-footnote-group');
+    expect(Array.from(rows).map((r) => r.textContent)).toEqual([
+      'Doc One1 p. 323 p. 56',
+      'Doc Two2 p. 4',
+    ]);
+  });
+
+  test('single per document: one row per document, numbered, with no page numbers', () => {
+    render(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    const rows = document.querySelectorAll('.brief-footnote-row');
+    expect(Array.from(rows).map((r) => r.textContent)).toEqual(['1Doc One', '2Doc Two']);
+    expect(document.body.textContent).not.toMatch(/p\.\s*\d/);
+  });
+
+  test('clicking a document-level reference opens its first cited passage', () => {
+    const onSourceClick = jest.fn();
+    render(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={jest.fn()} onSourceClick={onSourceClick} />,
+    );
+    fireEvent.click(screen.getByText('Doc One'));
+    expect(onSourceClick).toHaveBeenCalledWith(expect.objectContaining({ docId: 'd1', page: 32 }));
+  });
+});

--- a/ui/frontend/src/tests/briefTab.test.tsx
+++ b/ui/frontend/src/tests/briefTab.test.tsx
@@ -177,4 +177,53 @@ describe('BriefTab (Document Builder)', () => {
     // Brief name is capitalised too.
     expect(screen.getByDisplayValue('Cash Assistance')).toBeInTheDocument();
   });
+
+  test('single-per-document grouping renumbers the inline citations and the References list', () => {
+    const src = (index: number, docId: string, title: string, page: number) => ({
+      chunkId: `${docId}-${page}`, docId, title, text: 'passage', score: 0, page, index,
+    });
+    localStorage.setItem(
+      'evidencelab_brief_history_v1',
+      JSON.stringify([
+        {
+          id: 'b1', title: 'Cited brief', query: 'q', date: 1, sectionCount: 1, sourceCount: 5,
+          sections: [
+            {
+              id: 's1', title: 'Findings', level: 1, status: 'done',
+              content: 'A fact happened. [1][3] Then something else [2][4][5]',
+              sources: [
+                src(1, 'doc1', 'Doc One', 10), src(2, 'doc2', 'Doc Two', 4), src(3, 'doc1', 'Doc One', 20),
+                src(4, 'doc3', 'Doc Three', 7), src(5, 'doc1', 'Doc One', 30),
+              ],
+            },
+          ],
+        },
+      ]),
+    );
+    render(<BriefTab dataSource="wfp" />);
+    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText('Cited brief'));
+
+    const inlineNumbers = () =>
+      Array.from(document.querySelectorAll('.brief-doc-content .ai-summary-citation')).map((el) => el.textContent);
+    const referenceRows = () =>
+      Array.from(document.querySelectorAll('.brief-footnotes-list .brief-footnote-row')).map((el) => el.textContent);
+
+    // Default: one number per cited passage, references carry pages.
+    expect(inlineNumbers()).toEqual(['1', '3', '2', '4', '5']);
+    expect(referenceRows()).toEqual([
+      '1Doc One, p.10', '2Doc Two, p.4', '3Doc One, p.20', '4Doc Three, p.7', '5Doc One, p.30',
+    ]);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Group by document (single per document)' }));
+
+    // One number per document: [1][3] collapses to [1], [5] becomes [1], and
+    // the list has one row per document with no page numbers.
+    expect(inlineNumbers()).toEqual(['1', '2', '3', '1']);
+    expect(referenceRows()).toEqual(['1Doc One', '2Doc Two', '3Doc Three']);
+
+    // Back off: the original per-passage numbering returns.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Group by document (single per document)' }));
+    expect(inlineNumbers()).toEqual(['1', '3', '2', '4', '5']);
+  });
 });

--- a/ui/frontend/src/tests/citedReferencesHidePages.test.tsx
+++ b/ui/frontend/src/tests/citedReferencesHidePages.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CitedReferences } from '../components/citations/CitedContent';
+import { SourceReference } from '../types/api';
+
+const SOURCES: SourceReference[] = [
+  { chunkId: 'c1', docId: 'd1', title: 'Doc One', text: '', score: 0, page: 12, index: 1 },
+  { chunkId: 'c2', docId: 'd2', title: 'Doc Two', text: '', score: 0, page: 3, index: 2 },
+];
+
+describe('CitedReferences hidePages', () => {
+  test('shows each document with its page by default', () => {
+    render(<CitedReferences content="A [1] and B [2]." sources={SOURCES} collapsible={false} />);
+    const groups = document.querySelectorAll('.ai-summary-ref-group');
+    expect(Array.from(groups).map((g) => g.textContent)).toEqual([
+      'Doc One | 1 p.12',
+      'Doc Two | 2 p.3',
+    ]);
+  });
+
+  test('hidePages lists the documents and numbers without pages', () => {
+    render(
+      <CitedReferences content="A [1] and B [2]." sources={SOURCES} collapsible={false} hidePages />,
+    );
+    const groups = document.querySelectorAll('.ai-summary-ref-group');
+    expect(Array.from(groups).map((g) => g.textContent)).toEqual(['Doc One | 1', 'Doc Two | 2']);
+  });
+});

--- a/ui/frontend/src/tests/exportBriefDocx.test.ts
+++ b/ui/frontend/src/tests/exportBriefDocx.test.ts
@@ -193,3 +193,42 @@ describe('brief Word export — footnote citation style', () => {
     expect(xml).toContain('[');
   });
 });
+
+describe('brief Word export — references list layouts', () => {
+  const two = [
+    result({ chunk_id: 'c1', doc_id: 'd1', page_num: 26 }),
+    result({ chunk_id: 'c2', doc_id: 'd1', page_num: 40 }),
+  ];
+  const withList = (referenceList: 'flat' | 'grouped' | 'document') => ({
+    ...BRIEF_OPTS,
+    aiSummary: '# Access\n\nEnrolment has risen [1] and stayed up [2].\n',
+    results: two,
+    resultsSectionTitle: 'References',
+    referenceList,
+  });
+  const referencesXml = async (opts: ReturnType<typeof withList>): Promise<string> => {
+    const xml = await documentXml(opts);
+    return xml.slice(xml.lastIndexOf('References'));
+  };
+
+  test('flat: one line per citation with its page', async () => {
+    const refs = await referencesXml(withList('flat'));
+    expect(refs).toContain(', p.26');
+    expect(refs).toContain(', p.40');
+  });
+
+  test('grouped: one line per document listing its citation numbers', async () => {
+    const refs = await referencesXml(withList('grouped'));
+    expect(refs).toContain('1, 2. ');
+    expect(refs).not.toContain(', p.26');
+  });
+
+  test('document: one line per document-level citation and no page numbers', async () => {
+    // With single-per-document grouping the brief hands over one result per
+    // document; the list shows its number and title only.
+    const refs = await referencesXml({ ...withList('document'), results: [two[0]] });
+    expect(refs).toContain('1. ');
+    expect(refs).toContain('Breaking Barriers for Girls Education in Niger');
+    expect(refs).not.toContain('p.26');
+  });
+});

--- a/ui/frontend/src/tests/exportBriefDocx.test.ts
+++ b/ui/frontend/src/tests/exportBriefDocx.test.ts
@@ -5,13 +5,15 @@ import type { SearchResult } from '../types/api';
 
 const TOPIC = 'girls education in Kenya';
 const REF_EXCERPTS = 'Reference Excerpts';
+const REFERENCES = 'References';
+const DOC_TITLE = 'Breaking Barriers for Girls Education in Niger';
 const DOC_XML = 'word/document.xml';
 
 const result = (over: Partial<SearchResult>): SearchResult =>
   ({
     chunk_id: 'c1',
     doc_id: 'd1',
-    title: 'Breaking Barriers for Girls Education in Niger',
+    title: DOC_TITLE,
     text: 'Full excerpt sentence one. Full excerpt sentence two that should appear in italics.',
     score: 0.5,
     page_num: 26,
@@ -150,7 +152,7 @@ describe('brief Word export — footnote citation style', () => {
   test('footnote holds the source title, page and a clickable PDF link', async () => {
     const zip = await zipOf(footOpts);
     const footnotes = await zip.file('word/footnotes.xml')!.async('string');
-    expect(footnotes).toContain('Breaking Barriers for Girls Education in Niger');
+    expect(footnotes).toContain(DOC_TITLE);
     expect(footnotes).toContain('p.26');
     expect(footnotes).toContain('Open PDF');
     const rels = await zip.file('word/_rels/footnotes.xml.rels')!.async('string');
@@ -203,12 +205,12 @@ describe('brief Word export — references list layouts', () => {
     ...BRIEF_OPTS,
     aiSummary: '# Access\n\nEnrolment has risen [1] and stayed up [2].\n',
     results: two,
-    resultsSectionTitle: 'References',
+    resultsSectionTitle: REFERENCES,
     referenceList,
   });
   const referencesXml = async (opts: ReturnType<typeof withList>): Promise<string> => {
     const xml = await documentXml(opts);
-    return xml.slice(xml.lastIndexOf('References'));
+    return xml.slice(xml.lastIndexOf(REFERENCES));
   };
 
   test('flat: one line per citation with its page', async () => {
@@ -228,7 +230,34 @@ describe('brief Word export — references list layouts', () => {
     // document; the list shows its number and title only.
     const refs = await referencesXml({ ...withList('document'), results: [two[0]] });
     expect(refs).toContain('1. ');
-    expect(refs).toContain('Breaking Barriers for Girls Education in Niger');
+    expect(refs).toContain(DOC_TITLE);
     expect(refs).not.toContain('p.26');
+  });
+});
+
+describe('brief Word export — a single References section', () => {
+  // Count "References" heading paragraphs (w:pStyle Heading1/Heading2) in the
+  // document body.
+  const referenceHeadings = (xml: string): number =>
+    (xml.match(/<w:pStyle w:val="Heading[12]"\/>(?:(?!<\/w:p>)[^])*?>References<\/w:t>/g) || []).length;
+
+  test.each(['flat', 'grouped', 'document'] as const)(
+    'the brief export (%s layout) has exactly one References section',
+    async (referenceList) => {
+      const xml = await documentXml({
+        ...BRIEF_OPTS,
+        resultsSectionTitle: REFERENCES,
+        referenceList,
+      });
+      expect(referenceHeadings(xml)).toBe(1);
+    },
+  );
+
+  test('the search export keeps its references under the prose before the result cards', async () => {
+    // No referenceList: the search export's embedded grouped references plus
+    // the result-card section (whose heading is not "References").
+    const xml = await documentXml({ ...BRIEF_OPTS, resultsSectionTitle: 'Search Results' });
+    expect(referenceHeadings(xml)).toBe(1);
+    expect(xml).toContain('Search Results (1)');
   });
 });

--- a/ui/frontend/src/tests/exportBriefDocx.test.ts
+++ b/ui/frontend/src/tests/exportBriefDocx.test.ts
@@ -219,10 +219,25 @@ describe('brief Word export — references list layouts', () => {
     expect(refs).toContain(', p.40');
   });
 
-  test('grouped: one line per document listing its citation numbers', async () => {
+  test('grouped: one line per document, laid out as on screen — "Title, [1] p. 26, [2] p. 40"', async () => {
     const refs = await referencesXml(withList('grouped'));
-    expect(refs).toContain('1, 2. ');
+    // The visible text of the row, in order, with the XML stripped.
+    const text = refs.replace(/<[^>]+>/g, '');
+    expect(text).toContain(`${DOC_TITLE}, [1] p. 26, [2] p. 40`);
+    // Neither the flat "1. " label nor the flat ", p.26" form appears.
+    expect(refs).not.toContain('1. ');
     expect(refs).not.toContain(', p.26');
+  });
+
+  test('grouped: the title links to the document and each [n] to its cited page', async () => {
+    const opts = {
+      ...withList('grouped'),
+      results: two.map((r) => ({ ...r, report_url: PDF_URL })),
+    };
+    const rels = await relTargets(buildExportDocument(opts));
+    expect(rels).toContain(`${PDF_URL}"`); // document link, no page anchor
+    expect(rels).toContain(`${PDF_URL}#page=26`);
+    expect(rels).toContain(`${PDF_URL}#page=40`);
   });
 
   test('document: one line per document-level citation and no page numbers', async () => {

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -55,6 +55,9 @@ import {
   type DocumentGroup,
 } from './citations';
 
+/** Layout of the compact references list (see {@link ExportOptions.referenceList}). */
+export type ReferenceListLayout = 'flat' | 'grouped' | 'document';
+
 export interface ExportOptions {
   query: string;
   aiSummary?: string;
@@ -70,9 +73,8 @@ export interface ExportOptions {
    *  The Brief export passes "Reference Excerpts". */
   resultsSectionTitle?: string;
   // Render a compact references list (no excerpts) instead of full result
-  // cards, mirroring the Brief's on-screen References section. 'grouped'
-  // collapses to one row per document.
-  referenceList?: 'flat' | 'grouped';
+  // cards, mirroring the Brief's on-screen References section.
+  referenceList?: ReferenceListLayout;
   /** Cover-page document title (default "Evidence Lab — Search Export").
    *  The Brief export passes "AI-generated Research Brief". */
   documentTitle?: string;
@@ -1081,15 +1083,17 @@ const buildResultCard = (
 };
 
 /**
- * A compact references list: one line per citation (flat) or per document
- * (grouped), title hyperlinked to the source, no excerpt text. Mirrors what
- * the Brief shows on screen so the export matches the reader's view.
+ * A compact references list, title hyperlinked to the source, no excerpt text:
+ * one line per citation with its page ('flat'), one line per document listing
+ * each of its citation numbers ('grouped'), or one line per document-level
+ * citation with no page ('document'). Mirrors what the Brief shows on screen
+ * so the export matches the reader's view.
  */
 const buildReferenceList = (
   results: SearchResult[],
   siteOrigin: string,
   dataSource: string | undefined,
-  grouped: boolean,
+  layout: ReferenceListLayout,
   sectionTitle = 'References',
 ): Paragraph[] => {
   const titleOf = (r: SearchResult): string =>
@@ -1098,7 +1102,7 @@ const buildReferenceList = (
     '(untitled document)';
 
   const rows: Array<{ label: string; title: string; result: SearchResult }> = [];
-  if (grouped) {
+  if (layout === 'grouped') {
     const byDoc = new Map<string, { nums: number[]; result: SearchResult }>();
     results.forEach((r, idx) => {
       const key = r.doc_id || titleOf(r);
@@ -1111,7 +1115,7 @@ const buildReferenceList = (
     );
   } else {
     results.forEach((r, idx) => {
-      const page = r.page_num ? `, p.${r.page_num}` : '';
+      const page = layout === 'flat' && r.page_num ? `, p.${r.page_num}` : '';
       rows.push({ label: String(idx + 1), title: `${titleOf(r)}${page}`, result: r });
     });
   }
@@ -1207,7 +1211,7 @@ export const buildExportDocument = (
           opts.results,
           siteOrigin,
           opts.dataSource,
-          opts.referenceList === 'grouped',
+          opts.referenceList,
           opts.resultsSectionTitle,
         )
       : buildResultsSection(

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -1091,12 +1091,96 @@ const buildResultCard = (
   return out;
 };
 
+const referenceTitleOf = (r: SearchResult): string =>
+  (r.title && r.title.trim()) ||
+  (typeof r.document_title === 'string' && r.document_title.trim()) ||
+  '(untitled document)';
+
+/**
+ * One row per document, exactly as the Brief shows it on screen with
+ * "Group by document (multiple per document)":
+ *   Title, [1] p. 32, [2] p. 56
+ * The title links to the document; each [n] and its page link to that
+ * citation's page. As on screen, a number is shown once per run of the same
+ * citation, so a document cited from many pages reads "[1] p. 9, p. 11".
+ */
+const buildGroupedReferenceRows = (
+  results: SearchResult[],
+  siteOrigin: string,
+  dataSource: string | undefined,
+): Paragraph[] => {
+  type Cite = { n: number; page: number; result: SearchResult };
+  const byDoc = new Map<string, { result: SearchResult; cites: Cite[] }>();
+  results.forEach((result, idx) => {
+    const key = result.doc_id || referenceTitleOf(result);
+    const cite = { n: idx + 1, page: result.page_num || 0, result };
+    const found = byDoc.get(key);
+    if (found) found.cites.push(cite);
+    else byDoc.set(key, { result, cites: [cite] });
+  });
+
+  const rows: Paragraph[] = [];
+  byDoc.forEach(({ result, cites }) => {
+    cites.sort((a, b) => a.page - b.page || a.n - b.n);
+    const children: InlineChild[] = [
+      new ExternalHyperlink({
+        link: resolveDocumentLink(result, siteOrigin, dataSource),
+        children: [new TextRun({ text: referenceTitleOf(result), style: 'Hyperlink' })],
+      }),
+    ];
+    cites.forEach((cite, i) => {
+      const link = resolveResultLink(cite.result, siteOrigin, dataSource);
+      children.push(new TextRun({ text: ', ' }));
+      if (i === 0 || cites[i - 1].n !== cite.n) {
+        children.push(
+          new ExternalHyperlink({
+            link,
+            children: [new TextRun({ text: `[${cite.n}]`, style: 'Hyperlink' })],
+          }),
+        );
+      }
+      if (cite.page) {
+        children.push(
+          new ExternalHyperlink({
+            link,
+            children: [new TextRun({ text: ` p. ${cite.page}`, style: 'Hyperlink' })],
+          }),
+        );
+      }
+    });
+    rows.push(new Paragraph({ spacing: { after: 60 }, children }));
+  });
+  return rows;
+};
+
+/** One row per citation — "1. Title, p.26" — or, for document-level
+ *  citations, "1. Title" with no page. */
+const buildNumberedReferenceRows = (
+  results: SearchResult[],
+  siteOrigin: string,
+  dataSource: string | undefined,
+  withPages: boolean,
+): Paragraph[] =>
+  results.map((result, idx) => {
+    const page = withPages && result.page_num ? `, p.${result.page_num}` : '';
+    return new Paragraph({
+      spacing: { after: 60 },
+      children: [
+        new TextRun({ text: `${idx + 1}. `, bold: true }),
+        new ExternalHyperlink({
+          link: resolveResultLink(result, siteOrigin, dataSource),
+          children: [new TextRun({ text: `${referenceTitleOf(result)}${page}`, style: 'Hyperlink' })],
+        }),
+      ],
+    });
+  });
+
 /**
  * A compact references list, title hyperlinked to the source, no excerpt text:
  * one line per citation with its page ('flat'), one line per document listing
- * each of its citation numbers ('grouped'), or one line per document-level
- * citation with no page ('document'). Mirrors what the Brief shows on screen
- * so the export matches the reader's view.
+ * each of its citation numbers with their pages ('grouped'), or one line per
+ * document-level citation with no page ('document'). Mirrors what the Brief
+ * shows on screen so the export matches the reader's view.
  */
 const buildReferenceList = (
   results: SearchResult[],
@@ -1104,54 +1188,16 @@ const buildReferenceList = (
   dataSource: string | undefined,
   layout: ReferenceListLayout,
   sectionTitle = 'References',
-): Paragraph[] => {
-  const titleOf = (r: SearchResult): string =>
-    (r.title && r.title.trim()) ||
-    (typeof r.document_title === 'string' && r.document_title.trim()) ||
-    '(untitled document)';
-
-  const rows: Array<{ label: string; title: string; result: SearchResult }> = [];
-  if (layout === 'grouped') {
-    const byDoc = new Map<string, { nums: number[]; result: SearchResult }>();
-    results.forEach((r, idx) => {
-      const key = r.doc_id || titleOf(r);
-      const found = byDoc.get(key);
-      if (found) found.nums.push(idx + 1);
-      else byDoc.set(key, { nums: [idx + 1], result: r });
-    });
-    byDoc.forEach(({ nums, result }) =>
-      rows.push({ label: nums.join(', '), title: titleOf(result), result }),
-    );
-  } else {
-    results.forEach((r, idx) => {
-      const page = layout === 'flat' && r.page_num ? `, p.${r.page_num}` : '';
-      rows.push({ label: String(idx + 1), title: `${titleOf(r)}${page}`, result: r });
-    });
-  }
-
-  const out: Paragraph[] = [
-    new Paragraph({
-      heading: HeadingLevel.HEADING_1,
-      children: [new TextRun({ text: sectionTitle })],
-      spacing: { before: 360, after: 120 },
-    }),
-  ];
-  rows.forEach(({ label, title, result }) => {
-    out.push(
-      new Paragraph({
-        spacing: { after: 60 },
-        children: [
-          new TextRun({ text: `${label}. `, bold: true }),
-          new ExternalHyperlink({
-            link: resolveResultLink(result, siteOrigin, dataSource),
-            children: [new TextRun({ text: title, style: 'Hyperlink' })],
-          }),
-        ],
-      }),
-    );
-  });
-  return out;
-};
+): Paragraph[] => [
+  new Paragraph({
+    heading: HeadingLevel.HEADING_1,
+    children: [new TextRun({ text: sectionTitle })],
+    spacing: { before: 360, after: 120 },
+  }),
+  ...(layout === 'grouped'
+    ? buildGroupedReferenceRows(results, siteOrigin, dataSource)
+    : buildNumberedReferenceRows(results, siteOrigin, dataSource, layout === 'flat')),
+];
 
 const buildResultsSection = (
   results: SearchResult[],

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -73,7 +73,9 @@ export interface ExportOptions {
    *  The Brief export passes "Reference Excerpts". */
   resultsSectionTitle?: string;
   // Render a compact references list (no excerpts) instead of full result
-  // cards, mirroring the Brief's on-screen References section.
+  // cards, mirroring the Brief's on-screen References section. This is then
+  // the document's only References section: the grouped list the search
+  // export embeds under its prose is not added.
   referenceList?: ReferenceListLayout;
   /** Cover-page document title (default "Evidence Lab — Search Export").
    *  The Brief export passes "AI-generated Research Brief". */
@@ -850,6 +852,11 @@ const buildSummarySection = (
   heading = 'AI Summary',
   bookmarkPrefix?: string,
   footnotes?: FootnoteRegistry,
+  // The search export lists its references directly under the prose, before
+  // the result cards. The Brief export instead renders one References section
+  // laid out per the reader's grouping (see ExportOptions.referenceList), so
+  // it turns this embedded list off to avoid two References sections.
+  embeddedReferences = true,
 ): Paragraph[] => {
   if (!summary.trim()) return [];
   const out: Paragraph[] = [];
@@ -872,7 +879,9 @@ const buildSummarySection = (
   // body become clickable links, renumbered to match the screen. When a
   // bookmarkPrefix is set, headings are bookmarked for the manual TOC.
   out.push(...markdownToParagraphs(summary, 1, citations, bookmarkPrefix));
-  out.push(...buildReferenceParagraphs(buildGroupedReferences(summary, results), citations));
+  if (embeddedReferences) {
+    out.push(...buildReferenceParagraphs(buildGroupedReferences(summary, results), citations));
+  }
   return out;
 };
 
@@ -1196,6 +1205,7 @@ export const buildExportDocument = (
       opts.summaryHeading,
       opts.tableOfContents ? tocBookmarkPrefix : undefined,
       footnotes,
+      !opts.referenceList,
     ),
     ...(opts.documentList
       ? buildDocumentListParagraphs(


### PR DESCRIPTION
## Summary

The References list at the end of a brief now offers two exclusive **Group by document** checkboxes instead of one:

- **Group by document (multiple per document)** — the existing grouping, renamed. One number per cited passage; the list collapses to one row per document showing each number with its page (`Title, [1] p. 32, [2] p. 56`).
- **Group by document (single per document)** — new. One number per document and no page numbers. Every passage cited from the same document shares that number, so the prose is renumbered too:

  | | Prose | References |
  |---|---|---|
  | Before | `A fact happened. [1][3] Then something else [2][4][5]` | `[1] Doc1, p.10` · `[2] Doc2, p.4` · `[3] Doc1, p.20` · `[4] Doc3, p.7` · `[5] Doc1, p.30` |
  | Single per document | `A fact happened. [1] Then something else [2][3][1]` | `[1] Doc1` · `[2] Doc2` · `[3] Doc3` |

Ticking one checkbox clears the other; clearing both returns to one row per cited passage with pages.

## How it works

- `ReferenceGrouping` (`'passage' | 'document-multiple' | 'document-single'`) replaces the boolean `groupReferences` in `useBrief`.
- `buildGlobalCitations` takes the grouping and, in single mode, keys citation numbers by document instead of by passage. The other passages of a document ride along as `variants` on the display source, so the inline hover card can still show the passage that supports the hovered claim (the mechanism the assistant already uses). Adjacent duplicate markers produced by the collapse (`[1][1]`) are merged.
- The References section is extracted into a new `BriefReferences` component. Clicking a document-level reference opens the document at its first cited passage.
- The per-section **Evidence** panel drops page numbers in single mode (`hidePages` on `CitedReferences`).
- The hook's unused per-passage `references` copy (and the `BriefReference` type) is removed so there is one numbering source.
- Docs updated in `docs/using-evidence-lab/brief.md`.

## Word export

- **One References section.** The brief export reused the search exporter, which always embedded its own grouped references under the prose, and then appended the brief's layout-specific list, so documents had two References sections. The embedded list is now skipped when a `referenceList` layout is requested. The search export is unchanged.
- **The list follows the on-screen grouping.** Neither ticked: `1. Title, p.26` per citation. Multiple per document: `Title, [1] p. 26, [2] p. 40`, laid out exactly as on screen, with the title linked to the document and each number and page linked to that citation's page. Single per document: `1. Title` with no page.

## Also in this PR

- **Seed screen buttons.** The three action buttons ("Generate outline", "Write my own headings", "Load a saved brief") only ever fit on one line by a pixel, and the third carried `margin-left: auto`, so on most windows it wrapped and sat alone on the right. The buttons now share the row: one line at full card width, each line filled when a narrower window wraps them, stacked full-width on a phone.
- **CLAUDE.md**: adds a rule forbidding suppression of type or lint errors in tooling or dev-server config (e.g. `TSC_COMPILE_ON_ERROR`), not just in source.

## Testing

- New unit tests: `briefCitations.test.ts` (document-level numbering, variants, cross-section sharing, combined markers), `briefReferences.test.tsx` (labels, exclusivity, row layouts, click-through), `exportBriefDocx.test.ts` (flat / grouped / document list layouts, exactly one References heading per layout, grouped row text and link targets), `citedReferencesHidePages.test.tsx`, and an end-to-end toggle test in `briefTab.test.tsx` that checks the inline numbers and the References rows before, during and after ticking the single-per-document box.
- Full frontend suite: 100 suites, 802 tests pass.
- Verified in the browser against real data: default, single and multiple states render as in the table above; unticking restores the original numbering; Evidence panels show no pages in single mode; Export to Word runs without errors; the seed buttons verified at 1100px, 640px and 420px windows.
- `pre-commit` (incl. code-metrics) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
