### PR TITLE
feat(brief): control section length with a word target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ python scripts/sync/db/sync_backup_to_remote.py \
 
 ### Code Quality
 - **NEVER use `noqa`, `type: ignore`, or similar suppressions to bypass pre-commit hooks or linters.** Fix the actual issue instead. Only use suppressions if explicitly requested by the user.
+- **NEVER suppress, demote, or hide type or lint errors in tooling or environment config either** — no `TSC_COMPILE_ON_ERROR`, `ESLINT_NO_DEV_ERRORS`, `DISABLE_ESLINT_PLUGIN`, closing a compile-error overlay and carrying on, or any equivalent, not even for a throwaway local dev server. Find the cause (a stale package, a wrong config) and fix that.
 - **NEVER code fallbacks or graceful degradation unless explicitly requested.** If a dependency or feature is required, fail hard and loud. Silent fallbacks hide bugs.
 - **NEVER install packages ad-hoc.** New dependencies MUST be added to `requirements.txt` (root) and/or `ui/backend/requirements.txt` so they are part of the build environment. Both CI and Docker must pick them up.
 - **NEVER use deprecated APIs or methods.** Check library documentation for current recommended usage before implementing.

--- a/config.json
+++ b/config.json
@@ -3,6 +3,18 @@
     "ai_summary": {
       "enabled": true
     },
+    "brief": {
+      "target_words": {
+        "presets": [
+          { "label": "Short", "words": 150 },
+          { "label": "Standard", "words": 350 },
+          { "label": "Long", "words": 700 }
+        ],
+        "min": 50,
+        "max": 3000,
+        "tolerance": 0.25
+      }
+    },
     "assistant": {
       "enabled": true,
       "max_search_results": 20,

--- a/docs/admin/user-administration.md
+++ b/docs/admin/user-administration.md
@@ -255,6 +255,12 @@ Click **Save Settings** to apply, or **Reset to Defaults** to clear all group ov
 
 ---
 
+#### Brief
+
+| Setting | Description |
+|---------|-------------|
+| **Default section length** | The section length target new briefs start with, in words per section (Short, Standard, Long, a custom number, or no target). Authors can change it per brief and per section; sections that overshoot by more than the configured tolerance are condensed automatically. Default: no target. |
+
 ### User Self-Service
 
 Users have access to a **Profile** modal (click avatar → Profile) where they can:

--- a/docs/using-evidence-lab/brief.md
+++ b/docs/using-evidence-lab/brief.md
@@ -24,7 +24,7 @@ Click the **Brief** tab and you'll land on the start screen.
 
 You have three ways to start:
 
-- **Generate outline** — enter a **Topic** (e.g. *girls education in Kenya*), optionally add **Instructions** to steer the headings (e.g. *focus on East Africa, prioritise RCTs since 2018, structure around outcomes*), choose the **Number of sections**, and click **Generate outline**. Evidence Lab runs a deep-research survey across the document library and proposes headings grounded in what the collection actually contains.
+- **Generate outline** — enter a **Topic** (e.g. *girls education in Kenya*), optionally add **Instructions** to steer the headings (e.g. *focus on East Africa, prioritise RCTs since 2018, structure around outcomes*), choose the **Number of sections** and the **Section length** (see [Section length](#section-length) below), and click **Generate outline**. Evidence Lab runs a deep-research survey across the document library and proposes headings grounded in what the collection actually contains.
 - **Write my own headings** — skip the survey and start from a small set of placeholder headings you edit yourself.
 - **Load a saved brief** — reopen any brief from your history.
 
@@ -66,7 +66,21 @@ When a section finishes, it shows the written text with inline citations.
 For each completed section you can:
 
 - **Edit text** — tweak the generated prose by hand.
-- **Regenerate** — re-run the research, optionally with new guidance.
+- **Regenerate** — re-run the research, optionally with new guidance or a different length.
+
+Each researched section shows its word count next to its heading, and the line under the brief title shows the total.
+
+#### Section length
+
+A brief can ask for sections of about a given number of words. Choose a **Section length** when you start a brief (Short, Standard, Long, a custom number, or *No target*, which lets the model decide, as before), change it for the whole brief in **AI Regenerate All**, or override it for one section in that section's research panel, where *Use brief target* inherits the brief's setting. The target is remembered with the brief. Your team may set a default in the group settings.
+
+The target is enforced three ways, because a model on its own only approximates a word count:
+
+1. The research prompt asks for about that many words, in place of its usual "at least three or four paragraphs".
+2. The model's output limit is raised so a long target is never cut off mid-sentence.
+3. When a section comes back more than a quarter longer than its target, Evidence Lab condenses it with an AI edit that keeps every citation. You will see *Condensing to about N words* in the section's activity while that runs, and the edit is recorded in the section's **Log**.
+
+Sections that come back short are left as they are: the target is a ceiling on length as much as a goal, and padding a section would only dilute its evidence. The presets, the allowed range and the tolerance are set in `config.json` under `application.brief.target_words`.
 
 Citations work like the rest of Evidence Lab: inline number badges link to the source document and page, an expandable **Evidence** panel lists the supporting documents for that section, and a compiled **References** list appears at the end of the brief. Citation numbers are renumbered consecutively across the whole brief. By default there is one number per cited passage — the same numbering the Research Assistant uses, so a document cited from three pages carries three numbers. Two **Group by document** checkboxes above the References list change how the list is laid out, and the single-per-document option also changes the numbering itself (see [Export to Word](#5-export-to-word) below).
 

--- a/docs/using-evidence-lab/brief.md
+++ b/docs/using-evidence-lab/brief.md
@@ -68,7 +68,7 @@ For each completed section you can:
 - **Edit text** — tweak the generated prose by hand.
 - **Regenerate** — re-run the research, optionally with new guidance.
 
-Citations work like the rest of Evidence Lab: inline number badges link to the source document and page, an expandable **Evidence** panel lists the supporting documents for that section, and a compiled **References** list appears at the end of the brief. Citation numbers are renumbered consecutively across the whole brief, one number per cited passage — the same numbering the Research Assistant uses, so a document cited from three pages carries three numbers.
+Citations work like the rest of Evidence Lab: inline number badges link to the source document and page, an expandable **Evidence** panel lists the supporting documents for that section, and a compiled **References** list appears at the end of the brief. Citation numbers are renumbered consecutively across the whole brief. By default there is one number per cited passage — the same numbering the Research Assistant uses, so a document cited from three pages carries three numbers. Two **Group by document** checkboxes above the References list change how the list is laid out, and the single-per-document option also changes the numbering itself (see [Export to Word](#5-export-to-word) below).
 
 ---
 
@@ -86,7 +86,11 @@ From a card you can **open**, **share** or **delete** a brief. **New brief** sta
 
 When your brief is ready, click **Export to Word** at the top right.
 
-The exported document mirrors what you see on screen: inline `[n]` citation numbers in the prose and a compiled **References** list at the end, laid out according to the **Group by document** checkbox above that list. Leave it off for one line per citation; tick it to collapse the list to one line per document — `Title, [1] p. 32, [2] p. 56` — which is more compact when a brief leans on a handful of reports.
+The exported document mirrors what you see on screen: inline `[n]` citation numbers in the prose and a compiled **References** list at the end, laid out according to the **Group by document** checkboxes above that list (tick at most one):
+
+- **Neither ticked** — one line per citation, with its page: `[1] Title, p.32`.
+- **Group by document (multiple per document)** — one line per document listing each of its citation numbers with the page it points at: `Title, [1] p. 32, [2] p. 56`. The numbering is unchanged, so this is more compact when a brief leans on a handful of reports.
+- **Group by document (single per document)** — one number per document and no page numbers: `[1] Title`. Every passage cited from the same document shares that number, so the prose is renumbered too — `A fact happened. [1][3]` becomes `A fact happened. [1]` when both citations came from the same report. Clicking an inline number still opens the document at the passage it was cited from.
 
 ![Export to Word button](/docs/images/brief/brief-export-button.png)
 

--- a/prompts/assistant_deep_research_coordinator.j2
+++ b/prompts/assistant_deep_research_coordinator.j2
@@ -33,10 +33,14 @@ Follow these steps for every request:
 
 ## Response quality rules — CRITICAL
 
-- You MUST produce a detailed, multi-paragraph response with citations whenever the researcher returns ANY relevant information.
+- You MUST produce a {% if target_words %}well-cited{% else %}detailed, multi-paragraph{% endif %} response whenever the researcher returns ANY relevant information.
 - Read every finding from the researcher carefully — use information from document titles, text excerpts, and any details present.
 - NEVER dismiss researcher findings as "not containing enough information" when they clearly discuss the topic. If findings mention the topic, extract and synthesize what they say.
+{% if target_words %}
+- LENGTH — FIRM TARGET: write approximately {{ target_words }} words in total, between {{ (target_words * 0.8) | int }} and {{ (target_words * 1.2) | int }}. Count the prose only, not the [n] markers. Fit the structure to the length: {% if target_words <= 200 %}one or two tight paragraphs and no headings{% else %}fewer, denser paragraphs and only as many headings as the length can carry{% endif %}. Prefer the strongest, best-cited evidence over covering everything; leave out the weakest material rather than compressing every point into a fragment.
+{% else %}
 - Your response should be AT LEAST 3-4 paragraphs with clear headings, organized by theme.
+{% endif %}
 - If findings mention relevant programmes, evaluations, reports, or initiatives, describe them with citations.
 - A short dismissive answer like "the search results do not contain specific information" when findings clearly cover the topic is WRONG. Always synthesize what the findings DO contain.
 - NEVER say documents or files "were not found in the system". If the researcher returned findings, the documents exist. Use them.
@@ -45,7 +49,9 @@ Follow these steps for every request:
 
 - Answer ONLY the user's specific question using ONLY the information from researcher findings.
 - Use markdown: headings (##), bullet points, bold for emphasis.
+{% if not target_words %}
 - Structure your answer as several paragraphs with clear headings.
+{% endif %}
 - Do NOT include a 'References' section — citations are inline only.
 - Do NOT include a conclusion, summary, or closing paragraph. NEVER write sentences like "In summary", "Overall", "In conclusion", or "Taken together". End with your last substantive point — do not add any paragraph that rounds up, recaps, or wraps up what you already said.
 - Do NOT include any '---' separators.

--- a/tests/unit/test_assistant_routes.py
+++ b/tests/unit/test_assistant_routes.py
@@ -219,6 +219,50 @@ class TestStreamAssistantChat:
 
     @pytest.mark.asyncio
     @patch("ui.backend.routes.assistant.stream_research_response")
+    async def test_passes_target_words(self, mock_stream):
+        """A length target reaches the service alongside the model config."""
+
+        async def mock_gen(*args, **kwargs):
+            yield {"type": "done", "messageId": "msg-1"}
+
+        mock_stream.return_value = mock_gen()
+
+        from ui.backend.routes.assistant import stream_assistant_chat
+
+        request = _make_request(path="/assistant/chat/stream")
+        body = AssistantChatRequest(query="test", deep_research=True, target_words=300)
+        response = await stream_assistant_chat(
+            request=request, body=body, user=None, session=None
+        )
+        async for _chunk in response.body_iterator:
+            pass
+
+        assert mock_stream.call_args[1]["target_words"] == 300
+
+    @pytest.mark.asyncio
+    @patch("ui.backend.routes.assistant.stream_research_response")
+    async def test_target_words_defaults_to_none(self, mock_stream):
+        async def mock_gen(*args, **kwargs):
+            yield {"type": "done", "messageId": "msg-1"}
+
+        mock_stream.return_value = mock_gen()
+
+        from ui.backend.routes.assistant import stream_assistant_chat
+
+        request = _make_request(path="/assistant/chat/stream")
+        response = await stream_assistant_chat(
+            request=request,
+            body=AssistantChatRequest(query="test"),
+            user=None,
+            session=None,
+        )
+        async for _chunk in response.body_iterator:
+            pass
+
+        assert mock_stream.call_args[1]["target_words"] is None
+
+    @pytest.mark.asyncio
+    @patch("ui.backend.routes.assistant.stream_research_response")
     async def test_handles_stream_error(self, mock_stream):
         """Errors during streaming should yield error events."""
 

--- a/tests/unit/test_assistant_schemas.py
+++ b/tests/unit/test_assistant_schemas.py
@@ -400,3 +400,18 @@ class TestAssistantSearchSettingsWide:
             AssistantSearchSettings(wide_group_size=0)
         with pytest.raises(ValidationError):
             AssistantSearchSettings(wide_limit=1001)
+
+
+class TestAssistantChatRequestTargetWords:
+    """target_words: optional length target for the written answer."""
+
+    def test_defaults_to_none(self):
+        assert AssistantChatRequest(query="q").target_words is None
+
+    def test_accepts_a_target(self):
+        assert AssistantChatRequest(query="q", target_words=350).target_words == 350
+
+    @pytest.mark.parametrize("value", [0, 49, 5001, -10])
+    def test_rejects_out_of_range_targets(self, value):
+        with pytest.raises(ValidationError):
+            AssistantChatRequest(query="q", target_words=value)

--- a/tests/unit/test_assistant_target_length.py
+++ b/tests/unit/test_assistant_target_length.py
@@ -1,0 +1,101 @@
+"""Unit tests for the deep-research answer length target (``target_words``).
+
+The Brief tab asks for sections of about N words. That target must (1) reach
+the coordinator prompt as a firm length rule in place of the default
+"at least 3-4 paragraphs", and (2) raise the token ceiling so a long target
+is not silently truncated.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from ui.backend.services.assistant_graph import (
+    _load_deep_research_prompt,
+    build_deep_research_agent,
+)
+from ui.backend.services.assistant_service import (
+    TARGET_LENGTH_HEADROOM_TOKENS,
+    TOKENS_PER_WORD,
+    max_tokens_for_target,
+)
+
+PROMPTS_DIR = Path(__file__).resolve().parents[2] / "prompts"
+DEFAULT_LENGTH_RULE = "AT LEAST 3-4 paragraphs"
+
+
+@pytest.fixture
+def jinja_env():
+    return Environment(loader=FileSystemLoader(str(PROMPTS_DIR)), autoescape=True)
+
+
+@pytest.mark.unit
+class TestMaxTokensForTarget:
+    def test_no_target_leaves_the_ceiling_alone(self):
+        assert max_tokens_for_target(2000, None) == 2000
+        assert max_tokens_for_target(None, None) is None
+
+    def test_small_target_never_lowers_the_ceiling(self):
+        # 150 words needs far fewer than 2000 tokens; the prompt (not the
+        # ceiling) enforces a short answer, so the configured value stands.
+        assert max_tokens_for_target(2000, 150) == 2000
+
+    def test_long_target_raises_the_ceiling_to_fit(self):
+        needed = int(1500 * TOKENS_PER_WORD + 0.999) + TARGET_LENGTH_HEADROOM_TOKENS
+        assert max_tokens_for_target(2000, 1500) == needed
+        assert needed > 2000
+
+    def test_unconfigured_ceiling_becomes_what_the_target_needs(self):
+        assert max_tokens_for_target(None, 700) == 1120 + TARGET_LENGTH_HEADROOM_TOKENS
+
+
+@pytest.mark.unit
+class TestCoordinatorPromptLengthRule:
+    def test_without_a_target_the_default_rule_stands(self, jinja_env):
+        result = jinja_env.get_template(
+            "assistant_deep_research_coordinator.j2"
+        ).render()
+        assert DEFAULT_LENGTH_RULE in result
+        assert "FIRM TARGET" not in result
+        assert "Structure your answer as several paragraphs" in result
+
+    def test_with_a_target_the_default_rule_is_replaced(self, jinja_env):
+        result = jinja_env.get_template(
+            "assistant_deep_research_coordinator.j2"
+        ).render(target_words=350)
+        assert DEFAULT_LENGTH_RULE not in result
+        assert "approximately 350 words" in result
+        # 80%-120% band, integer bounds.
+        assert "between 280 and 420" in result
+        # A mid-length target keeps headings but fewer, denser paragraphs.
+        assert "fewer, denser paragraphs" in result
+        assert "Structure your answer as several paragraphs" not in result
+
+    def test_short_target_asks_for_no_headings(self, jinja_env):
+        result = jinja_env.get_template(
+            "assistant_deep_research_coordinator.j2"
+        ).render(target_words=150)
+        assert "one or two tight paragraphs and no headings" in result
+
+    def test_loader_passes_the_target_through(self):
+        assert "approximately 500 words" in _load_deep_research_prompt(target_words=500)
+        assert DEFAULT_LENGTH_RULE in _load_deep_research_prompt()
+
+
+@pytest.mark.unit
+class TestBuildDeepResearchAgentTargetWords:
+    @patch("ui.backend.services.assistant_graph.create_deep_agent")
+    def test_target_reaches_the_coordinator_system_prompt(self, mock_create):
+        mock_create.return_value = MagicMock()
+        build_deep_research_agent(MagicMock(), data_source="wfp", target_words=300)
+        system_prompt = mock_create.call_args.kwargs["system_prompt"]
+        assert "approximately 300 words" in system_prompt
+        assert DEFAULT_LENGTH_RULE not in system_prompt
+
+    @patch("ui.backend.services.assistant_graph.create_deep_agent")
+    def test_no_target_keeps_the_default_rule(self, mock_create):
+        mock_create.return_value = MagicMock()
+        build_deep_research_agent(MagicMock(), data_source="wfp")
+        assert DEFAULT_LENGTH_RULE in mock_create.call_args.kwargs["system_prompt"]

--- a/ui/backend/auth/schemas.py
+++ b/ui/backend/auth/schemas.py
@@ -742,6 +742,11 @@ class AssistantChatRequest(BaseModel):
     reranker_model: Optional[str] = None
     search_settings: Optional[AssistantSearchSettings] = None
     deep_research: bool = False
+    # Target length of the written answer, in words. The Brief tab sends its
+    # per-section target so the coordinator prompt asks for that length and
+    # the token ceiling is raised to fit it. None keeps the prompt's default
+    # ("at least 3-4 paragraphs").
+    target_words: Optional[int] = Field(None, ge=50, le=5000)
     conversation_history: Optional[List[Dict[str, Any]]] = Field(
         None,
         description=(

--- a/ui/backend/routes/assistant.py
+++ b/ui/backend/routes/assistant.py
@@ -264,6 +264,7 @@ async def stream_assistant_chat(
                 search_settings=search_kwargs,
                 system_prompt_override=group_prompt,
                 deep_research=body.deep_research,
+                target_words=body.target_words,
             ).__aiter__()
 
             async for event in _stream_with_heartbeat(ait):

--- a/ui/backend/services/assistant_graph.py
+++ b/ui/backend/services/assistant_graph.py
@@ -585,13 +585,19 @@ def build_research_agent(
 def _load_deep_research_prompt(
     data_source: Optional[str] = None,
     prior_sources: Optional[List[Dict[str, Any]]] = None,
+    target_words: Optional[int] = None,
 ) -> str:
-    """Load and render the deep research coordinator prompt."""
+    """Load and render the deep research coordinator prompt.
+
+    ``target_words`` swaps the prompt's default length rule ("at least 3-4
+    paragraphs") for a firm target of about that many words.
+    """
     template = _jinja_env.get_template("assistant_deep_research_coordinator.j2")
     return template.render(
         data_source=data_source,
         prior_sources=prior_sources or [],
         next_index=_next_citation_index(prior_sources),
+        target_words=target_words,
     )
 
 
@@ -617,6 +623,7 @@ def build_deep_research_agent(
     search_settings: Optional[Dict[str, Any]] = None,
     system_prompt_override: Optional[str] = None,
     prior_sources: Optional[List[Dict[str, Any]]] = None,
+    target_words: Optional[int] = None,
 ) -> tuple:
     """Build a deep research agent with sub-agent delegation.
 
@@ -642,7 +649,7 @@ def build_deep_research_agent(
     search_tool = _build_search_tool(tracker)
 
     coordinator_prompt = _load_deep_research_prompt(
-        data_source, prior_sources=prior_sources
+        data_source, prior_sources=prior_sources, target_words=target_words
     )
     researcher_prompt = _load_researcher_prompt(
         data_source, max_queries=max_queries, prior_sources=prior_sources

--- a/ui/backend/services/assistant_service.py
+++ b/ui/backend/services/assistant_service.py
@@ -364,11 +364,12 @@ async def stream_research_response(
     tracker = None
     usage_handler = UsageMetadataCallbackHandler()
     logger.info(
-        "[deepres] stream start: run_id=%s deep=%s model=%s data_source=%s",
+        "[deepres] stream start: run_id=%s deep=%s model=%s data_source=%s target_words=%s",
         run_id,
         deep_research,
         model_key,
         data_source,
+        target_words,
     )
 
     try:

--- a/ui/backend/services/assistant_service.py
+++ b/ui/backend/services/assistant_service.py
@@ -7,6 +7,7 @@ SSE streaming and conversation persistence.
 
 import asyncio
 import logging
+import math
 import sys
 import uuid as uuid_mod
 from pathlib import Path
@@ -23,6 +24,32 @@ from ui.backend.services.assistant_graph import (
 from ui.backend.services.llm_service import summarize_usage_metadata
 
 logger = logging.getLogger(__name__)
+
+
+# Token ceiling for a requested length in words. English prose runs at about
+# 1.3 tokens per word; inline [n] citations and markdown headings push that
+# up, and the model needs room to finish its last sentence rather than be cut
+# off mid-citation, hence the ratio and the fixed headroom.
+TOKENS_PER_WORD = 1.6
+TARGET_LENGTH_HEADROOM_TOKENS = 400
+
+
+def max_tokens_for_target(
+    max_tokens: Optional[int], target_words: Optional[int]
+) -> Optional[int]:
+    """Raise the configured ``max_tokens`` so a ``target_words`` answer fits.
+
+    The configured ceiling (e.g. 2000 tokens, roughly 1,400 words) silently
+    truncates longer targets, so when a target is given the ceiling becomes
+    at least what that many words need. It is never lowered: a small target
+    is enforced by the prompt (and the Brief's condense pass), not by cutting
+    the model off, which would also starve the researcher sub-agent that
+    shares this limit.
+    """
+    if not target_words:
+        return max_tokens
+    needed = math.ceil(target_words * TOKENS_PER_WORD) + TARGET_LENGTH_HEADROOM_TOKENS
+    return max(max_tokens or 0, needed)
 
 
 def _get_llm(model_key=None, temperature=None, max_tokens=None):
@@ -312,9 +339,13 @@ async def stream_research_response(
     search_settings: Optional[Dict[str, Any]] = None,
     system_prompt_override: Optional[str] = None,
     deep_research: bool = False,
+    target_words: Optional[int] = None,
 ) -> AsyncGenerator[Dict[str, Any], None]:
     """
     Stream a research response via SSE events.
+
+    ``target_words`` (deep research only) asks the coordinator for an answer
+    of about that length and raises the token ceiling to fit it.
 
     Runs the deepagents research agent and yields structured events
     as the agent searches, plans, and synthesizes its response.
@@ -344,18 +375,28 @@ async def stream_research_response(
         llm = _get_llm(
             model_key=model_key,
             temperature=temperature,
-            max_tokens=max_tokens,
+            max_tokens=max_tokens_for_target(max_tokens, target_words),
         )
         prior_sources = _extract_prior_sources(conversation_messages)
-        builder = build_deep_research_agent if deep_research else build_research_agent
-        agent, tracker = builder(
-            llm,
-            data_source,
-            reranker_model,
-            search_settings,
-            system_prompt_override=system_prompt_override,
-            prior_sources=prior_sources,
-        )
+        if deep_research:
+            agent, tracker = build_deep_research_agent(
+                llm,
+                data_source,
+                reranker_model,
+                search_settings,
+                system_prompt_override=system_prompt_override,
+                prior_sources=prior_sources,
+                target_words=target_words,
+            )
+        else:
+            agent, tracker = build_research_agent(
+                llm,
+                data_source,
+                reranker_model,
+                search_settings,
+                system_prompt_override=system_prompt_override,
+                prior_sources=prior_sources,
+            )
         messages = _build_conversation_messages(query, conversation_messages)
         if prior_sources:
             logger.info(

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -793,6 +793,8 @@ function App() {
   const [fieldBoostFields, setFieldBoostFields] = useState<Record<string, number>>(initialSearchState.fieldBoostFields);
   // Group greeting message (overrides search placeholder on landing page)
   const [greetingMessage, setGreetingMessage] = useState<string>('');
+  // Group default section length for new briefs (null = no target)
+  const [briefTargetWords, setBriefTargetWords] = useState<number | null>(null);
   const [aiSummary, setAiSummary] = useState<string>('');
   const [aiSummaryLoading, setAiSummaryLoading] = useState<boolean>(false);
   const [aiPrompt, setAiPrompt] = useState<string>('');
@@ -854,6 +856,7 @@ function App() {
     summaryLimitResults: setSummaryLimitResults,
     summaryMaxResults: setSummaryMaxResults,
     summaryTemperature: setSummaryTemperature,
+    briefTargetWords: setBriefTargetWords,
     greetingMessage: setGreetingMessage,
   });
 
@@ -3088,6 +3091,7 @@ function App() {
               wideSearch,
               wideGroupSize,
               wideLimit,
+              briefTargetWords,
             }}
             onResultClick={handleResultClick}
           />

--- a/ui/frontend/src/components/admin/GroupSettingsManager.tsx
+++ b/ui/frontend/src/components/admin/GroupSettingsManager.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../utils/searchUrl';
 import { DEFAULT_TAB_LABELS, TAB_KEYS, TabKey } from '../layout/tabConfig';
 import { AiSummaryControls, GroupByDocumentControl, WideSearchControls } from '../filters/SearchSettingsPanel';
+import { BriefLengthControl } from '../brief/BriefLengthControl';
 
 type TabValues = Record<TabKey, { enabled: boolean; label: string }>;
 
@@ -40,6 +41,7 @@ const SETTING_KEYS: (keyof SearchSettings)[] = [
   'summaryLimitResults',
   'summaryMaxResults',
   'summaryTemperature',
+  'briefTargetWords',
   'greetingMessage',
 ];
 
@@ -867,6 +869,34 @@ const GroupSettingsManager: React.FC = () => {
                   </div>
                 )}
               </div>
+            </div>
+
+            {/* Brief Settings */}
+            <div className="filter-section">
+              <div className="filter-section-header" onClick={() => toggleSection('brief')}>
+                <span className="filter-section-toggle">
+                  {collapsedSections.has('brief') ? '▼' : '▶'}
+                </span>
+                <span className="filter-section-title">Brief</span>
+              </div>
+              {collapsedSections.has('brief') && (
+                <div className="filter-section-content">
+                  <label className="rerank-checkbox-label" htmlFor="group-brief-target-words">
+                    <span>Default section length</span>
+                    <span
+                      className="rerank-tooltip"
+                      title="The section length target new briefs start with, in words per section. Authors can change it per brief and per section. Sections that overshoot the target by more than the configured tolerance are condensed automatically."
+                    >
+                      ⓘ
+                    </span>
+                  </label>
+                  <BriefLengthControl
+                    id="group-brief-target-words"
+                    value={values.briefTargetWords}
+                    onChange={(v) => update('briefTargetWords', v)}
+                  />
+                </div>
+              )}
             </div>
 
             {/* Actions */}

--- a/ui/frontend/src/components/brief/BriefCentral.tsx
+++ b/ui/frontend/src/components/brief/BriefCentral.tsx
@@ -161,12 +161,15 @@ interface BriefCentralProps {
   central: UseBriefCentralReturn;
   onOpenBrief: (id: string) => void;
   onCreateBrief: (args: NewBriefSubmit) => void;
+  // The team's default section length for a new brief (null = no target).
+  defaultTargetWords?: number | null;
 }
 
 export const BriefCentral: React.FC<BriefCentralProps> = ({
   central,
   onOpenBrief,
   onCreateBrief,
+  defaultTargetWords,
 }) => {
   const [modal, setModal] = useState<'new' | 'template' | 'voice' | 'share' | null>(null);
   const [newTemplateId, setNewTemplateId] = useState<string | null>(null);
@@ -314,6 +317,7 @@ export const BriefCentral: React.FC<BriefCentralProps> = ({
           templates={central.templates}
           voices={central.voices}
           initialTemplateId={newTemplateId}
+          defaultTargetWords={defaultTargetWords}
           onSubmit={submitNew}
           onClose={() => setModal(null)}
         />

--- a/ui/frontend/src/components/brief/BriefCentralModals.tsx
+++ b/ui/frontend/src/components/brief/BriefCentralModals.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { BriefLengthControl } from './BriefLengthControl';
 import {
   addBriefShare,
   getBrief,
@@ -49,6 +50,8 @@ export interface NewBriefSubmit {
   instructions: string;
   voiceId: string | null;
   numHeadings: number;
+  // Section length target in words; null = no target.
+  targetWords: number | null;
   template: BriefTemplate | null;
 }
 
@@ -56,14 +59,17 @@ export const BriefNewModal: React.FC<{
   templates: BriefTemplate[];
   voices: VoiceProfile[];
   initialTemplateId?: string | null;
+  // The group's default section length, if the team set one.
+  defaultTargetWords?: number | null;
   onSubmit: (args: NewBriefSubmit) => void;
   onClose: () => void;
-}> = ({ templates, voices, initialTemplateId, onSubmit, onClose }) => {
+}> = ({ templates, voices, initialTemplateId, defaultTargetWords, onSubmit, onClose }) => {
   const [mode, setMode] = useState<'ai' | 'manual'>(initialTemplateId ? 'manual' : 'ai');
   const [title, setTitle] = useState('');
   const [instructions, setInstructions] = useState('');
   const [voiceId, setVoiceId] = useState<string | null>(null);
   const [numHeadings, setNumHeadings] = useState(6);
+  const [targetWords, setTargetWords] = useState<number | null>(defaultTargetWords ?? null);
   const [templateId, setTemplateId] = useState<string>(initialTemplateId || '');
 
   const template = templates.find((t) => t.id === templateId) || null;
@@ -74,7 +80,15 @@ export const BriefNewModal: React.FC<{
   );
 
   const submit = () => {
-    onSubmit({ mode, title: title.trim(), instructions: instructions.trim(), voiceId, numHeadings, template });
+    onSubmit({
+      mode,
+      title: title.trim(),
+      instructions: instructions.trim(),
+      voiceId,
+      numHeadings,
+      targetWords,
+      template,
+    });
   };
 
   return (
@@ -210,6 +224,15 @@ export const BriefNewModal: React.FC<{
             </>
           )}
 
+          <div className="bc-field">
+            <label className="brief-label brief-label-spaced" htmlFor="bc-new-length">
+              Section length
+            </label>
+            <BriefLengthControl id="bc-new-length" value={targetWords} onChange={setTargetWords} />
+            <div className="bc-hint">
+              About this many words per section. Sections that run long are condensed automatically.
+            </div>
+          </div>
           <div className="bc-modal-actions">
             <button className="brief-btn brief-btn-primary" onClick={submit} disabled={!title.trim() && mode === 'ai'}>
               {mode === 'ai' ? <IconSparkle size={15} /> : <IconPlus />}
@@ -750,6 +773,8 @@ export const BriefShareModal: React.FC<{
 export interface RegenAllSubmit {
   instructions: string;
   voiceId: string | null;
+  // Section length target in words; null = no target.
+  targetWords: number | null;
   // Clear each section's own profile so the chosen one applies document-wide.
   applyVoiceToAllSections: boolean;
 }
@@ -763,12 +788,22 @@ export const BriefRegenAllModal: React.FC<{
   voices: VoiceProfile[];
   briefVoiceId: string | null;
   instructions: string;
+  targetWords: number | null;
   hasSectionVoices: boolean;
   onSubmit: (submit: RegenAllSubmit) => void;
   onClose: () => void;
-}> = ({ voices, briefVoiceId, instructions: initial, hasSectionVoices, onSubmit, onClose }) => {
+}> = ({
+  voices,
+  briefVoiceId,
+  instructions: initial,
+  targetWords: initialTarget,
+  hasSectionVoices,
+  onSubmit,
+  onClose,
+}) => {
   const [instructions, setInstructions] = useState(initial);
   const [voiceId, setVoiceId] = useState<string | null>(briefVoiceId);
+  const [targetWords, setTargetWords] = useState<number | null>(initialTarget);
   const [applyToAll, setApplyToAll] = useState(false);
   const selected = voices.find((v) => v.id === voiceId) || null;
 
@@ -815,6 +850,13 @@ export const BriefRegenAllModal: React.FC<{
             ))}
           </select>
           {selected && <div className="bc-voice-hint">{selected.description}</div>}
+          <label className="brief-label brief-label-spaced" htmlFor="bc-regen-length">
+            Section length
+          </label>
+          <BriefLengthControl id="bc-regen-length" value={targetWords} onChange={setTargetWords} />
+          <div className="bc-hint">
+            About this many words per section; sections with their own length keep it.
+          </div>
           {hasSectionVoices && (
             <>
               <div className="bc-voice-hint">
@@ -834,7 +876,7 @@ export const BriefRegenAllModal: React.FC<{
             <button
               className="brief-btn brief-btn-primary"
               onClick={() =>
-                onSubmit({ instructions, voiceId, applyVoiceToAllSections: applyToAll })
+                onSubmit({ instructions, voiceId, targetWords, applyVoiceToAllSections: applyToAll })
               }
             >
               <IconSparkle /> Regenerate all sections

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -11,6 +11,8 @@ import {
   IconShare,
   IconSparkle,
 } from './BriefIcons';
+import { BriefLengthControl } from './BriefLengthControl';
+import { countWords, describeTarget } from './briefLength';
 import { BriefReferences } from './BriefReferences';
 import { BriefToc } from './BriefToc';
 import { BriefSelection } from './BriefSelectionMenu';
@@ -117,6 +119,12 @@ interface SectionViewProps {
   activeThreadId?: string | null;
 }
 
+// Tooltip for a section's word count: which target (if any) it was written to.
+const sectionWordsTitle = (section: BriefSection, briefTarget: number | null): string => {
+  const target = section.targetWords ?? briefTarget;
+  return target ? `Target: about ${target} words` : 'No length target';
+};
+
 // A textarea for editing a section's heading guidance / regenerating, shown for
 // both pending sections (research with guidance) and done sections (re-research).
 const GuidancePanel: React.FC<{
@@ -166,6 +174,13 @@ const GuidancePanel: React.FC<{
           </div>
         </>
       )}
+      <div className="brief-regen-voice-label">Section length</div>
+      <BriefLengthControl
+        value={section.targetWords}
+        onChange={(target) => brief.setSectionTargetWords(section.id, target)}
+        inheritLabel={`Use brief target — ${describeTarget(brief.targetWords)}`}
+        ariaLabel="Length target for this section"
+      />
       <div className="brief-regen-actions">
         <button
           className="brief-btn brief-btn-primary"
@@ -478,6 +493,11 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
           onBlur={brief.commitEdits}
           readOnly={readOnly}
         />
+        {isDone && (
+          <span className="brief-doc-section-words" title={sectionWordsTitle(section, brief.targetWords)}>
+            {countWords(section.content).toLocaleString()} words
+          </span>
+        )}
       </div>
 
       {isDone && !readOnly && (
@@ -828,6 +848,12 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
           <span>{sections.length} sections</span>
           <span>·</span>
           <span>{brief.totalSources} sources synthesised</span>
+          {brief.totalWords > 0 && (
+            <>
+              <span>·</span>
+              <span>{brief.totalWords.toLocaleString()} words</span>
+            </>
+          )}
           {readOnly && brief.ownerName && (
             <>
               <span>·</span>

--- a/ui/frontend/src/components/brief/BriefDocument.tsx
+++ b/ui/frontend/src/components/brief/BriefDocument.tsx
@@ -1,10 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { SearchResult, SourceReference } from '../../types/api';
-import {
-  CitedMarkdown,
-  CitedReferences,
-  extractCitedNumbers,
-} from '../citations/CitedContent';
+import { CitedMarkdown, CitedReferences } from '../citations/CitedContent';
 import { buildGlobalCitations, SectionDisplay } from './briefCitations';
 import {
   IconClock,
@@ -15,6 +11,7 @@ import {
   IconShare,
   IconSparkle,
 } from './BriefIcons';
+import { BriefReferences } from './BriefReferences';
 import { BriefToc } from './BriefToc';
 import { BriefSelection } from './BriefSelectionMenu';
 import { BUBBLE_CLASS, CommentMark, MARK_CLASS, paintCommentMarks } from './briefCommentMarks';
@@ -102,60 +99,6 @@ const AiInstructionPanel: React.FC<{
     </div>
   </div>
 );
-
-// One row per document: its title, then each citation number pointing into it
-// with that number's page — "Title, [1] p. 32, [2] p. 56". No excerpts.
-const groupReferencesByDoc = (
-  refs: Array<{ n: number; title: string; page?: number; source: SourceReference }>,
-): Array<{
-  key: string;
-  title: string;
-  cites: Array<{ n: number; page: number; source: SourceReference }>;
-}> => {
-  const byDoc = new Map<
-    string,
-    {
-      key: string;
-      title: string;
-      cites: Array<{ n: number; page: number; source: SourceReference }>;
-    }
-  >();
-  // Numbers are per cited passage, so a document collects each of its own
-  // numbers with the page that number points at.
-  for (const r of refs) {
-    const key = r.source.docId || r.title;
-    const cite = { n: r.n, page: r.page ?? 0, source: r.source };
-    const found = byDoc.get(key);
-    if (found) found.cites.push(cite);
-    else byDoc.set(key, { key, title: r.title, cites: [cite] });
-  }
-  byDoc.forEach((g) => g.cites.sort((a, b) => a.page - b.page || a.n - b.n));
-  return Array.from(byDoc.values());
-};
-
-/**
- * Every cited chunk of each document, as the page and the source behind it.
- * The grouped references row lists these after the title, each labelled with
- * the citation number that appears inline in the prose.
- */
-const citedPagesByDoc = (
-  sections: BriefSection[],
-): Map<string, Array<{ page: number; source: SourceReference }>> => {
-  const map = new Map<string, Array<{ page: number; source: SourceReference }>>();
-  sections.forEach((s) => {
-    if (!(s.status === 'done' || s.revising) || !s.content) return;
-    const cited = new Set(extractCitedNumbers(s.content));
-    s.sources.forEach((src) => {
-      if (src.index == null || !cited.has(src.index) || src.page == null) return;
-      const key = src.docId || src.title;
-      const hits = map.get(key) || [];
-      if (!hits.some((h) => h.page === src.page)) hits.push({ page: src.page, source: src });
-      map.set(key, hits);
-    });
-  });
-  map.forEach((hits) => hits.sort((a, b) => a.page - b.page));
-  return map;
-};
 
 interface SectionViewProps {
   section: BriefSection;
@@ -452,6 +395,7 @@ const SectionDoneBody: React.FC<{
         collapsible
         labelPrefix="Evidence"
         className="brief-evidence"
+        hidePages={brief.referenceGrouping === 'document-single'}
       />
     </>
   );
@@ -616,7 +560,7 @@ const BriefSectionView: React.FC<SectionViewProps> = ({
 };
 
 // "Export to Word": one button. The document mirrors the on-screen
-// references, so its layout follows the "Group by document" toggle.
+// references, so its layout follows the "Group by document" toggles.
 const ExportButton: React.FC<{
   disabled: boolean;
   busy: boolean;
@@ -791,7 +735,10 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
   const [logOpen, setLogOpen] = useState(false);
   const titleRef = useRef<HTMLTextAreaElement>(null);
   const hasOutlineLog = brief.generatingActivity.length > 0;
-  const { refs: references, display } = useMemo(() => buildGlobalCitations(sections), [sections]);
+  const { refs: references, display } = useMemo(
+    () => buildGlobalCitations(sections, brief.referenceGrouping),
+    [sections, brief.referenceGrouping],
+  );
 
   useEffect(() => autoSizeTitle(titleRef.current), [brief.briefTitle]);
 
@@ -987,82 +934,12 @@ export const BriefDocument: React.FC<BriefDocumentProps> = ({
         </div>
       )}
 
-      {references.length > 0 && (
-        <section className="brief-footnotes">
-          <div className="brief-footnotes-head">
-            <h2 className="brief-footnotes-title">References</h2>
-            <label className="brief-footnotes-group-toggle">
-              <input
-                type="checkbox"
-                checked={brief.groupReferences}
-                onChange={(e) => brief.setGroupReferences(e.target.checked)}
-              />
-              Group by document
-            </label>
-          </div>
-          <div className="brief-footnotes-list">
-            {brief.groupReferences
-              ? groupReferencesByDoc(references).map((g) => (
-                  <div className="brief-footnote-group" key={g.key}>
-                    <span className="brief-footnote-text">{g.title}</span>
-                    {g.cites.map((c, i) => (
-                      <span className="brief-footnote-cite" key={`${c.n}-${c.page}-${i}`}>
-                        {/* The number is shown once per run of the same
-                            citation, so a document cited from many pages reads
-                            "[1] p. 9, p. 11" rather than repeating "[1]". */}
-                        {(i === 0 || g.cites[i - 1].n !== c.n) && (
-                          <span className="citation-doc-group">
-                            <a
-                              href="#"
-                              className="ai-summary-citation"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                handleSourceClick(c.source);
-                              }}
-                            >
-                              {c.n}
-                            </a>
-                          </span>
-                        )}
-                        {c.page ? (
-                          <a
-                            href="#"
-                            className="brief-footnote-page-link"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              handleSourceClick(c.source);
-                            }}
-                          >
-                            {` p. ${c.page}`}
-                          </a>
-                        ) : null}
-                      </span>
-                    ))}
-                  </div>
-                ))
-              : references.map((r) => (
-                  <div className="brief-footnote-row" key={r.n}>
-                    <a
-                      href="#"
-                      className="brief-footnote-link"
-                      onClick={(e) => {
-                        e.preventDefault();
-                        handleSourceClick(r.source);
-                      }}
-                    >
-                      <span className="citation-doc-group">
-                        <span className="ai-summary-citation">{r.n}</span>
-                      </span>
-                      <span className="brief-footnote-text">
-                        {r.title}
-                        {r.page ? `, p.${r.page}` : ''}
-                      </span>
-                    </a>
-                  </div>
-                ))}
-          </div>
-        </section>
-      )}
+      <BriefReferences
+        references={references}
+        grouping={brief.referenceGrouping}
+        onGroupingChange={brief.setReferenceGrouping}
+        onSourceClick={handleSourceClick}
+      />
 
       <ResearchStatusBar brief={brief} />
     </div>

--- a/ui/frontend/src/components/brief/BriefLengthControl.tsx
+++ b/ui/frontend/src/components/brief/BriefLengthControl.tsx
@@ -1,0 +1,90 @@
+import React, { useState } from 'react';
+import { BRIEF_LENGTH, clampTargetWords, describeTarget } from './briefLength';
+
+const CUSTOM = 'custom';
+const NONE = 'none';
+const INHERIT = 'inherit';
+
+/**
+ * Picks a section length target: a configured preset, a custom word count, or
+ * no target. With `inheritLabel` set (per-section use) the first option is
+ * "use the brief's target", represented by a null value.
+ */
+export const BriefLengthControl: React.FC<{
+  value: number | null | undefined;
+  onChange: (target: number | null) => void;
+  id?: string;
+  // Per-section override: the null value means "inherit the brief target",
+  // shown with this label (e.g. "Use brief target — Standard (~350 words)").
+  inheritLabel?: string;
+  ariaLabel?: string;
+}> = ({ value, onChange, id, inheritLabel, ariaLabel }) => {
+  const target = value ?? null;
+  const isPreset = target != null && BRIEF_LENGTH.presets.some((p) => p.words === target);
+  const [customMode, setCustomMode] = useState(target != null && !isPreset);
+  const [customText, setCustomText] = useState(target != null && !isPreset ? String(target) : '');
+
+  const selected = customMode ? CUSTOM : target == null ? (inheritLabel ? INHERIT : NONE) : String(target);
+
+  const handleSelect = (choice: string) => {
+    if (choice === CUSTOM) {
+      setCustomMode(true);
+      setCustomText(target ? String(target) : '');
+      return;
+    }
+    setCustomMode(false);
+    if (choice === NONE || choice === INHERIT) onChange(null);
+    else onChange(Number(choice));
+  };
+
+  const commitCustom = () => {
+    const parsed = Number(customText);
+    if (!customText.trim() || Number.isNaN(parsed)) return;
+    const clamped = clampTargetWords(parsed);
+    setCustomText(String(clamped));
+    onChange(clamped);
+  };
+
+  return (
+    <div className="brief-length-control">
+      <select
+        id={id}
+        className="bc-select"
+        value={selected}
+        onChange={(e) => handleSelect(e.target.value)}
+        aria-label={ariaLabel}
+      >
+        {inheritLabel ? (
+          <option value={INHERIT}>{inheritLabel}</option>
+        ) : (
+          <option value={NONE}>No target (model decides)</option>
+        )}
+        {BRIEF_LENGTH.presets.map((preset) => (
+          <option key={preset.words} value={String(preset.words)}>
+            {describeTarget(preset.words)}
+          </option>
+        ))}
+        <option value={CUSTOM}>Custom…</option>
+      </select>
+      {customMode && (
+        <label className="brief-length-custom">
+          <input
+            type="number"
+            className="brief-number"
+            min={BRIEF_LENGTH.min}
+            max={BRIEF_LENGTH.max}
+            step={50}
+            value={customText}
+            onChange={(e) => setCustomText(e.target.value)}
+            onBlur={commitCustom}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commitCustom();
+            }}
+            aria-label="Target words per section"
+          />
+          <span>words per section</span>
+        </label>
+      )}
+    </div>
+  );
+};

--- a/ui/frontend/src/components/brief/BriefReferences.tsx
+++ b/ui/frontend/src/components/brief/BriefReferences.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { SourceReference } from '../../types/api';
+import { GlobalRef } from './briefCitations';
+import { ReferenceGrouping } from './briefTypes';
+
+// The two "Group by document" options offered above the References list. They
+// are exclusive: ticking one clears the other, and clearing both returns to
+// one row per cited passage.
+export const REFERENCE_GROUPING_LABELS: Record<
+  Exclude<ReferenceGrouping, 'passage'>,
+  string
+> = {
+  'document-multiple': 'Group by document (multiple per document)',
+  'document-single': 'Group by document (single per document)',
+};
+
+const GROUPING_OPTIONS = Object.keys(REFERENCE_GROUPING_LABELS) as Array<
+  keyof typeof REFERENCE_GROUPING_LABELS
+>;
+
+interface DocCite {
+  n: number;
+  page: number;
+  source: SourceReference;
+}
+
+interface DocGroup {
+  key: string;
+  title: string;
+  cites: DocCite[];
+}
+
+// One row per document: its title, then each citation number pointing into it
+// with that number's page — "Title, [1] p. 32, [2] p. 56". No excerpts.
+export const groupReferencesByDoc = (refs: GlobalRef[]): DocGroup[] => {
+  const byDoc = new Map<string, DocGroup>();
+  // Numbers are per cited passage, so a document collects each of its own
+  // numbers with the page that number points at.
+  for (const r of refs) {
+    const key = r.source.docId || r.title;
+    const cite = { n: r.n, page: r.page ?? 0, source: r.source };
+    const found = byDoc.get(key);
+    if (found) found.cites.push(cite);
+    else byDoc.set(key, { key, title: r.title, cites: [cite] });
+  }
+  byDoc.forEach((g) => g.cites.sort((a, b) => a.page - b.page || a.n - b.n));
+  return Array.from(byDoc.values());
+};
+
+type SourceClick = (source: SourceReference) => void;
+
+const clickSource = (onSourceClick: SourceClick, source: SourceReference) =>
+  (e: React.MouseEvent) => {
+    e.preventDefault();
+    onSourceClick(source);
+  };
+
+// "[1] Title, p.32" — or just "[1] Title" for a document-level reference.
+const FlatRow: React.FC<{ reference: GlobalRef; onSourceClick: SourceClick }> = ({
+  reference: r,
+  onSourceClick,
+}) => (
+  <div className="brief-footnote-row">
+    <a href="#" className="brief-footnote-link" onClick={clickSource(onSourceClick, r.source)}>
+      <span className="citation-doc-group">
+        <span className="ai-summary-citation">{r.n}</span>
+      </span>
+      <span className="brief-footnote-text">
+        {r.title}
+        {r.page ? `, p.${r.page}` : ''}
+      </span>
+    </a>
+  </div>
+);
+
+// "Title, [1] p. 32, [2] p. 56": the document once, then each of its numbers.
+const GroupedRow: React.FC<{ group: DocGroup; onSourceClick: SourceClick }> = ({
+  group: g,
+  onSourceClick,
+}) => (
+  <div className="brief-footnote-group">
+    <span className="brief-footnote-text">{g.title}</span>
+    {g.cites.map((c, i) => (
+      <span className="brief-footnote-cite" key={`${c.n}-${c.page}-${i}`}>
+        {/* The number is shown once per run of the same citation, so a
+            document cited from many pages reads "[1] p. 9, p. 11" rather
+            than repeating "[1]". */}
+        {(i === 0 || g.cites[i - 1].n !== c.n) && (
+          <span className="citation-doc-group">
+            <a
+              href="#"
+              className="ai-summary-citation"
+              onClick={clickSource(onSourceClick, c.source)}
+            >
+              {c.n}
+            </a>
+          </span>
+        )}
+        {c.page ? (
+          <a
+            href="#"
+            className="brief-footnote-page-link"
+            onClick={clickSource(onSourceClick, c.source)}
+          >
+            {` p. ${c.page}`}
+          </a>
+        ) : null}
+      </span>
+    ))}
+  </div>
+);
+
+/**
+ * The compiled References list at the end of a brief, with the grouping
+ * toggles. The grouping also decides the citation numbering (see
+ * buildGlobalCitations), so switching it renumbers the inline `[n]` markers
+ * as well as this list.
+ */
+export const BriefReferences: React.FC<{
+  references: GlobalRef[];
+  grouping: ReferenceGrouping;
+  onGroupingChange: (grouping: ReferenceGrouping) => void;
+  onSourceClick: SourceClick;
+}> = ({ references, grouping, onGroupingChange, onSourceClick }) => {
+  if (references.length === 0) return null;
+  return (
+    <section className="brief-footnotes">
+      <div className="brief-footnotes-head">
+        <h2 className="brief-footnotes-title">References</h2>
+        <div className="brief-footnotes-group-toggles">
+          {GROUPING_OPTIONS.map((option) => (
+            <label className="brief-footnotes-group-toggle" key={option}>
+              <input
+                type="checkbox"
+                checked={grouping === option}
+                onChange={(e) => onGroupingChange(e.target.checked ? option : 'passage')}
+              />
+              {REFERENCE_GROUPING_LABELS[option]}
+            </label>
+          ))}
+        </div>
+      </div>
+      <div className="brief-footnotes-list">
+        {grouping === 'document-multiple'
+          ? groupReferencesByDoc(references).map((g) => (
+              <GroupedRow key={g.key} group={g} onSourceClick={onSourceClick} />
+            ))
+          : references.map((r) => (
+              <FlatRow key={r.n} reference={r} onSourceClick={onSourceClick} />
+            ))}
+      </div>
+    </section>
+  );
+};

--- a/ui/frontend/src/components/brief/BriefSeed.tsx
+++ b/ui/frontend/src/components/brief/BriefSeed.tsx
@@ -91,31 +91,33 @@ export const BriefSeed: React.FC<BriefSeedProps> = ({ brief }) => {
           rows={2}
         />
 
-        <div className="brief-seed-num">
-          <label className="brief-label" htmlFor="brief-numheadings">
-            Number of sections
-          </label>
-          <input
-            id="brief-numheadings"
-            type="number"
-            min={1}
-            max={20}
-            className="brief-number"
-            value={numHeadings}
-            onChange={(e) =>
-              setNumHeadings(Math.max(1, Math.min(20, Number(e.target.value) || 1)))
-            }
-          />
-        </div>
-        <div className="brief-seed-num brief-seed-length">
-          <label className="brief-label" htmlFor="brief-target-words">
-            Section length
-          </label>
-          <BriefLengthControl
-            id="brief-target-words"
-            value={targetWords}
-            onChange={setTargetWords}
-          />
+        <div className="brief-seed-num-row">
+          <div className="brief-seed-num">
+            <label className="brief-label" htmlFor="brief-numheadings">
+              Number of sections
+            </label>
+            <input
+              id="brief-numheadings"
+              type="number"
+              min={1}
+              max={20}
+              className="brief-number"
+              value={numHeadings}
+              onChange={(e) =>
+                setNumHeadings(Math.max(1, Math.min(20, Number(e.target.value) || 1)))
+              }
+            />
+          </div>
+          <div className="brief-seed-num brief-seed-length">
+            <label className="brief-label" htmlFor="brief-target-words">
+              Section length
+            </label>
+            <BriefLengthControl
+              id="brief-target-words"
+              value={targetWords}
+              onChange={setTargetWords}
+            />
+          </div>
         </div>
 
         {error && <div className="brief-error">{error}</div>}

--- a/ui/frontend/src/components/brief/BriefSeed.tsx
+++ b/ui/frontend/src/components/brief/BriefSeed.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { IconHistory, IconSparkle } from './BriefIcons';
+import { BriefLengthControl } from './BriefLengthControl';
 import { UseBriefReturn } from './useBrief';
 
 const tagClass = (tag: string): string => `brief-tag brief-tag-${tag.toLowerCase()}`;
@@ -42,6 +43,8 @@ export const BriefSeed: React.FC<BriefSeedProps> = ({ brief }) => {
     setInstructions,
     numHeadings,
     setNumHeadings,
+    targetWords,
+    setTargetWords,
     generateOutline,
     startManual,
     outlineLoading,
@@ -102,6 +105,16 @@ export const BriefSeed: React.FC<BriefSeedProps> = ({ brief }) => {
             onChange={(e) =>
               setNumHeadings(Math.max(1, Math.min(20, Number(e.target.value) || 1)))
             }
+          />
+        </div>
+        <div className="brief-seed-num brief-seed-length">
+          <label className="brief-label" htmlFor="brief-target-words">
+            Section length
+          </label>
+          <BriefLengthControl
+            id="brief-target-words"
+            value={targetWords}
+            onChange={setTargetWords}
           />
         </div>
 

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -4,11 +4,9 @@ import API_BASE_URL, { APP_BASE_PATH, USER_MODULE } from '../../config';
 import { useAuth } from '../../hooks/useAuth';
 import { SearchResult, SourceReference, SummaryModelConfig } from '../../types/api';
 import { SearchSettings } from '../../types/auth';
-import {
-  buildExportFilename,
-  exportResultsToDocxBlob,
-} from '../../utils/exportResultsToDocx';
+import { buildExportFilename, exportResultsToDocxBlob, ReferenceListLayout } from '../../utils/exportResultsToDocx';
 import { buildGlobalCitations } from './briefCitations';
+import { ReferenceGrouping } from './briefTypes';
 import { BriefCentral } from './BriefCentral';
 import {
   BriefRegenAllModal,
@@ -70,9 +68,9 @@ export const sourceToResult = (src: SourceReference, dataSource: string): Search
 /**
  * Flatten the brief into one Markdown body + a global SearchResult[] so it can
  * reuse the search summary's .docx exporter. Uses the same global citation
- * model as the on-screen render (combined by document), so `[n]` in the body
- * lines up with the references list and citations link to the source document
- * at the cited page.
+ * model (and the same reference grouping) as the on-screen render, so `[n]` in
+ * the body lines up with the references list and citations link to the source
+ * document at the cited page.
  */
 // Shown as a call-out box on the exported Word cover so readers treat the
 // AI-generated content as a draft to verify, not a finished product.
@@ -81,11 +79,18 @@ const BRIEF_DISCLAIMER =
   'Please verify any factual claims closely, and review for coverage and accuracy. ' +
   'This is meant as a guide for humans as part of the writing process, not as a final product.';
 
+// The Word export's references layout for each on-screen grouping.
+const REFERENCE_LIST_LAYOUT: Record<ReferenceGrouping, ReferenceListLayout> = {
+  passage: 'flat',
+  'document-multiple': 'grouped',
+  'document-single': 'document',
+};
+
 const assembleBriefForExport = (
   brief: ReturnType<typeof useBrief>,
   dataSource: string,
 ): { summary: string; results: SearchResult[] } => {
-  const { refs, display } = buildGlobalCitations(brief.sections);
+  const { refs, display } = buildGlobalCitations(brief.sections, brief.referenceGrouping);
   const lines: string[] = [];
   brief.sections.forEach((s, i) => {
     // The summary section's own H1 is the brief topic; sections sit one level
@@ -405,10 +410,9 @@ export const BriefTab: React.FC<BriefTabProps> = ({
           tableOfContents: true,
           resultsSectionTitle: 'References',
           // The document mirrors the on-screen References section: inline [n]
-          // citations and a compact list, grouped by document when the reader
-          // has that turned on.
+          // citations and a compact list laid out per the reader's grouping.
           citationStyle: 'links',
-          referenceList: brief.groupReferences ? 'grouped' : 'flat',
+          referenceList: REFERENCE_LIST_LAYOUT[brief.referenceGrouping],
           siteOrigin:
             typeof window !== 'undefined' && window.location ? window.location.origin : undefined,
           // Same API base the on-screen cards use to load table/figure

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -377,6 +377,7 @@ export const BriefTab: React.FC<BriefTabProps> = ({
       brief.setInstructions(args.instructions);
       brief.setNumHeadings(args.numHeadings);
       brief.setBriefVoiceId(args.voiceId);
+      brief.setTargetWords(args.targetWords);
       if (args.mode === 'ai') {
         void brief.generateOutline({
           topic: args.title,
@@ -453,7 +454,12 @@ export const BriefTab: React.FC<BriefTabProps> = ({
     ) : (
       <>
         {brief.error && <div className="brief-error brief-error-banner">{brief.error}</div>}
-        <BriefCentral central={central} onOpenBrief={openBrief} onCreateBrief={createBrief} />
+        <BriefCentral
+          central={central}
+          onOpenBrief={openBrief}
+          onCreateBrief={createBrief}
+          defaultTargetWords={brief.targetWords}
+        />
       </>
     )
   ) : (
@@ -521,8 +527,9 @@ export const BriefTab: React.FC<BriefTabProps> = ({
           voices={brief.voices}
           briefVoiceId={brief.briefVoiceId}
           instructions={brief.instructions}
+          targetWords={brief.targetWords}
           hasSectionVoices={brief.sections.some((s) => !!s.voiceId)}
-          onSubmit={({ instructions, voiceId, applyVoiceToAllSections }) => {
+          onSubmit={({ instructions, voiceId, targetWords, applyVoiceToAllSections }) => {
             if (applyVoiceToAllSections) {
               brief.sections.forEach((s) => {
                 if (s.voiceId) brief.setSectionVoiceId(s.id, null);
@@ -531,7 +538,7 @@ export const BriefTab: React.FC<BriefTabProps> = ({
             setWorkspaceModal(null);
             // Passed explicitly: the research loop reads refs, which React
             // would not have updated from the setters by the time it starts.
-            void brief.startResearch({ instructions, voiceId });
+            void brief.startResearch({ instructions, voiceId, targetWords });
           }}
           onClose={() => setWorkspaceModal(null)}
         />

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -3125,8 +3125,16 @@
 .brief-length-custom .brief-number {
   width: 90px;
 }
-.brief-seed-length {
-  margin-top: 12px;
+/* "Number of sections" and "Section length" side by side; each field keeps
+   its own label-then-control row, and they wrap when the card is narrow. */
+.brief-seed-num-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 32px;
+}
+.brief-seed-num-row .brief-seed-num {
+  margin-top: 16px;
 }
 /* Word count beside a researched section's title. */
 .brief-doc-section-words {

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -3104,3 +3104,35 @@
 .brief-comment .brief-comment-actions {
   margin-left: 29px;
 }
+
+/* ---------- section length target ---------- */
+.brief-length-control {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+}
+.brief-length-control .bc-select {
+  min-width: 220px;
+}
+.brief-length-custom {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--brand-text-secondary);
+}
+.brief-length-custom .brief-number {
+  width: 90px;
+}
+.brief-seed-length {
+  margin-top: 12px;
+}
+/* Word count beside a researched section's title. */
+.brief-doc-section-words {
+  flex: none;
+  margin-left: 10px;
+  font-size: 12px;
+  color: var(--brand-text-tertiary);
+  white-space: nowrap;
+}

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -2522,6 +2522,12 @@
   flex-wrap: wrap;
   gap: 10px;
 }
+.brief-footnotes-group-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 16px;
+}
 .brief-footnotes-group-toggle {
   display: inline-flex;
   align-items: center;
@@ -2536,9 +2542,10 @@
   height: 15px;
   cursor: pointer;
 }
-/* Grouped view: one document per row, with its citation numbers. */
-/* "Title, [1] p. 32, [2] p. 56" — the title then each inline citation with
-   the page it points at. */
+/* Grouped view (multiple per document): one document per row, with its
+   citation numbers — "Title, [1] p. 32, [2] p. 56", the title then each inline
+   citation with the page it points at. The single-per-document view reuses the
+   flat rows: "[1] Title", one number per document and no pages. */
 .brief-footnote-group {
   display: block;
   padding: 3px 0;

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -75,11 +75,17 @@
   flex-wrap: wrap;
   align-items: center;
 }
-/* The three buttons flow left and wrap left. "Load a saved brief" used to
-   carry margin-left: auto to sit apart on the right, but the card is capped at
-   720px (676px inside) and the buttons need about 675px, so the row only ever
-   fit on one line by a pixel; on any narrower window it wrapped and the auto
-   margin stranded that button alone on the right of its own line. */
+/* The three buttons share the row: at the card's full width (720px, 676px
+   inside) they sit on one line, and on a narrower window they wrap and each
+   line's buttons grow to fill it, so no button is ever stranded alone on the
+   right. Slightly tighter padding than the default button keeps the three
+   comfortably on one line at full width. */
+.brief-seed-actions .brief-btn {
+  flex: 1 1 auto;
+  padding-left: 18px;
+  padding-right: 18px;
+  white-space: nowrap;
+}
 
 /* ---------- buttons ---------- */
 .brief-btn {

--- a/ui/frontend/src/components/brief/brief.css
+++ b/ui/frontend/src/components/brief/brief.css
@@ -75,9 +75,11 @@
   flex-wrap: wrap;
   align-items: center;
 }
-.brief-seed-load {
-  margin-left: auto;
-}
+/* The three buttons flow left and wrap left. "Load a saved brief" used to
+   carry margin-left: auto to sit apart on the right, but the card is capped at
+   720px (676px inside) and the buttons need about 675px, so the row only ever
+   fit on one line by a pixel; on any narrower window it wrapped and the auto
+   margin stranded that button alone on the right of its own line. */
 
 /* ---------- buttons ---------- */
 .brief-btn {

--- a/ui/frontend/src/components/brief/briefCitations.ts
+++ b/ui/frontend/src/components/brief/briefCitations.ts
@@ -1,8 +1,22 @@
 import { SourceReference } from '../../types/api';
 import { extractCitedNumbers } from '../citations/CitedContent';
-import { BriefSection } from './briefTypes';
+import { BriefSection, ReferenceGrouping } from './briefTypes';
 
 const CITATION_RE = /\[(\d+(?:,\s*\d+)*)\]/g;
+// Two markers side by side that carry the same number(s) — `[1][1]`, `[1] [1]`.
+// Combining citations by document produces these wherever the model cited two
+// passages of one report back to back, and the reader should see `[1]` once.
+const ADJACENT_DUPLICATE_RE = /\[(\d+(?:, \d+)*)\]\s*\[\1\]/g;
+
+const collapseAdjacentDuplicates = (content: string): string => {
+  let out = content;
+  let prev: string;
+  do {
+    prev = out;
+    out = out.replace(ADJACENT_DUPLICATE_RE, '[$1]');
+  } while (out !== prev);
+  return out;
+};
 
 // Normalise a line to compare it against a heading title: drop markdown heading
 // hashes, leading "1." / "2.1" numbering, and emphasis markers.
@@ -46,24 +60,34 @@ export interface SectionDisplay {
   sources: SourceReference[];
 }
 
+/** The identity a citation number is assigned to: the cited passage (chunk),
+ *  or — for single-per-document grouping — the document itself. */
+const citationKey = (src: SourceReference, grouping: ReferenceGrouping): string =>
+  grouping === 'document-single'
+    ? `doc:${src.docId || src.title}`
+    : src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
+
 /**
- * Renumber citations across the whole brief into one consecutive sequence,
- * combined by document: every section's per-section `[n]` markers are remapped
- * to a global number (same document → same number everywhere), and the compiled
- * References list is built from the same global registry. Used for both the
- * on-screen render (inline citations, per-section Evidence panels, References)
- * and the Word export, so all three stay in sync as sections are researched.
+ * Renumber citations across the whole brief into one consecutive sequence:
+ * every section's per-section `[n]` markers are remapped to a global number,
+ * and the compiled References list is built from the same global registry.
+ * Used for both the on-screen render (inline citations, per-section Evidence
+ * panels, References) and the Word export, so all three stay in sync as
+ * sections are researched.
+ *
+ * With the default grouping there is one number per cited passage, exactly as
+ * the AI summary numbers its sources (assistant_graph assigns global_index per
+ * chunk): a report cited from p.32 and p.56 gets two numbers, and the reader
+ * can see which page each claim came from. With 'document-single' grouping
+ * every passage of a document shares one number and the reference carries no
+ * page, so the list reads at the document level only.
  */
 export const buildGlobalCitations = (
   sections: BriefSection[],
+  grouping: ReferenceGrouping = 'passage',
 ): { refs: GlobalRef[]; display: Map<string, SectionDisplay> } => {
-  // One citation number per cited passage, exactly as the AI summary numbers
-  // its sources (assistant_graph assigns global_index per chunk). A report
-  // cited from p.32 and p.56 therefore gets two numbers, and the reader can
-  // see which page each claim came from.
-  const chunkKey = (src: SourceReference): string =>
-    src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
-  const chunkToGlobal = new Map<string, number>();
+  const perDocument = grouping === 'document-single';
+  const keyToGlobal = new Map<string, number>();
   const refs: GlobalRef[] = [];
   // A section mid-Edit/Update (revising) keeps its old content on screen, so
   // it stays in the numbering — otherwise citations would jump twice per run.
@@ -74,10 +98,12 @@ export const buildGlobalCitations = (
     if (!isVisible(s)) return;
     extractCitedNumbers(s.content).forEach((localN) => {
       const src = s.sources.find((x) => x.index === localN);
-      if (!src || chunkToGlobal.has(chunkKey(src))) return;
+      if (!src || keyToGlobal.has(citationKey(src, grouping))) return;
       const n = refs.length + 1;
-      chunkToGlobal.set(chunkKey(src), n);
-      refs.push({ n, title: src.title, page: src.page, source: src });
+      keyToGlobal.set(citationKey(src, grouping), n);
+      // A document-level reference has no page; its source is the first cited
+      // passage, so clicking the reference still opens the document.
+      refs.push({ n, title: src.title, page: perDocument ? undefined : src.page, source: src });
     });
   });
   // Build per-section display content + sources keyed by the global number.
@@ -86,29 +112,41 @@ export const buildGlobalCitations = (
     if (!isVisible(s)) return;
     const localToGlobal = new Map<number, number>();
     const sources: SourceReference[] = [];
-    const seen = new Set<number>();
+    const byGlobal = new Map<number, SourceReference>();
     s.sources.forEach((src) => {
       if (src.index == null) return;
-      const g = chunkToGlobal.get(chunkKey(src));
+      const g = keyToGlobal.get(citationKey(src, grouping));
       if (g == null) return;
       localToGlobal.set(src.index, g);
-      // Each number belongs to one passage, so there is nothing to merge.
-      if (seen.has(g)) return;
-      seen.add(g);
-      sources.push({ ...src, index: g });
+      const existing = byGlobal.get(g);
+      if (!existing) {
+        const entry = { ...src, index: g };
+        byGlobal.set(g, entry);
+        sources.push(entry);
+        return;
+      }
+      // Per passage, each number belongs to one passage, so there is nothing to
+      // merge. Per document, the other passages ride along as variants so the
+      // hover card can still show the passage that supports the hovered claim.
+      if (perDocument && src.chunkId !== existing.chunkId) {
+        existing.variants = [...(existing.variants || []), src];
+      }
     });
-    const content = stripLeadingTitle(s.content, s.title).replace(CITATION_RE, (_m, nums: string) => {
-      const mapped = Array.from(
-        new Set(
-          nums
-            .split(',')
-            .map((x) => localToGlobal.get(parseInt(x.trim(), 10)))
-            .filter((g): g is number => g != null),
-        ),
-      );
-      return mapped.length ? `[${mapped.join(', ')}]` : '';
-    });
-    display.set(s.id, { content, sources });
+    const renumbered = stripLeadingTitle(s.content, s.title).replace(
+      CITATION_RE,
+      (_m, nums: string) => {
+        const mapped = Array.from(
+          new Set(
+            nums
+              .split(',')
+              .map((x) => localToGlobal.get(parseInt(x.trim(), 10)))
+              .filter((g): g is number => g != null),
+          ),
+        );
+        return mapped.length ? `[${mapped.join(', ')}]` : '';
+      },
+    );
+    display.set(s.id, { content: collapseAdjacentDuplicates(renumbered), sources });
   });
   return { refs, display };
 };

--- a/ui/frontend/src/components/brief/briefLength.ts
+++ b/ui/frontend/src/components/brief/briefLength.ts
@@ -1,0 +1,74 @@
+import configJson from '../../config.json';
+
+/**
+ * Section length target for briefs.
+ *
+ * A brief (or a single section) can ask for about N words per section. The
+ * target is enforced three ways: the backend prompt asks for that length, the
+ * token ceiling is raised to fit it, and — because models only approximate a
+ * word count — a finished section that overshoots by more than `tolerance` is
+ * condensed with an AI edit. The presets, bounds and tolerance come from
+ * config.json (application.brief.target_words), never from code.
+ */
+export interface BriefLengthPreset {
+  label: string;
+  words: number;
+}
+
+export interface BriefLengthConfig {
+  presets: BriefLengthPreset[];
+  min: number;
+  max: number;
+  // Fraction over the target a finished section may run before it is condensed.
+  tolerance: number;
+}
+
+const configured = (configJson as { application: { brief?: { target_words?: BriefLengthConfig } } })
+  .application.brief?.target_words;
+if (!configured) {
+  throw new Error('config.json is missing application.brief.target_words');
+}
+export const BRIEF_LENGTH: BriefLengthConfig = configured;
+
+const CITATION_MARKER_RE = /\[\d+(?:,\s*\d+)*\]/g;
+const MARKDOWN_SYNTAX_RE = /[#*_`>|]+/g;
+
+/** Words of prose in a section: inline [n] citation markers and markdown
+ *  syntax are not words. A word is any run of characters with at least one
+ *  letter or digit. */
+export const countWords = (markdown: string): number =>
+  (markdown || '')
+    .replace(CITATION_MARKER_RE, ' ')
+    .replace(MARKDOWN_SYNTAX_RE, ' ')
+    .split(/\s+/)
+    .filter((token) => /[\p{L}\p{N}]/u.test(token)).length;
+
+/** The most words a section may run before it is condensed. */
+export const maxWordsFor = (target: number, tolerance: number = BRIEF_LENGTH.tolerance): number =>
+  Math.round(target * (1 + tolerance));
+
+/** True when a section of `words` words overshoots `target` by more than the
+ *  tolerance. No target means nothing to enforce. */
+export const exceedsTarget = (
+  words: number,
+  target: number | null | undefined,
+  tolerance: number = BRIEF_LENGTH.tolerance,
+): boolean => !!target && words > maxWordsFor(target, tolerance);
+
+/** Clamp a user-entered target to the configured bounds. */
+export const clampTargetWords = (value: number): number =>
+  Math.min(BRIEF_LENGTH.max, Math.max(BRIEF_LENGTH.min, Math.round(value)));
+
+/** The AI-edit instruction that condenses an over-length section to its
+ *  target. Citations must survive: the section's sources are unchanged. */
+export const buildCondenseInstruction = (target: number, current: number): string =>
+  `Condense this section to approximately ${target} words (it is currently about ${current} words). ` +
+  'Keep every [n] citation marker attached to the claim it supports, keep the strongest and ' +
+  'best-cited evidence, and cut the weakest material rather than compressing every point into a fragment.';
+
+/** Label for a target, e.g. "Standard (~350 words)" or "~200 words". */
+export const describeTarget = (target: number | null | undefined): string => {
+  if (!target) return 'No target';
+  const preset = BRIEF_LENGTH.presets.find((entry) => entry.words === target);
+  return preset ? `${preset.label} (~${target} words)` : `~${target} words`;
+};

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -2,6 +2,15 @@ import { SourceReference } from '../../types/api';
 import { BriefActivityEvent } from '../../utils/briefStream';
 
 export type BriefStage = 'seed' | 'outline' | 'research' | 'done';
+
+// How the compiled References list is laid out — and, because the list and the
+// inline `[n]` markers share one numbering, how citations are numbered:
+//   'passage'           one number per cited passage; one row per number.
+//   'document-multiple' one number per cited passage; rows collapsed to one per
+//                       document, each number shown with its page.
+//   'document-single'   one number per document, no page numbers: every passage
+//                       of a document cites the same `[n]`.
+export type ReferenceGrouping = 'passage' | 'document-multiple' | 'document-single';
 export type SectionStatus = 'pending' | 'researching' | 'done';
 
 // What kind of AI operation produced a version of a section. `generate` is the
@@ -62,14 +71,6 @@ export interface BriefSection {
   guidance?: string;
   // Voice & tone profile override for this section (null/absent = brief default).
   voiceId?: string | null;
-}
-
-export interface BriefReference {
-  n: number;
-  title: string;
-  page?: number;
-  section: string;
-  source: SourceReference; // for click-through to the document preview
 }
 
 export interface SavedBriefSection {

--- a/ui/frontend/src/components/brief/briefTypes.ts
+++ b/ui/frontend/src/components/brief/briefTypes.ts
@@ -71,6 +71,9 @@ export interface BriefSection {
   guidance?: string;
   // Voice & tone profile override for this section (null/absent = brief default).
   voiceId?: string | null;
+  // Length target override for this section, in words (null/absent = the
+  // brief's target). See briefLength.ts.
+  targetWords?: number | null;
 }
 
 export interface SavedBriefSection {
@@ -86,6 +89,7 @@ export interface SavedBriefSection {
   lastResearchedAt?: number;
   voiceId?: string | null;
   guidance?: string;
+  targetWords?: number | null;
 }
 
 export interface SavedBrief {
@@ -105,6 +109,9 @@ export interface SavedBrief {
   activityId?: string;
   // Brief-level voice & tone profile id (sections may override individually).
   voiceId?: string | null;
+  // Brief-level section length target in words (sections may override).
+  // Absent/null = no target: the model decides.
+  targetWords?: number | null;
 }
 
 export const BRIEF_HISTORY_KEY = 'evidencelab_brief_history_v1';

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -16,10 +16,10 @@ import {
 } from '../../utils/briefStream';
 import {
   BRIEF_HISTORY_KEY,
-  BriefReference,
   BriefSection,
   BriefStage,
   DEFAULT_BRIEF_TITLE,
+  ReferenceGrouping,
   SavedBrief,
   SectionAuditEntry,
   VoiceProfile,
@@ -163,35 +163,6 @@ const computeNumbers = (sections: BriefSection[]): string[] => {
   });
 };
 
-// Compiled footnotes: the actually-cited sources across done sections, one
-// entry per document (grouped/deduped), like the search summary's references.
-const computeReferences = (sections: BriefSection[]): BriefReference[] => {
-  const seen = new Set<string>();
-  const refs: BriefReference[] = [];
-  sections.forEach((s) => {
-    // Sections mid-Edit/Update keep their (old) content on screen, so they
-    // keep their footnotes too — no renumbering while a revise runs.
-    if (s.status !== 'done' && !s.revising) return;
-    const cited = new Set(extractCitedNumbers(s.content));
-    s.sources.forEach((src: SourceReference) => {
-      if (src.index == null || !cited.has(src.index)) return;
-      // One entry per cited passage, matching the numbering in
-      // buildGlobalCitations (and the AI summary), not one per document.
-      const key = src.chunkId || `${src.docId}#${src.page ?? 'na'}`;
-      if (seen.has(key)) return;
-      seen.add(key);
-      refs.push({
-        n: refs.length + 1,
-        title: src.title,
-        page: src.page,
-        section: s.title,
-        source: src,
-      });
-    });
-  });
-  return refs;
-};
-
 export const useBrief = ({
   apiBaseUrl,
   dataSource,
@@ -211,9 +182,10 @@ export const useBrief = ({
   const [query, setQuery] = useState(''); // the brief topic
   const [instructions, setInstructions] = useState('');
   const [numHeadings, setNumHeadings] = useState(6);
-  // References list: one row per document (off) vs grouped by document (on).
-  // Also chooses how the Word export lays its references out.
-  const [groupReferences, setGroupReferences] = useState(false);
+  // How the References list is laid out and how citations are numbered (one
+  // number per passage or per document) — see ReferenceGrouping. Drives the
+  // inline [n] markers, the References list and the Word export together.
+  const [referenceGrouping, setReferenceGrouping] = useState<ReferenceGrouping>('passage');
   const [newHeading, setNewHeading] = useState('');
   const [regenFor, setRegenFor] = useState<string | null>(null);
   const [regenText, setRegenText] = useState('');
@@ -1354,7 +1326,6 @@ export const useBrief = ({
 
   // ---- derived ----
   const numbers = useMemo(() => computeNumbers(sections), [sections]);
-  const references = useMemo(() => computeReferences(sections), [sections]);
   const doneCount = sections.filter((s) => s.status === 'done').length;
   const totalProgress = sections.length
     ? Math.round(
@@ -1371,7 +1342,6 @@ export const useBrief = ({
     currentBriefId: briefIdRef.current,
     sections,
     numbers,
-    references,
     query,
     instructions,
     numHeadings,
@@ -1403,8 +1373,8 @@ export const useBrief = ({
     setError,
     setHistoryOpen,
     setBriefVoiceId,
-    groupReferences,
-    setGroupReferences,
+    referenceGrouping,
+    setReferenceGrouping,
     requestSourceHighlight,
     setSectionGuidance: (id: string, guidance: string) => updateSection(id, { guidance }),
     setSectionVoiceId: (id: string, voiceId: string | null) =>

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -3,6 +3,7 @@ import { SourceReference, SummaryModelConfig } from '../../types/api';
 import { SearchSettings } from '../../types/auth';
 import { useActivityLogging } from '../../hooks/useActivityLogging';
 import { extractCitedNumbers } from '../citations/CitedContent';
+import { buildCondenseInstruction, countWords, exceedsTarget } from './briefLength';
 import {
   BriefActivityEvent,
   BriefSourceSample,
@@ -186,6 +187,10 @@ export const useBrief = ({
   // number per passage or per document) — see ReferenceGrouping. Drives the
   // inline [n] markers, the References list and the Word export together.
   const [referenceGrouping, setReferenceGrouping] = useState<ReferenceGrouping>('passage');
+  // Section length target in words for this brief (sections may override);
+  // null = no target, the model decides. Persisted with the brief. See
+  // briefLength.ts for how it is enforced.
+  const [targetWords, setTargetWordsState] = useState<number | null>(null);
   const [newHeading, setNewHeading] = useState('');
   const [regenFor, setRegenFor] = useState<string | null>(null);
   const [regenText, setRegenText] = useState('');
@@ -221,6 +226,12 @@ export const useBrief = ({
   instructionsRef.current = instructions;
   const numberHeadingsRef = useRef(numberHeadings);
   numberHeadingsRef.current = numberHeadings;
+  // Read by the research loop, so it is written together with the state.
+  const targetWordsRef = useRef<number | null>(targetWords);
+  const setTargetWords = useCallback((target: number | null) => {
+    targetWordsRef.current = target;
+    setTargetWordsState(target);
+  }, []);
   const historyRef = useRef(history);
   historyRef.current = history;
   // Group search settings, read at research time so the research callbacks stay
@@ -237,6 +248,13 @@ export const useBrief = ({
   canEditRef.current = canEdit;
   // True once the current brief exists as a server row (remote mode).
   const remoteSavedRef = useRef(false);
+
+  // The team's default section length applies to a brief that has not started
+  // yet; once a brief is open its own (persisted) target stands.
+  const groupTargetWords = searchSettings?.briefTargetWords;
+  useEffect(() => {
+    if (stage === 'seed') setTargetWords(groupTargetWords ?? null);
+  }, [stage, groupTargetWords, setTargetWords]);
 
   // Resolve the style instructions for a section: its own profile wins, else
   // the brief default; null when neither is set (or the profile was deleted).
@@ -515,12 +533,14 @@ export const useBrief = ({
           lastResearchedAt: s.lastResearchedAt,
           voiceId: s.voiceId ?? undefined,
           guidance: s.guidance || undefined,
+          targetWords: s.targetWords ?? undefined,
         };
       }),
       outlineLog: outlineLogRef.current,
       numberHeadings: numberHeadingsRef.current,
       activityId: briefActivityIdRef.current ?? undefined,
       voiceId: briefVoiceIdRef.current,
+      targetWords: targetWordsRef.current ?? undefined,
     };
     if (remote) {
       pushRemoteSave(entry);
@@ -749,6 +769,75 @@ export const useBrief = ({
   );
 
   // ---- research engine ----
+  // Condense a finished section that overshot its length target: one AI edit
+  // of the current draft (sources and [n] markers unchanged), recorded in the
+  // section's log. The long draft stays on screen, greyed, until the condensed
+  // text arrives; on failure the long draft is kept and the error surfaced.
+  const condenseSection = useCallback(
+    async (
+      id: string,
+      // The just-finished draft and its sources, passed explicitly: the state
+      // update that stored them may not have rendered into sectionsRef yet.
+      priorContent: string,
+      priorSources: SourceReference[],
+      target: number,
+      words: number,
+      signal: AbortSignal,
+    ): Promise<void> => {
+      const section = sectionsRef.current.find((s) => s.id === id);
+      if (!section || signal.aborted) return;
+      updateSection(id, { status: 'researching', progress: 95, revising: true });
+      pushActivity(id, { tag: 'DRAFT', text: `Condensing to about ${target} words (was ${words})` });
+      try {
+        const revised = await requestBriefRevise({
+          apiBaseUrl,
+          dataSource,
+          content: priorContent,
+          instruction: buildCondenseInstruction(target, words),
+          voiceInstructions: voiceInstructionsFor(section.voiceId),
+          activityId: briefActivityIdRef.current,
+          signal,
+        });
+        if (signal.aborted) return;
+        const cur = sectionsRef.current.find((s) => s.id === id);
+        const entry: SectionAuditEntry = {
+          id: uid(),
+          kind: 'edit',
+          at: Date.now(),
+          instruction: buildCondenseInstruction(target, words),
+          sourceCount: priorSources.length,
+          addedSourceCount: 0,
+          before: priorContent,
+          after: revised,
+        };
+        const doneAt = Date.now();
+        const sources = priorSources.map(
+          ({ claimMatches: _cm, semanticMatches: _sm, ...rest }) => rest,
+        );
+        updateSection(id, {
+          status: 'done',
+          progress: 100,
+          content: revised,
+          sources,
+          audit: [...(cur?.audit || []), entry],
+          revising: undefined,
+        });
+        pushActivity(id, { tag: 'DONE', text: `Condensed to ${countWords(revised)} words` });
+        researchTokenRef.current[id] = doneAt;
+        setTimeout(() => enrichSectionHighlights(id, doneAt, revised, sources), 0);
+      } catch (e) {
+        if (signal.aborted) return;
+        updateSection(id, { status: 'done', progress: 100, revising: undefined });
+        setError(
+          `“${section.title}” came back at ${words} words against a target of ${target} and could not be condensed: ${
+            e instanceof Error ? e.message : 'condense failed'
+          }`,
+        );
+      }
+    },
+    [apiBaseUrl, dataSource, updateSection, pushActivity, voiceInstructionsFor, enrichSectionHighlights],
+  );
+
   const researchOne = useCallback(
     (
       id: string,
@@ -792,6 +881,11 @@ export const useBrief = ({
           : { status: 'researching', progress: 4, content: '', sources: [], activity: [] },
       );
       const briefTopic = queryRef.current.trim() || briefTitleRef.current;
+      // The section's own target wins over the brief's; null = no target.
+      const sectionTarget = section.targetWords ?? targetWordsRef.current;
+      // Set by onDone when the finished section overshoots its target; the
+      // research promise waits for it so a document-wide run stays sequential.
+      let condensePass: Promise<void> = Promise.resolve();
       return researchBriefSection({
         apiBaseUrl,
         dataSource,
@@ -809,6 +903,7 @@ export const useBrief = ({
         instruction,
         publishedAfterIso,
         voiceInstructions: voiceInstructionsFor(section.voiceId),
+        targetWords: sectionTarget,
         // The whole document structure (plus a gist of written sections), so
         // this section stays in scope and doesn't duplicate the others.
         outlineContext: buildOutlineContext(
@@ -835,7 +930,7 @@ export const useBrief = ({
             // A run that read sources but answered with process narration
             // ("I'll go research that…") instead of the section is a failure —
             // surface it and keep the section pending rather than storing it.
-            if (!isRevise && isLikelyNonAnswer(content, sources.length)) {
+            if (!isRevise && isLikelyNonAnswer(content, sources.length, sectionTarget)) {
               updateSection(id, { status: 'pending', progress: 0 });
               setError(
                 `The model did not return researched content for “${section.title}” — please try again.`,
@@ -875,6 +970,12 @@ export const useBrief = ({
             // synchronously so the deferred run can tell if it was superseded.
             researchTokenRef.current[id] = doneAt;
             setTimeout(() => enrichSectionHighlights(id, doneAt, content, sources), 0);
+            // A model only approximates a word count: a section that overshoots
+            // its target by more than the tolerance is condensed to it.
+            const words = countWords(content);
+            if (sectionTarget && exceedsTarget(words, sectionTarget)) {
+              condensePass = condenseSection(id, content, sources, sectionTarget, words, signal);
+            }
           },
           onError: (m) => {
             // A revise keeps its previous good content; a fresh research reverts.
@@ -887,14 +988,16 @@ export const useBrief = ({
             setError(m);
           },
         },
-      }).catch(() =>
-        updateSection(
-          id,
-          isRevise
-            ? { status: 'done', progress: 100, revising: undefined }
-            : { status: 'pending', progress: 0 },
-        ),
-      );
+      })
+        .catch(() =>
+          updateSection(
+            id,
+            isRevise
+              ? { status: 'done', progress: 100, revising: undefined }
+              : { status: 'pending', progress: 0 },
+          ),
+        )
+        .then(() => condensePass);
     },
     [
       apiBaseUrl,
@@ -904,6 +1007,7 @@ export const useBrief = ({
       pushActivity,
       voiceInstructionsFor,
       enrichSectionHighlights,
+      condenseSection,
     ],
   );
 
@@ -911,7 +1015,11 @@ export const useBrief = ({
   // refs as well as to state, because the research loop below reads the refs
   // and React will not have committed the setState by the time it runs.
   const startResearch = useCallback(
-    async (overrides?: { instructions?: string; voiceId?: string | null }) => {
+    async (overrides?: {
+      instructions?: string;
+      voiceId?: string | null;
+      targetWords?: number | null;
+    }) => {
       if (overrides?.instructions !== undefined) {
         instructionsRef.current = overrides.instructions;
         setInstructions(overrides.instructions);
@@ -920,6 +1028,7 @@ export const useBrief = ({
         briefVoiceIdRef.current = overrides.voiceId;
         setBriefVoiceId(overrides.voiceId);
       }
+      if (overrides?.targetWords !== undefined) setTargetWords(overrides.targetWords);
       const ids = sectionsRef.current.map((s) => s.id);
       if (!ids.length) return;
       setError(null);
@@ -938,7 +1047,7 @@ export const useBrief = ({
         saveCurrent();
       }
     },
-    [researchOne, saveCurrent],
+    [researchOne, saveCurrent, setTargetWords],
   );
 
   // Run "Get Updates" (fold in sources newer than each section's last run) on
@@ -1150,6 +1259,7 @@ export const useBrief = ({
       setCanEdit(access.canEdit);
       setOwnerName(access.ownerName);
       setBriefVoiceId(entry.voiceId ?? null);
+      setTargetWords(entry.targetWords ?? null);
       setSections(
         entry.sections.map((h) => ({
           ...makeSection(h.title, h.level),
@@ -1165,6 +1275,7 @@ export const useBrief = ({
           lastResearchedAt: h.lastResearchedAt,
           voiceId: h.voiceId ?? null,
           guidance: h.guidance || '',
+          targetWords: h.targetWords ?? null,
         })),
       );
       setGeneratingActivity(entry.outlineLog || []);
@@ -1334,6 +1445,10 @@ export const useBrief = ({
       )
     : 0;
   const totalSources = sections.reduce((a, s) => a + s.sources.length, 0);
+  const totalWords = useMemo(
+    () => sections.reduce((a, s) => a + (s.status === 'done' ? countWords(s.content) : 0), 0),
+    [sections],
+  );
 
   return {
     // state
@@ -1357,6 +1472,8 @@ export const useBrief = ({
     doneCount,
     totalProgress,
     totalSources,
+    totalWords,
+    targetWords,
     briefVoiceId,
     canEdit,
     ownerName,
@@ -1375,6 +1492,9 @@ export const useBrief = ({
     setBriefVoiceId,
     referenceGrouping,
     setReferenceGrouping,
+    setTargetWords,
+    setSectionTargetWords: (id: string, target: number | null) =>
+      updateSection(id, { targetWords: target }),
     requestSourceHighlight,
     setSectionGuidance: (id: string, guidance: string) => updateSection(id, { guidance }),
     setSectionVoiceId: (id: string, voiceId: string | null) =>

--- a/ui/frontend/src/components/citations/CitedContent.tsx
+++ b/ui/frontend/src/components/citations/CitedContent.tsx
@@ -416,7 +416,8 @@ const RefGroupLinks: React.FC<{
   group: DocGroup;
   sources: SourceReference[];
   onSourceClick?: (source: SourceReference) => void;
-}> = ({ group, sources, onSourceClick }) => (
+  hidePages?: boolean;
+}> = ({ group, sources, onSourceClick, hidePages }) => (
   <div className="ai-summary-ref-group">
     {group.title}
     {' | '}
@@ -435,7 +436,7 @@ const RefGroupLinks: React.FC<{
           <span className="citation-doc-group">
             <span className="ai-summary-citation">{idx}</span>
           </span>
-          {group.page ? ` p.${group.page}` : ''}
+          {!hidePages && group.page ? ` p.${group.page}` : ''}
         </a>
       </React.Fragment>
     ))}
@@ -450,6 +451,9 @@ export const CitedReferences: React.FC<{
   collapsible?: boolean;
   labelPrefix?: string;
   className?: string;
+  // Document-level citations (one number per document): list the documents
+  // without page numbers.
+  hidePages?: boolean;
 }> = ({
   content,
   sources,
@@ -457,6 +461,7 @@ export const CitedReferences: React.FC<{
   collapsible = true,
   labelPrefix = 'References',
   className = '',
+  hidePages = false,
 }) => {
   const [expanded, setExpanded] = useState(!collapsible);
   const groups = useMemo(() => groupCitedSourcesByDoc(content, sources), [content, sources]);
@@ -473,6 +478,7 @@ export const CitedReferences: React.FC<{
           group={group}
           sources={sources}
           onSourceClick={onSourceClick}
+          hidePages={hidePages}
         />
       ))}
     </div>

--- a/ui/frontend/src/hooks/useGroupDefaults.ts
+++ b/ui/frontend/src/hooks/useGroupDefaults.ts
@@ -60,9 +60,12 @@ function applyGroupDefaults(defaults: SearchSettings, setters: Setters): void {
       setters[key](value);
     }
   }
-  // greetingMessage has no URL param — apply directly if present
+  // greetingMessage and briefTargetWords have no URL param — apply directly
   if (defaults.greetingMessage !== undefined && setters.greetingMessage) {
     setters.greetingMessage(defaults.greetingMessage);
+  }
+  if (defaults.briefTargetWords !== undefined && setters.briefTargetWords) {
+    setters.briefTargetWords(defaults.briefTargetWords);
   }
 }
 

--- a/ui/frontend/src/tests/assistantStreamTargetWords.test.ts
+++ b/ui/frontend/src/tests/assistantStreamTargetWords.test.ts
@@ -1,0 +1,35 @@
+import { streamAssistantChat } from '../utils/assistantStream';
+
+jest.mock('../config', () => ({ __esModule: true, default: '/api', API_KEY: undefined }));
+
+describe('streamAssistantChat target_words', () => {
+  const originalFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  const captureBody = async (extra: Record<string, unknown>) => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 500, statusText: 'nope', text: async () => '' });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const handlers = {
+      onPhase: jest.fn(), onPlan: jest.fn(), onSearchStatus: jest.fn(), onToken: jest.fn(),
+      onSources: jest.fn(), onDone: jest.fn(), onError: jest.fn(),
+    };
+    try {
+      await streamAssistantChat({ apiBaseUrl: '/api', query: 'q', dataSource: 'wfp', deepResearch: true, handlers, ...extra } as any);
+    } catch {
+      // the fake response is not a stream; only the request matters here
+    }
+    return JSON.parse(fetchMock.mock.calls[0][1].body);
+  };
+
+  test('sends the length target to the backend', async () => {
+    const body = await captureBody({ targetWords: 350 });
+    expect(body.target_words).toBe(350);
+  });
+
+  test('omits the field when there is no target', async () => {
+    expect(await captureBody({})).not.toHaveProperty('target_words');
+    expect(await captureBody({ targetWords: null })).not.toHaveProperty('target_words');
+  });
+});

--- a/ui/frontend/src/tests/briefCitations.test.ts
+++ b/ui/frontend/src/tests/briefCitations.test.ts
@@ -189,3 +189,106 @@ describe('footnotes react to citation changes', () => {
     expect(display.get('a')?.content).toBe('Still on screen [1].');
   });
 });
+
+describe('buildGlobalCitations with single-per-document grouping', () => {
+  // Doc One is cited from three pages, Doc Two and Doc Three once each.
+  const sections: BriefSection[] = [
+    section({
+      id: 'a',
+      content: 'A fact happened. [1][3] Then something else [2][4][5]',
+      sources: [
+        src({ index: 1, docId: 'doc1', title: 'Doc One', page: 10 }),
+        src({ index: 2, docId: 'doc2', title: 'Doc Two', page: 4 }),
+        src({ index: 3, docId: 'doc1', title: 'Doc One', page: 20 }),
+        src({ index: 4, docId: 'doc3', title: 'Doc Three', page: 7 }),
+        src({ index: 5, docId: 'doc1', title: 'Doc One', page: 30 }),
+      ],
+    }),
+  ];
+
+  test('per passage (default): one number per page, references carry pages', () => {
+    const { refs, display } = buildGlobalCitations(sections, 'passage');
+    expect(refs.map((r) => [r.n, r.title, r.page])).toEqual([
+      [1, 'Doc One', 10],
+      [2, 'Doc Two', 4],
+      [3, 'Doc One', 20],
+      [4, 'Doc Three', 7],
+      [5, 'Doc One', 30],
+    ]);
+    expect(display.get('a')?.content).toBe(
+      'A fact happened. [1][3] Then something else [2][4][5]',
+    );
+  });
+
+  test('per document: one number per document, no pages, prose renumbered', () => {
+    const { refs, display } = buildGlobalCitations(sections, 'document-single');
+    expect(refs.map((r) => [r.n, r.title, r.page])).toEqual([
+      [1, 'Doc One', undefined],
+      [2, 'Doc Two', undefined],
+      [3, 'Doc Three', undefined],
+    ]);
+    // [1][3] were both Doc One, so they collapse to a single [1]; [5] is
+    // Doc One again and keeps that number.
+    expect(display.get('a')?.content).toBe('A fact happened. [1] Then something else [2][3][1]');
+  });
+
+  test('per document: the reference opens the first cited passage of the document', () => {
+    const { refs } = buildGlobalCitations(sections, 'document-single');
+    expect(refs[0].source.page).toBe(10);
+    expect(refs[0].source.docId).toBe('doc1');
+  });
+
+  test('per document: the other passages ride along as variants of the display source', () => {
+    const { display } = buildGlobalCitations(sections, 'document-single');
+    const sources = display.get('a')!.sources;
+    expect(sources.map((x) => x.index)).toEqual([1, 2, 3]);
+    const docOne = sources.find((x) => x.index === 1)!;
+    expect(docOne.page).toBe(10);
+    expect((docOne.variants || []).map((v) => v.page)).toEqual([20, 30]);
+    // Single-passage documents carry no variants.
+    expect(sources.find((x) => x.index === 2)!.variants).toBeUndefined();
+  });
+
+  test('per document: one number for a document cited across sections', () => {
+    const two: BriefSection[] = [
+      section({
+        id: 'a',
+        content: 'First [1].',
+        sources: [src({ index: 1, docId: 'doc1', title: 'Doc One', page: 1 })],
+      }),
+      section({
+        id: 'b',
+        content: 'Second [7] and [8].',
+        sources: [
+          src({ index: 7, docId: 'doc2', title: 'Doc Two', page: 2 }),
+          src({ index: 8, docId: 'doc1', title: 'Doc One', page: 9 }),
+        ],
+      }),
+    ];
+    const { refs, display } = buildGlobalCitations(two, 'document-single');
+    expect(refs.map((r) => r.title)).toEqual(['Doc One', 'Doc Two']);
+    expect(display.get('b')?.content).toBe('Second [2] and [1].');
+  });
+
+  test('per document: a combined marker citing one document twice reads once', () => {
+    const one: BriefSection[] = [
+      section({
+        id: 'a',
+        content: 'Claim [1, 2].',
+        sources: [
+          src({ index: 1, docId: 'doc1', title: 'Doc One', page: 1 }),
+          src({ index: 2, docId: 'doc1', title: 'Doc One', page: 5 }),
+        ],
+      }),
+    ];
+    expect(buildGlobalCitations(one, 'document-single').display.get('a')?.content).toBe(
+      'Claim [1].',
+    );
+  });
+
+  test('multiple-per-document grouping numbers exactly like per passage', () => {
+    expect(buildGlobalCitations(sections, 'document-multiple')).toEqual(
+      buildGlobalCitations(sections, 'passage'),
+    );
+  });
+});

--- a/ui/frontend/src/tests/briefLength.test.ts
+++ b/ui/frontend/src/tests/briefLength.test.ts
@@ -1,0 +1,91 @@
+import {
+  BRIEF_LENGTH,
+  buildCondenseInstruction,
+  clampTargetWords,
+  countWords,
+  describeTarget,
+  exceedsTarget,
+  maxWordsFor,
+} from '../components/brief/briefLength';
+import { isLikelyNonAnswer } from '../utils/briefStream';
+
+describe('brief length config', () => {
+  test('is read from config.json with presets, bounds and a tolerance', () => {
+    expect(BRIEF_LENGTH.presets.map((p) => p.label)).toEqual(['Short', 'Standard', 'Long']);
+    expect(BRIEF_LENGTH.min).toBeLessThan(BRIEF_LENGTH.presets[0].words);
+    expect(BRIEF_LENGTH.max).toBeGreaterThan(BRIEF_LENGTH.presets[2].words);
+    expect(BRIEF_LENGTH.tolerance).toBeGreaterThan(0);
+  });
+});
+
+describe('countWords', () => {
+  test('counts prose words and ignores citation markers and markdown syntax', () => {
+    expect(countWords('Enrolment rose by 12% in 2023 [1]. It fell later [2, 3].')).toBe(9);
+    expect(countWords('## Heading\n\n- **bold** item\n- _em_ item')).toBe(5);
+    expect(countWords('')).toBe(0);
+    expect(countWords('[1][2] --- ***')).toBe(0);
+  });
+
+  test('counts words in any script', () => {
+    expect(countWords('L’évaluation a constaté une hausse')).toBe(5);
+    expect(countWords('评估 发现 入学率 上升')).toBe(4);
+  });
+});
+
+describe('exceedsTarget', () => {
+  test('allows the tolerance band above the target', () => {
+    expect(maxWordsFor(400, 0.25)).toBe(500);
+    expect(exceedsTarget(500, 400, 0.25)).toBe(false);
+    expect(exceedsTarget(501, 400, 0.25)).toBe(true);
+  });
+
+  test('no target means nothing to enforce', () => {
+    expect(exceedsTarget(5000, null)).toBe(false);
+    expect(exceedsTarget(5000, undefined)).toBe(false);
+  });
+
+  test('uses the configured tolerance by default', () => {
+    const limit = Math.round(200 * (1 + BRIEF_LENGTH.tolerance));
+    expect(exceedsTarget(limit, 200)).toBe(false);
+    expect(exceedsTarget(limit + 1, 200)).toBe(true);
+  });
+});
+
+describe('clampTargetWords / describeTarget', () => {
+  test('clamps to the configured range and rounds', () => {
+    expect(clampTargetWords(1)).toBe(BRIEF_LENGTH.min);
+    expect(clampTargetWords(999999)).toBe(BRIEF_LENGTH.max);
+    expect(clampTargetWords(333.4)).toBe(333);
+  });
+
+  test('names presets and custom targets', () => {
+    expect(describeTarget(350)).toBe('Standard (~350 words)');
+    expect(describeTarget(275)).toBe('~275 words');
+    expect(describeTarget(null)).toBe('No target');
+  });
+});
+
+describe('buildCondenseInstruction', () => {
+  test('states the target, the current length and keeps citations', () => {
+    const instruction = buildCondenseInstruction(150, 240);
+    expect(instruction).toContain('approximately 150 words');
+    expect(instruction).toContain('currently about 240 words');
+    expect(instruction).toContain('[n] citation marker');
+  });
+});
+
+describe('isLikelyNonAnswer with a length target', () => {
+  const short = 'The programme raised enrolment across the districts it covered. '.repeat(6); // ~390 chars
+
+  test('without a target, short uncited text after reading sources is a non-answer', () => {
+    expect(isLikelyNonAnswer(short, 5)).toBe(true);
+  });
+
+  test('with a short target, the same text is a complete answer', () => {
+    expect(isLikelyNonAnswer(short, 5, 100)).toBe(false);
+  });
+
+  test('a target never raises the bar above the default', () => {
+    expect(isLikelyNonAnswer(short, 5, 2000)).toBe(true);
+  });
+});

--- a/ui/frontend/src/tests/briefLengthControl.test.tsx
+++ b/ui/frontend/src/tests/briefLengthControl.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BriefLengthControl } from '../components/brief/BriefLengthControl';
+import { BRIEF_LENGTH } from '../components/brief/briefLength';
+
+const LENGTH = 'Length';
+const CUSTOM_INPUT = 'Target words per section';
+
+describe('BriefLengthControl', () => {
+  test('offers no target, the configured presets and custom', () => {
+    render(<BriefLengthControl value={null} onChange={jest.fn()} ariaLabel={LENGTH} />);
+    const options = Array.from(screen.getByRole('combobox', { name: LENGTH }).querySelectorAll('option')).map(
+      (o) => o.textContent,
+    );
+    expect(options).toEqual([
+      'No target (model decides)',
+      ...BRIEF_LENGTH.presets.map((p) => `${p.label} (~${p.words} words)`),
+      'Custom…',
+    ]);
+  });
+
+  test('picking a preset reports its word count; picking no target reports null', () => {
+    const onChange = jest.fn();
+    render(<BriefLengthControl value={null} onChange={onChange} ariaLabel={LENGTH} />);
+    fireEvent.change(screen.getByRole('combobox', { name: LENGTH }), { target: { value: '150' } });
+    expect(onChange).toHaveBeenLastCalledWith(150);
+    fireEvent.change(screen.getByRole('combobox', { name: LENGTH }), { target: { value: 'none' } });
+    expect(onChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test('custom shows a number input and clamps to the configured range on commit', () => {
+    const onChange = jest.fn();
+    render(<BriefLengthControl value={null} onChange={onChange} ariaLabel={LENGTH} />);
+    fireEvent.change(screen.getByRole('combobox', { name: LENGTH }), { target: { value: 'custom' } });
+    const input = screen.getByRole('spinbutton', { name: CUSTOM_INPUT });
+    fireEvent.change(input, { target: { value: '275' } });
+    fireEvent.blur(input);
+    expect(onChange).toHaveBeenLastCalledWith(275);
+    fireEvent.change(input, { target: { value: '999999' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onChange).toHaveBeenLastCalledWith(BRIEF_LENGTH.max);
+  });
+
+  test('a non-preset value opens in custom mode showing that value', () => {
+    render(<BriefLengthControl value={275} onChange={jest.fn()} ariaLabel={LENGTH} />);
+    expect(screen.getByRole('combobox', { name: LENGTH })).toHaveValue('custom');
+    expect(screen.getByRole('spinbutton', { name: CUSTOM_INPUT })).toHaveValue(275);
+  });
+
+  test('per-section use offers an inherit option that reports null', () => {
+    const onChange = jest.fn();
+    render(
+      <BriefLengthControl value={350} onChange={onChange} inheritLabel="Use brief target — Short (~150 words)" ariaLabel={LENGTH} />,
+    );
+    expect(screen.getByRole('combobox', { name: LENGTH })).toHaveValue('350');
+    fireEvent.change(screen.getByRole('combobox', { name: LENGTH }), { target: { value: 'inherit' } });
+    expect(onChange).toHaveBeenLastCalledWith(null);
+    expect(screen.queryByText('No target (model decides)')).toBeNull();
+  });
+});

--- a/ui/frontend/src/tests/briefReferences.test.tsx
+++ b/ui/frontend/src/tests/briefReferences.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BriefReferences } from '../components/brief/BriefReferences';
+import { GlobalRef } from '../components/brief/briefCitations';
+import { SourceReference } from '../types/api';
+
+const MULTIPLE = 'Group by document (multiple per document)';
+const SINGLE = 'Group by document (single per document)';
+
+const src = (docId: string, title: string, page: number): SourceReference => ({
+  chunkId: `${docId}-${page}`,
+  docId,
+  title,
+  text: '',
+  score: 0,
+  page,
+});
+
+// Per-passage numbering: Doc One cited from p.32 and p.56, Doc Two from p.4.
+const PER_PASSAGE: GlobalRef[] = [
+  { n: 1, title: 'Doc One', page: 32, source: src('d1', 'Doc One', 32) },
+  { n: 2, title: 'Doc Two', page: 4, source: src('d2', 'Doc Two', 4) },
+  { n: 3, title: 'Doc One', page: 56, source: src('d1', 'Doc One', 56) },
+];
+
+// Per-document numbering: no pages on the references.
+const PER_DOCUMENT: GlobalRef[] = [
+  { n: 1, title: 'Doc One', source: src('d1', 'Doc One', 32) },
+  { n: 2, title: 'Doc Two', source: src('d2', 'Doc Two', 4) },
+];
+
+describe('BriefReferences', () => {
+  test('offers both grouping checkboxes, unticked by default', () => {
+    render(
+      <BriefReferences references={PER_PASSAGE} grouping="passage" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    expect(screen.getByRole('checkbox', { name: MULTIPLE })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: SINGLE })).not.toBeChecked();
+  });
+
+  test('renders nothing when there are no references', () => {
+    const view = render(
+      <BriefReferences references={[]} grouping="passage" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    expect(view.container).toBeEmptyDOMElement();
+  });
+
+  test('ticking a checkbox selects that grouping; unticking returns to per passage', () => {
+    const onChange = jest.fn();
+    const view = render(
+      <BriefReferences references={PER_PASSAGE} grouping="passage" onGroupingChange={onChange} onSourceClick={jest.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: SINGLE }));
+    expect(onChange).toHaveBeenLastCalledWith('document-single');
+
+    view.rerender(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={onChange} onSourceClick={jest.fn()} />,
+    );
+    expect(screen.getByRole('checkbox', { name: SINGLE })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: MULTIPLE })).not.toBeChecked();
+    fireEvent.click(screen.getByRole('checkbox', { name: SINGLE }));
+    expect(onChange).toHaveBeenLastCalledWith('passage');
+  });
+
+  test('the two groupings are exclusive: ticking one replaces the other', () => {
+    const onChange = jest.fn();
+    render(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={onChange} onSourceClick={jest.fn()} />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: MULTIPLE }));
+    expect(onChange).toHaveBeenLastCalledWith('document-multiple');
+  });
+
+  test('per passage: one row per citation with its page', () => {
+    render(
+      <BriefReferences references={PER_PASSAGE} grouping="passage" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    const rows = document.querySelectorAll('.brief-footnote-row');
+    expect(Array.from(rows).map((r) => r.textContent)).toEqual([
+      '1Doc One, p.32',
+      '2Doc Two, p.4',
+      '3Doc One, p.56',
+    ]);
+  });
+
+  test('multiple per document: one row per document with each number and page', () => {
+    render(
+      <BriefReferences references={PER_PASSAGE} grouping="document-multiple" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    const rows = document.querySelectorAll('.brief-footnote-group');
+    expect(Array.from(rows).map((r) => r.textContent)).toEqual([
+      'Doc One1 p. 323 p. 56',
+      'Doc Two2 p. 4',
+    ]);
+  });
+
+  test('single per document: one row per document, numbered, with no page numbers', () => {
+    render(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={jest.fn()} onSourceClick={jest.fn()} />,
+    );
+    const rows = document.querySelectorAll('.brief-footnote-row');
+    expect(Array.from(rows).map((r) => r.textContent)).toEqual(['1Doc One', '2Doc Two']);
+    expect(document.body.textContent).not.toMatch(/p\.\s*\d/);
+  });
+
+  test('clicking a document-level reference opens its first cited passage', () => {
+    const onSourceClick = jest.fn();
+    render(
+      <BriefReferences references={PER_DOCUMENT} grouping="document-single" onGroupingChange={jest.fn()} onSourceClick={onSourceClick} />,
+    );
+    fireEvent.click(screen.getByText('Doc One'));
+    expect(onSourceClick).toHaveBeenCalledWith(expect.objectContaining({ docId: 'd1', page: 32 }));
+  });
+});

--- a/ui/frontend/src/tests/briefTab.test.tsx
+++ b/ui/frontend/src/tests/briefTab.test.tsx
@@ -177,4 +177,53 @@ describe('BriefTab (Document Builder)', () => {
     // Brief name is capitalised too.
     expect(screen.getByDisplayValue('Cash Assistance')).toBeInTheDocument();
   });
+
+  test('single-per-document grouping renumbers the inline citations and the References list', () => {
+    const src = (index: number, docId: string, title: string, page: number) => ({
+      chunkId: `${docId}-${page}`, docId, title, text: 'passage', score: 0, page, index,
+    });
+    localStorage.setItem(
+      'evidencelab_brief_history_v1',
+      JSON.stringify([
+        {
+          id: 'b1', title: 'Cited brief', query: 'q', date: 1, sectionCount: 1, sourceCount: 5,
+          sections: [
+            {
+              id: 's1', title: 'Findings', level: 1, status: 'done',
+              content: 'A fact happened. [1][3] Then something else [2][4][5]',
+              sources: [
+                src(1, 'doc1', 'Doc One', 10), src(2, 'doc2', 'Doc Two', 4), src(3, 'doc1', 'Doc One', 20),
+                src(4, 'doc3', 'Doc Three', 7), src(5, 'doc1', 'Doc One', 30),
+              ],
+            },
+          ],
+        },
+      ]),
+    );
+    render(<BriefTab dataSource="wfp" />);
+    fireEvent.click(screen.getByText('Write my own headings'));
+    fireEvent.click(screen.getByText('Cited brief'));
+
+    const inlineNumbers = () =>
+      Array.from(document.querySelectorAll('.brief-doc-content .ai-summary-citation')).map((el) => el.textContent);
+    const referenceRows = () =>
+      Array.from(document.querySelectorAll('.brief-footnotes-list .brief-footnote-row')).map((el) => el.textContent);
+
+    // Default: one number per cited passage, references carry pages.
+    expect(inlineNumbers()).toEqual(['1', '3', '2', '4', '5']);
+    expect(referenceRows()).toEqual([
+      '1Doc One, p.10', '2Doc Two, p.4', '3Doc One, p.20', '4Doc Three, p.7', '5Doc One, p.30',
+    ]);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Group by document (single per document)' }));
+
+    // One number per document: [1][3] collapses to [1], [5] becomes [1], and
+    // the list has one row per document with no page numbers.
+    expect(inlineNumbers()).toEqual(['1', '2', '3', '1']);
+    expect(referenceRows()).toEqual(['1Doc One', '2Doc Two', '3Doc Three']);
+
+    // Back off: the original per-passage numbering returns.
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Group by document (single per document)' }));
+    expect(inlineNumbers()).toEqual(['1', '3', '2', '4', '5']);
+  });
 });

--- a/ui/frontend/src/tests/briefTargetLength.test.tsx
+++ b/ui/frontend/src/tests/briefTargetLength.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { BriefTab } from '../components/brief/BriefTab';
+
+jest.mock('../config', () => ({
+  __esModule: true,
+  default: '/api',
+  API_KEY: undefined,
+  USER_MODULE: false,
+}));
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({ user: null }),
+}));
+// Activity logging posts each auto-save; resolve it so the save path is exercised.
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn().mockResolvedValue({ data: [] }),
+    post: jest.fn().mockResolvedValue({ data: {} }),
+    put: jest.fn().mockResolvedValue({ data: {} }),
+    delete: jest.fn().mockResolvedValue({ data: {} }),
+  },
+}));
+
+// Keep the real helpers (isLikelyNonAnswer etc.); stub only the network calls.
+const mockRequestOutline = jest.fn();
+const mockResearchSection = jest.fn();
+const mockRunDeepResearch = jest.fn();
+const mockRequestRevise = jest.fn();
+jest.mock('../utils/briefStream', () => ({
+  __esModule: true,
+  ...jest.requireActual('../utils/briefStream'),
+  requestBriefOutline: (...args: unknown[]) => mockRequestOutline(...args),
+  researchBriefSection: (...args: unknown[]) => mockResearchSection(...args),
+  runDeepResearch: (...args: unknown[]) => mockRunDeepResearch(...args),
+  requestBriefRevise: (...args: unknown[]) => mockRequestRevise(...args),
+}));
+
+const SHORT_OPTION = '150'; // the "Short" preset
+const START = 'Start deep research →';
+const MANUAL = 'Write my own headings';
+const sentence = 'The programme raised enrolment in the districts it covered [1]. ';
+// Nine prose words per sentence (the [1] marker is not a word).
+const longText = sentence.repeat(30); // 270 words, well over the Short target
+const condensedText = sentence.repeat(14); // 126 words, within tolerance of 150
+const source = { chunkId: 'c1', docId: 'd1', title: 'Doc', text: 'x', score: 0.5, page: 1, index: 1 };
+
+// A researched section: the mock resolves with a source and the given content.
+const answerWith = (content: string) => async ({ handlers }: any) => {
+  handlers.onSources([source]);
+  handlers.onDone({ content, sources: [source] });
+};
+
+describe('Brief section length target', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    // CRA's jest config resets mock implementations before each test, so the
+    // activity-log post must be re-armed here or its .catch() has no promise.
+    (axios.post as jest.Mock).mockResolvedValue({ data: {} });
+    mockRunDeepResearch.mockImplementation(async ({ handlers }: any) => {
+      handlers.onSources([]);
+      handlers.onDone({ content: '', sources: [] });
+    });
+  });
+
+  const startManualBriefWithShortTarget = () => {
+    render(<BriefTab dataSource="wfp" />);
+    fireEvent.change(screen.getByLabelText('Section length'), { target: { value: SHORT_OPTION } });
+    fireEvent.click(screen.getByText(MANUAL));
+  };
+
+  // "Start deep research" opens the Regenerate-all modal, whose Length control
+  // is pre-filled with the brief's target; submitting it starts the run.
+  const runDeepResearch = () => {
+    fireEvent.click(screen.getByText(START));
+    expect(screen.getByLabelText('Section length')).toHaveValue(SHORT_OPTION);
+    fireEvent.click(screen.getByRole('button', { name: /Regenerate all sections/ }));
+  };
+
+  test('the seed screen target is sent with every section research request', async () => {
+    mockResearchSection.mockImplementation(answerWith(condensedText));
+    startManualBriefWithShortTarget();
+    runDeepResearch();
+    await waitFor(() => expect(screen.getAllByText('126 words').length).toBeGreaterThan(0));
+    expect(mockResearchSection).toHaveBeenCalled();
+    mockResearchSection.mock.calls.forEach(([args]) => expect(args.targetWords).toBe(150));
+    // 126 words is within the tolerance band of 150: no condense pass.
+    expect(mockRequestRevise).not.toHaveBeenCalled();
+  });
+
+  test('a section that overshoots the target is condensed with an AI edit that keeps citations', async () => {
+    mockResearchSection.mockImplementation(answerWith(longText));
+    mockRequestRevise.mockResolvedValue(condensedText);
+    startManualBriefWithShortTarget();
+    runDeepResearch();
+
+    await waitFor(() => expect(mockRequestRevise).toHaveBeenCalled());
+    const [reviseArgs] = mockRequestRevise.mock.calls[0];
+    expect(reviseArgs.content).toBe(longText);
+    expect(reviseArgs.instruction).toContain('approximately 150 words');
+    expect(reviseArgs.instruction).toContain('currently about 270 words');
+    expect(reviseArgs.instruction).toContain('[n] citation marker');
+
+    // The condensed text replaces the long draft, and the count reflects it.
+    await waitFor(() => expect(screen.getAllByText('126 words').length).toBeGreaterThan(0));
+    expect(screen.queryByText('270 words')).toBeNull();
+  });
+
+  test('with no target nothing is condensed', async () => {
+    mockResearchSection.mockImplementation(answerWith(longText));
+    render(<BriefTab dataSource="wfp" />);
+    fireEvent.click(screen.getByText(MANUAL));
+    fireEvent.click(screen.getByText(START));
+    expect(screen.getByLabelText('Section length')).toHaveValue('none');
+    fireEvent.click(screen.getByRole('button', { name: /Regenerate all sections/ }));
+    await waitFor(() => expect(screen.getAllByText('270 words').length).toBeGreaterThan(0));
+    mockResearchSection.mock.calls.forEach(([args]) => expect(args.targetWords).toBeNull());
+    expect(mockRequestRevise).not.toHaveBeenCalled();
+  });
+
+  test('the target is saved with the brief', async () => {
+    mockResearchSection.mockImplementation(answerWith(condensedText));
+    startManualBriefWithShortTarget();
+    runDeepResearch();
+    await waitFor(() => expect(screen.getAllByText('126 words').length).toBeGreaterThan(0));
+    await waitFor(() => {
+      const saved = JSON.parse(localStorage.getItem('evidencelab_brief_history_v1') || '[]');
+      expect(saved[0]?.targetWords).toBe(150);
+    });
+  });
+});

--- a/ui/frontend/src/tests/citedReferencesHidePages.test.tsx
+++ b/ui/frontend/src/tests/citedReferencesHidePages.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CitedReferences } from '../components/citations/CitedContent';
+import { SourceReference } from '../types/api';
+
+const SOURCES: SourceReference[] = [
+  { chunkId: 'c1', docId: 'd1', title: 'Doc One', text: '', score: 0, page: 12, index: 1 },
+  { chunkId: 'c2', docId: 'd2', title: 'Doc Two', text: '', score: 0, page: 3, index: 2 },
+];
+
+describe('CitedReferences hidePages', () => {
+  test('shows each document with its page by default', () => {
+    render(<CitedReferences content="A [1] and B [2]." sources={SOURCES} collapsible={false} />);
+    const groups = document.querySelectorAll('.ai-summary-ref-group');
+    expect(Array.from(groups).map((g) => g.textContent)).toEqual([
+      'Doc One | 1 p.12',
+      'Doc Two | 2 p.3',
+    ]);
+  });
+
+  test('hidePages lists the documents and numbers without pages', () => {
+    render(
+      <CitedReferences content="A [1] and B [2]." sources={SOURCES} collapsible={false} hidePages />,
+    );
+    const groups = document.querySelectorAll('.ai-summary-ref-group');
+    expect(Array.from(groups).map((g) => g.textContent)).toEqual(['Doc One | 1', 'Doc Two | 2']);
+  });
+});

--- a/ui/frontend/src/tests/exportBriefDocx.test.ts
+++ b/ui/frontend/src/tests/exportBriefDocx.test.ts
@@ -193,3 +193,42 @@ describe('brief Word export — footnote citation style', () => {
     expect(xml).toContain('[');
   });
 });
+
+describe('brief Word export — references list layouts', () => {
+  const two = [
+    result({ chunk_id: 'c1', doc_id: 'd1', page_num: 26 }),
+    result({ chunk_id: 'c2', doc_id: 'd1', page_num: 40 }),
+  ];
+  const withList = (referenceList: 'flat' | 'grouped' | 'document') => ({
+    ...BRIEF_OPTS,
+    aiSummary: '# Access\n\nEnrolment has risen [1] and stayed up [2].\n',
+    results: two,
+    resultsSectionTitle: 'References',
+    referenceList,
+  });
+  const referencesXml = async (opts: ReturnType<typeof withList>): Promise<string> => {
+    const xml = await documentXml(opts);
+    return xml.slice(xml.lastIndexOf('References'));
+  };
+
+  test('flat: one line per citation with its page', async () => {
+    const refs = await referencesXml(withList('flat'));
+    expect(refs).toContain(', p.26');
+    expect(refs).toContain(', p.40');
+  });
+
+  test('grouped: one line per document listing its citation numbers', async () => {
+    const refs = await referencesXml(withList('grouped'));
+    expect(refs).toContain('1, 2. ');
+    expect(refs).not.toContain(', p.26');
+  });
+
+  test('document: one line per document-level citation and no page numbers', async () => {
+    // With single-per-document grouping the brief hands over one result per
+    // document; the list shows its number and title only.
+    const refs = await referencesXml({ ...withList('document'), results: [two[0]] });
+    expect(refs).toContain('1. ');
+    expect(refs).toContain('Breaking Barriers for Girls Education in Niger');
+    expect(refs).not.toContain('p.26');
+  });
+});

--- a/ui/frontend/src/tests/exportBriefDocx.test.ts
+++ b/ui/frontend/src/tests/exportBriefDocx.test.ts
@@ -5,13 +5,15 @@ import type { SearchResult } from '../types/api';
 
 const TOPIC = 'girls education in Kenya';
 const REF_EXCERPTS = 'Reference Excerpts';
+const REFERENCES = 'References';
+const DOC_TITLE = 'Breaking Barriers for Girls Education in Niger';
 const DOC_XML = 'word/document.xml';
 
 const result = (over: Partial<SearchResult>): SearchResult =>
   ({
     chunk_id: 'c1',
     doc_id: 'd1',
-    title: 'Breaking Barriers for Girls Education in Niger',
+    title: DOC_TITLE,
     text: 'Full excerpt sentence one. Full excerpt sentence two that should appear in italics.',
     score: 0.5,
     page_num: 26,
@@ -150,7 +152,7 @@ describe('brief Word export — footnote citation style', () => {
   test('footnote holds the source title, page and a clickable PDF link', async () => {
     const zip = await zipOf(footOpts);
     const footnotes = await zip.file('word/footnotes.xml')!.async('string');
-    expect(footnotes).toContain('Breaking Barriers for Girls Education in Niger');
+    expect(footnotes).toContain(DOC_TITLE);
     expect(footnotes).toContain('p.26');
     expect(footnotes).toContain('Open PDF');
     const rels = await zip.file('word/_rels/footnotes.xml.rels')!.async('string');
@@ -203,12 +205,12 @@ describe('brief Word export — references list layouts', () => {
     ...BRIEF_OPTS,
     aiSummary: '# Access\n\nEnrolment has risen [1] and stayed up [2].\n',
     results: two,
-    resultsSectionTitle: 'References',
+    resultsSectionTitle: REFERENCES,
     referenceList,
   });
   const referencesXml = async (opts: ReturnType<typeof withList>): Promise<string> => {
     const xml = await documentXml(opts);
-    return xml.slice(xml.lastIndexOf('References'));
+    return xml.slice(xml.lastIndexOf(REFERENCES));
   };
 
   test('flat: one line per citation with its page', async () => {
@@ -228,7 +230,34 @@ describe('brief Word export — references list layouts', () => {
     // document; the list shows its number and title only.
     const refs = await referencesXml({ ...withList('document'), results: [two[0]] });
     expect(refs).toContain('1. ');
-    expect(refs).toContain('Breaking Barriers for Girls Education in Niger');
+    expect(refs).toContain(DOC_TITLE);
     expect(refs).not.toContain('p.26');
+  });
+});
+
+describe('brief Word export — a single References section', () => {
+  // Count "References" heading paragraphs (w:pStyle Heading1/Heading2) in the
+  // document body.
+  const referenceHeadings = (xml: string): number =>
+    (xml.match(/<w:pStyle w:val="Heading[12]"\/>(?:(?!<\/w:p>)[^])*?>References<\/w:t>/g) || []).length;
+
+  test.each(['flat', 'grouped', 'document'] as const)(
+    'the brief export (%s layout) has exactly one References section',
+    async (referenceList) => {
+      const xml = await documentXml({
+        ...BRIEF_OPTS,
+        resultsSectionTitle: REFERENCES,
+        referenceList,
+      });
+      expect(referenceHeadings(xml)).toBe(1);
+    },
+  );
+
+  test('the search export keeps its references under the prose before the result cards', async () => {
+    // No referenceList: the search export's embedded grouped references plus
+    // the result-card section (whose heading is not "References").
+    const xml = await documentXml({ ...BRIEF_OPTS, resultsSectionTitle: 'Search Results' });
+    expect(referenceHeadings(xml)).toBe(1);
+    expect(xml).toContain('Search Results (1)');
   });
 });

--- a/ui/frontend/src/tests/exportBriefDocx.test.ts
+++ b/ui/frontend/src/tests/exportBriefDocx.test.ts
@@ -219,10 +219,25 @@ describe('brief Word export — references list layouts', () => {
     expect(refs).toContain(', p.40');
   });
 
-  test('grouped: one line per document listing its citation numbers', async () => {
+  test('grouped: one line per document, laid out as on screen — "Title, [1] p. 26, [2] p. 40"', async () => {
     const refs = await referencesXml(withList('grouped'));
-    expect(refs).toContain('1, 2. ');
+    // The visible text of the row, in order, with the XML stripped.
+    const text = refs.replace(/<[^>]+>/g, '');
+    expect(text).toContain(`${DOC_TITLE}, [1] p. 26, [2] p. 40`);
+    // Neither the flat "1. " label nor the flat ", p.26" form appears.
+    expect(refs).not.toContain('1. ');
     expect(refs).not.toContain(', p.26');
+  });
+
+  test('grouped: the title links to the document and each [n] to its cited page', async () => {
+    const opts = {
+      ...withList('grouped'),
+      results: two.map((r) => ({ ...r, report_url: PDF_URL })),
+    };
+    const rels = await relTargets(buildExportDocument(opts));
+    expect(rels).toContain(`${PDF_URL}"`); // document link, no page anchor
+    expect(rels).toContain(`${PDF_URL}#page=26`);
+    expect(rels).toContain(`${PDF_URL}#page=40`);
   });
 
   test('document: one line per document-level citation and no page numbers', async () => {

--- a/ui/frontend/src/tests/useGroupDefaultsWide.test.tsx
+++ b/ui/frontend/src/tests/useGroupDefaultsWide.test.tsx
@@ -16,7 +16,7 @@ const SETTING_KEYS: (keyof SearchSettings)[] = [
   'denseWeight', 'rerank', 'recencyBoost', 'recencyWeight', 'recencyScaleDays', 'sectionTypes',
   'keywordBoostShortQueries', 'minChunkSize', 'semanticHighlighting', 'autoMinScore', 'deduplicate',
   'fieldBoost', 'fieldBoostFields', 'wideSearch', 'wideGroupSize', 'wideLimit', 'groupByDocument', 'summaryLimitResults',
-  'summaryMaxResults', 'summaryTemperature', 'greetingMessage',
+  'summaryMaxResults', 'summaryTemperature', 'briefTargetWords', 'greetingMessage',
 ];
 
 const makeSetters = () =>
@@ -72,5 +72,13 @@ describe('useGroupDefaults applies wide search team defaults', () => {
     await waitFor(() => expect(setters.wideSearch).toHaveBeenCalledWith(true));
     expect(setters.wideGroupSize).toHaveBeenCalledWith(3);
     expect(setters.wideLimit).not.toHaveBeenCalled();
+  });
+
+  test('applies the brief section-length team default (it has no URL param)', async () => {
+    setURL('?q=test');
+    mockedAxios.get.mockResolvedValue({ data: { briefTargetWords: 350 } });
+    const setters = makeSetters();
+    render(<Harness setters={setters} />);
+    await waitFor(() => expect(setters.briefTargetWords).toHaveBeenCalledWith(350));
   });
 });

--- a/ui/frontend/src/types/auth.ts
+++ b/ui/frontend/src/types/auth.ts
@@ -42,6 +42,8 @@ export interface SearchSettings {
   summaryMaxResults?: number;
   /** AI summary: sampling temperature, 0 (precise) to 1 (creative). */
   summaryTemperature?: number;
+  /** Brief: default section length target in words for new briefs (null = no target). */
+  briefTargetWords?: number | null;
   greetingMessage?: string;
 }
 

--- a/ui/frontend/src/utils/assistantStream.ts
+++ b/ui/frontend/src/utils/assistantStream.ts
@@ -56,6 +56,9 @@ interface AssistantStreamOptions {
   // resolved internally.
   activityId?: string | null;
   usageContext?: 'brief' | null;
+  // Target length of the written answer in words (deep research). The backend
+  // asks the coordinator for that length and raises its token ceiling to fit.
+  targetWords?: number | null;
   handlers: AssistantStreamHandlers;
   signal?: AbortSignal;
 }
@@ -236,6 +239,7 @@ export const streamAssistantChat = async ({
   publishedAfter,
   activityId,
   usageContext,
+  targetWords,
   handlers,
   signal,
 }: AssistantStreamOptions): Promise<void> => {
@@ -261,6 +265,7 @@ export const streamAssistantChat = async ({
       activity_id: activityId || undefined,
       session_id: getSessionId(),
       usage_context: usageContext || undefined,
+      target_words: targetWords || undefined,
     }),
     signal,
   });

--- a/ui/frontend/src/utils/briefStream.ts
+++ b/ui/frontend/src/utils/briefStream.ts
@@ -203,6 +203,8 @@ export interface RunDeepResearchOptions {
   // turn's token usage onto the brief's activity row (typed 'brief' via
   // the stream's usageContext).
   activityId?: string | null;
+  // Target length of the written text in words (see briefLength.ts).
+  targetWords?: number | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -221,6 +223,7 @@ export const runDeepResearch = async ({
   searchSettings = null,
   publishedAfter = null,
   activityId = null,
+  targetWords = null,
   handlers,
   signal,
 }: RunDeepResearchOptions): Promise<void> => {
@@ -238,6 +241,7 @@ export const runDeepResearch = async ({
     publishedAfter: publishedAfter ?? null,
     activityId: activityId ?? null,
     usageContext: 'brief',
+    targetWords: targetWords ?? null,
     handlers: {
       onPhase: (phase) => {
         const pct = PHASE_PROGRESS[phase];
@@ -307,6 +311,8 @@ export interface ResearchSectionOptions {
   outlineContext?: string | null;
   // Usage-recording context (see RunDeepResearchOptions).
   activityId?: string | null;
+  // Target length of the section in words (see briefLength.ts).
+  targetWords?: number | null;
   handlers: BriefSectionHandlers;
   signal?: AbortSignal;
 }
@@ -370,11 +376,18 @@ const buildGenerateQuery = (args: {
  * text with no [n] citation markers. Such a result is treated as a failed run
  * (fail loud, keep the section pending) rather than stored as content.
  */
-export const isLikelyNonAnswer = (content: string, sourceCount: number): boolean => {
+export const isLikelyNonAnswer = (
+  content: string,
+  sourceCount: number,
+  targetWords?: number | null,
+): boolean => {
   const text = (content || '').trim();
   if (!text) return true;
   const hasCitations = /\[\d+(?:,\s*\d+)*\]/.test(text);
-  return sourceCount >= 3 && !hasCitations && text.length < 800;
+  // A short section is only suspicious relative to the length asked for: with
+  // a target of 100 words, 700 characters is a complete answer, not narration.
+  const shortLimit = targetWords ? Math.min(800, targetWords * 3) : 800;
+  return sourceCount >= 3 && !hasCitations && text.length < shortLimit;
 };
 
 // A minimal shape of the brief's sections for outline context.
@@ -521,6 +534,7 @@ export const researchBriefSection = ({
   voiceInstructions,
   outlineContext,
   activityId,
+  targetWords,
   handlers,
   signal,
 }: ResearchSectionOptions): Promise<void> => {
@@ -549,6 +563,7 @@ export const researchBriefSection = ({
     // prompt instruction above).
     publishedAfter: mode === 'update' ? publishedAfterIso : null,
     activityId,
+    targetWords,
     handlers,
     signal,
   });

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -55,6 +55,9 @@ import {
   type DocumentGroup,
 } from './citations';
 
+/** Layout of the compact references list (see {@link ExportOptions.referenceList}). */
+export type ReferenceListLayout = 'flat' | 'grouped' | 'document';
+
 export interface ExportOptions {
   query: string;
   aiSummary?: string;
@@ -70,9 +73,8 @@ export interface ExportOptions {
    *  The Brief export passes "Reference Excerpts". */
   resultsSectionTitle?: string;
   // Render a compact references list (no excerpts) instead of full result
-  // cards, mirroring the Brief's on-screen References section. 'grouped'
-  // collapses to one row per document.
-  referenceList?: 'flat' | 'grouped';
+  // cards, mirroring the Brief's on-screen References section.
+  referenceList?: ReferenceListLayout;
   /** Cover-page document title (default "Evidence Lab — Search Export").
    *  The Brief export passes "AI-generated Research Brief". */
   documentTitle?: string;
@@ -1081,15 +1083,17 @@ const buildResultCard = (
 };
 
 /**
- * A compact references list: one line per citation (flat) or per document
- * (grouped), title hyperlinked to the source, no excerpt text. Mirrors what
- * the Brief shows on screen so the export matches the reader's view.
+ * A compact references list, title hyperlinked to the source, no excerpt text:
+ * one line per citation with its page ('flat'), one line per document listing
+ * each of its citation numbers ('grouped'), or one line per document-level
+ * citation with no page ('document'). Mirrors what the Brief shows on screen
+ * so the export matches the reader's view.
  */
 const buildReferenceList = (
   results: SearchResult[],
   siteOrigin: string,
   dataSource: string | undefined,
-  grouped: boolean,
+  layout: ReferenceListLayout,
   sectionTitle = 'References',
 ): Paragraph[] => {
   const titleOf = (r: SearchResult): string =>
@@ -1098,7 +1102,7 @@ const buildReferenceList = (
     '(untitled document)';
 
   const rows: Array<{ label: string; title: string; result: SearchResult }> = [];
-  if (grouped) {
+  if (layout === 'grouped') {
     const byDoc = new Map<string, { nums: number[]; result: SearchResult }>();
     results.forEach((r, idx) => {
       const key = r.doc_id || titleOf(r);
@@ -1111,7 +1115,7 @@ const buildReferenceList = (
     );
   } else {
     results.forEach((r, idx) => {
-      const page = r.page_num ? `, p.${r.page_num}` : '';
+      const page = layout === 'flat' && r.page_num ? `, p.${r.page_num}` : '';
       rows.push({ label: String(idx + 1), title: `${titleOf(r)}${page}`, result: r });
     });
   }
@@ -1207,7 +1211,7 @@ export const buildExportDocument = (
           opts.results,
           siteOrigin,
           opts.dataSource,
-          opts.referenceList === 'grouped',
+          opts.referenceList,
           opts.resultsSectionTitle,
         )
       : buildResultsSection(

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -1091,12 +1091,96 @@ const buildResultCard = (
   return out;
 };
 
+const referenceTitleOf = (r: SearchResult): string =>
+  (r.title && r.title.trim()) ||
+  (typeof r.document_title === 'string' && r.document_title.trim()) ||
+  '(untitled document)';
+
+/**
+ * One row per document, exactly as the Brief shows it on screen with
+ * "Group by document (multiple per document)":
+ *   Title, [1] p. 32, [2] p. 56
+ * The title links to the document; each [n] and its page link to that
+ * citation's page. As on screen, a number is shown once per run of the same
+ * citation, so a document cited from many pages reads "[1] p. 9, p. 11".
+ */
+const buildGroupedReferenceRows = (
+  results: SearchResult[],
+  siteOrigin: string,
+  dataSource: string | undefined,
+): Paragraph[] => {
+  type Cite = { n: number; page: number; result: SearchResult };
+  const byDoc = new Map<string, { result: SearchResult; cites: Cite[] }>();
+  results.forEach((result, idx) => {
+    const key = result.doc_id || referenceTitleOf(result);
+    const cite = { n: idx + 1, page: result.page_num || 0, result };
+    const found = byDoc.get(key);
+    if (found) found.cites.push(cite);
+    else byDoc.set(key, { result, cites: [cite] });
+  });
+
+  const rows: Paragraph[] = [];
+  byDoc.forEach(({ result, cites }) => {
+    cites.sort((a, b) => a.page - b.page || a.n - b.n);
+    const children: InlineChild[] = [
+      new ExternalHyperlink({
+        link: resolveDocumentLink(result, siteOrigin, dataSource),
+        children: [new TextRun({ text: referenceTitleOf(result), style: 'Hyperlink' })],
+      }),
+    ];
+    cites.forEach((cite, i) => {
+      const link = resolveResultLink(cite.result, siteOrigin, dataSource);
+      children.push(new TextRun({ text: ', ' }));
+      if (i === 0 || cites[i - 1].n !== cite.n) {
+        children.push(
+          new ExternalHyperlink({
+            link,
+            children: [new TextRun({ text: `[${cite.n}]`, style: 'Hyperlink' })],
+          }),
+        );
+      }
+      if (cite.page) {
+        children.push(
+          new ExternalHyperlink({
+            link,
+            children: [new TextRun({ text: ` p. ${cite.page}`, style: 'Hyperlink' })],
+          }),
+        );
+      }
+    });
+    rows.push(new Paragraph({ spacing: { after: 60 }, children }));
+  });
+  return rows;
+};
+
+/** One row per citation — "1. Title, p.26" — or, for document-level
+ *  citations, "1. Title" with no page. */
+const buildNumberedReferenceRows = (
+  results: SearchResult[],
+  siteOrigin: string,
+  dataSource: string | undefined,
+  withPages: boolean,
+): Paragraph[] =>
+  results.map((result, idx) => {
+    const page = withPages && result.page_num ? `, p.${result.page_num}` : '';
+    return new Paragraph({
+      spacing: { after: 60 },
+      children: [
+        new TextRun({ text: `${idx + 1}. `, bold: true }),
+        new ExternalHyperlink({
+          link: resolveResultLink(result, siteOrigin, dataSource),
+          children: [new TextRun({ text: `${referenceTitleOf(result)}${page}`, style: 'Hyperlink' })],
+        }),
+      ],
+    });
+  });
+
 /**
  * A compact references list, title hyperlinked to the source, no excerpt text:
  * one line per citation with its page ('flat'), one line per document listing
- * each of its citation numbers ('grouped'), or one line per document-level
- * citation with no page ('document'). Mirrors what the Brief shows on screen
- * so the export matches the reader's view.
+ * each of its citation numbers with their pages ('grouped'), or one line per
+ * document-level citation with no page ('document'). Mirrors what the Brief
+ * shows on screen so the export matches the reader's view.
  */
 const buildReferenceList = (
   results: SearchResult[],
@@ -1104,54 +1188,16 @@ const buildReferenceList = (
   dataSource: string | undefined,
   layout: ReferenceListLayout,
   sectionTitle = 'References',
-): Paragraph[] => {
-  const titleOf = (r: SearchResult): string =>
-    (r.title && r.title.trim()) ||
-    (typeof r.document_title === 'string' && r.document_title.trim()) ||
-    '(untitled document)';
-
-  const rows: Array<{ label: string; title: string; result: SearchResult }> = [];
-  if (layout === 'grouped') {
-    const byDoc = new Map<string, { nums: number[]; result: SearchResult }>();
-    results.forEach((r, idx) => {
-      const key = r.doc_id || titleOf(r);
-      const found = byDoc.get(key);
-      if (found) found.nums.push(idx + 1);
-      else byDoc.set(key, { nums: [idx + 1], result: r });
-    });
-    byDoc.forEach(({ nums, result }) =>
-      rows.push({ label: nums.join(', '), title: titleOf(result), result }),
-    );
-  } else {
-    results.forEach((r, idx) => {
-      const page = layout === 'flat' && r.page_num ? `, p.${r.page_num}` : '';
-      rows.push({ label: String(idx + 1), title: `${titleOf(r)}${page}`, result: r });
-    });
-  }
-
-  const out: Paragraph[] = [
-    new Paragraph({
-      heading: HeadingLevel.HEADING_1,
-      children: [new TextRun({ text: sectionTitle })],
-      spacing: { before: 360, after: 120 },
-    }),
-  ];
-  rows.forEach(({ label, title, result }) => {
-    out.push(
-      new Paragraph({
-        spacing: { after: 60 },
-        children: [
-          new TextRun({ text: `${label}. `, bold: true }),
-          new ExternalHyperlink({
-            link: resolveResultLink(result, siteOrigin, dataSource),
-            children: [new TextRun({ text: title, style: 'Hyperlink' })],
-          }),
-        ],
-      }),
-    );
-  });
-  return out;
-};
+): Paragraph[] => [
+  new Paragraph({
+    heading: HeadingLevel.HEADING_1,
+    children: [new TextRun({ text: sectionTitle })],
+    spacing: { before: 360, after: 120 },
+  }),
+  ...(layout === 'grouped'
+    ? buildGroupedReferenceRows(results, siteOrigin, dataSource)
+    : buildNumberedReferenceRows(results, siteOrigin, dataSource, layout === 'flat')),
+];
 
 const buildResultsSection = (
   results: SearchResult[],

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -73,7 +73,9 @@ export interface ExportOptions {
    *  The Brief export passes "Reference Excerpts". */
   resultsSectionTitle?: string;
   // Render a compact references list (no excerpts) instead of full result
-  // cards, mirroring the Brief's on-screen References section.
+  // cards, mirroring the Brief's on-screen References section. This is then
+  // the document's only References section: the grouped list the search
+  // export embeds under its prose is not added.
   referenceList?: ReferenceListLayout;
   /** Cover-page document title (default "Evidence Lab — Search Export").
    *  The Brief export passes "AI-generated Research Brief". */
@@ -850,6 +852,11 @@ const buildSummarySection = (
   heading = 'AI Summary',
   bookmarkPrefix?: string,
   footnotes?: FootnoteRegistry,
+  // The search export lists its references directly under the prose, before
+  // the result cards. The Brief export instead renders one References section
+  // laid out per the reader's grouping (see ExportOptions.referenceList), so
+  // it turns this embedded list off to avoid two References sections.
+  embeddedReferences = true,
 ): Paragraph[] => {
   if (!summary.trim()) return [];
   const out: Paragraph[] = [];
@@ -872,7 +879,9 @@ const buildSummarySection = (
   // body become clickable links, renumbered to match the screen. When a
   // bookmarkPrefix is set, headings are bookmarked for the manual TOC.
   out.push(...markdownToParagraphs(summary, 1, citations, bookmarkPrefix));
-  out.push(...buildReferenceParagraphs(buildGroupedReferences(summary, results), citations));
+  if (embeddedReferences) {
+    out.push(...buildReferenceParagraphs(buildGroupedReferences(summary, results), citations));
+  }
   return out;
 };
 
@@ -1196,6 +1205,7 @@ export const buildExportDocument = (
       opts.summaryHeading,
       opts.tableOfContents ? tocBookmarkPrefix : undefined,
       footnotes,
+      !opts.referenceList,
     ),
     ...(opts.documentList
       ? buildDocumentListParagraphs(

--- a/ui/frontend/src/utils/searchUrl.ts
+++ b/ui/frontend/src/utils/searchUrl.ts
@@ -72,6 +72,7 @@ export const SYSTEM_DEFAULTS: Required<SearchSettings> = {
   summaryLimitResults: true,
   summaryMaxResults: SUMMARY_RESULT_LIMIT,
   summaryTemperature: 0,
+  briefTargetWords: null,
   greetingMessage: '',
 };
 


### PR DESCRIPTION
## Summary

Briefs can now be asked for sections of about **N words**. The **Section length** control offers the configured presets (Short ~150, Standard ~350, Long ~700), a custom count, or *No target* (the model decides, as before). It appears on the seed screen and the New-brief modal, in **AI Regenerate All** for the whole brief, and per section in its research panel (*Use brief target* inherits). The target is saved with the brief, and a team can set a default in group settings (**Brief → Default section length**).

Each researched section shows its word count next to its heading; the brief shows the total under its title.

## Why not just a prompt, and why not tokens

- A model only approximates a word count, so a prompt alone drifts.
- A token cap is the wrong lever: it truncates mid-sentence (losing the last citations), users think in words, and in this graph the cap is shared with the researcher sub-agent's turns, so lowering it starves the research. Today the 2000-token ceiling already truncates anything over about 1,300 words.

## How the target is enforced

1. **Prompt (parameterised, not free text).** `POST /assistant/chat/stream` takes `target_words` (50–5000). The deep-research coordinator template renders a firm "write approximately N words (between 0.8N and 1.2N)" rule in place of its "AT LEAST 3-4 paragraphs" default; short targets are told to skip headings.
2. **Token ceiling.** `max_tokens_for_target` raises the configured `max_tokens` to at least 1.6 tokens/word plus headroom, so long targets are never cut off. It never lowers the ceiling.
3. **Measured enforcement.** When a section lands, its words are counted (citation markers and markdown excluded). If it exceeds the target by more than the configured tolerance (25%), the section is condensed with the existing AI-revise call ("condense to N words, keep every [n] citation marker"), shown as *Condensing to about N words* in the section activity and recorded in its Log. Short sections are left alone.

Also: the non-answer guard (short uncited text after reading sources) now scales with the target, so a genuinely short section is not mistaken for process narration.

## Config

`config.json` → `application.brief.target_words`: `presets`, `min`, `max`, `tolerance`. The frontend fails hard if the block is missing.

## Testing

- Backend: `test_assistant_target_length.py` (token ceiling, prompt rendering with/without target, target reaching the coordinator system prompt), schema bounds, route pass-through. Assistant suites: 191 pass.
- Frontend: `briefLength.test.ts` (word counting incl. non-Latin scripts, tolerance, clamping), `assistantStreamTargetWords.test.ts`, `briefLengthControl.test.tsx`, `briefTargetLength.test.tsx` (end-to-end: target sent with every section request, overshoot triggers the condense edit with the right instruction and the count updates, no target → nothing condensed, target persisted), group-default application. Full suite: 104 suites, 826 tests pass. `tsc` and ESLint clean.
- Verified in the dev server: seed screen control, per-section override with inherit, Regenerate-all modal, word counts per section and total.
- Docs updated (`brief.md`, `user-administration.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
