### PR TITLE
fix: Heatmapper filters (multi-select, multi-valued fields, title, language, sensitivity)

### DIFF
--- a/docs/using-evidence-lab/heatmapper.md
+++ b/docs/using-evidence-lab/heatmapper.md
@@ -36,6 +36,7 @@ Click any cell in the heatmap to drill down into the underlying data. You can:
 
 - **Wide Search** applies here too: with it on, each cell counts at most *Max results per document* paragraphs from any one document, so the **Paragraphs** metric reflects breadth rather than one long report. Document counts are not capped by the *Number of documents* setting. Cell searches take longer with Wide Search on.
 
+- Filters on multi-valued attributes (for example a document covering several countries) match every document that lists the value, so the heatmap counts agree with the filter panel.
 - Start with broad attribute combinations to get an overview, then add search queries to focus on specific topics.
 - Use Heatmapper alongside [Search](/docs/using-evidence-lab/search.md) — if you spot an interesting pattern in the heatmap, run a search to explore the underlying evidence.
 - Export data for inclusion in presentations or reports.

--- a/docs/using-evidence-lab/heatmapper.md
+++ b/docs/using-evidence-lab/heatmapper.md
@@ -36,6 +36,7 @@ Click any cell in the heatmap to drill down into the underlying data. You can:
 
 - **Wide Search** applies here too: with it on, each cell counts at most *Max results per document* paragraphs from any one document, so the **Paragraphs** metric reflects breadth rather than one long report. Document counts are not capped by the *Number of documents* setting. Cell searches take longer with Wide Search on.
 
+- **Search sensitivity** is set automatically the first time a query runs, from the scores that query returned. It then stays put while you re-run the same query with different filters, so excluding a document type, country or year really empties the cells it was in. Move the slider to change it by hand; it is recomputed only when you change the query.
 - Filters on multi-valued attributes (for example a document covering several countries) match every document that lists the value, so the heatmap counts agree with the filter panel.
 - Start with broad attribute combinations to get an overview, then add search queries to focus on specific topics.
 - Use Heatmapper alongside [Search](/docs/using-evidence-lab/search.md) — if you spot an interesting pattern in the heatmap, run a search to explore the underlying evidence.

--- a/tests/unit/test_docsearch.py
+++ b/tests/unit/test_docsearch.py
@@ -353,17 +353,6 @@ def test_build_metadata_filter_condition_list_value_uses_match_any():
     assert result.must[0].match.any == ["Kenya", "Kenya; Ethiopia"]
 
 
-def test_build_metadata_filter_condition_title_uses_match_text():
-    """Test _build_metadata_filter_condition uses MatchText for title field."""
-    result = _build_metadata_filter_condition("title", "Education", "map_title")
-
-    assert isinstance(result, qmodels.Filter)
-    assert len(result.should) == 1
-    assert result.should[0].key == "map_title"
-    assert isinstance(result.should[0].match, qmodels.MatchText)
-    assert result.should[0].match.text == "Education"
-
-
 def test_build_metadata_filter_condition_taxonomy_uses_full_value():
     """Test _build_metadata_filter_condition uses full taxonomy value."""
     result = _build_metadata_filter_condition(
@@ -873,3 +862,55 @@ async def test_docsearch_filters_out_documents_without_payload(mock_pg):
     assert len(result.results) == 2
     assert result.results[0].doc_id == "1"
     assert result.results[1].doc_id == "3"
+
+
+def _extract_has_id_from_filter(combined):
+    """Return the HasIdCondition ids from a combined docsearch filter."""
+    for cond in combined.must:
+        should = getattr(cond, "should", None)
+        if should and isinstance(should[0], qmodels.HasIdCondition):
+            return should[0].has_id
+    return None
+
+
+@pytest.mark.asyncio
+async def test_docsearch_title_multi_select_resolves_exact_titles(mock_pg):
+    """Two titles picked in the UI arrive comma-joined; each is resolved to its
+    document (exact display title) and applied as a doc_id constraint, not as
+    one substring match on the joined string (which matched nothing)."""
+    fake_db = FakeDB(scroll_results=[create_fake_document("1", "A", "WFP", "2023")])
+    mock_pg.fetch_indexed_doc_ids.return_value = ["1", "2", "3"]
+    mock_pg.fetch_doc_ids_by_exact_titles.return_value = ["1", "3"]
+    mock_pg.fetch_doc_ids_by_title.return_value = []
+
+    mock_request = Mock(spec=Request)
+    mock_request.query_params = {}
+
+    with patch("ui.backend.routes.search.get_db_for_source", return_value=fake_db):
+        with patch("ui.backend.routes.search.get_pg_for_source", return_value=mock_pg):
+            with patch("ui.backend.routes.search.run_in_threadpool") as mock_threadpool:
+                mock_threadpool.side_effect = lambda func, **kwargs: func(**kwargs)
+                result = await docsearch(
+                    request=mock_request,
+                    q="",
+                    limit=10,
+                    organization=None,
+                    title="Title A,Title B",
+                    published_year=None,
+                    document_type=None,
+                    country=None,
+                    language=None,
+                    data_source="uneg",
+                )
+
+    assert result.filters == {"title": ["Title A,Title B"]}
+    candidates = mock_pg.fetch_doc_ids_by_exact_titles.call_args.args[0]
+    assert "Title A" in candidates and "Title B" in candidates
+    combined = fake_db._scroll_calls[0]["filter"]
+    assert _extract_has_id_from_filter(combined) == ["1", "3"]
+    # No payload MatchText condition on map_title remains.
+    assert not any(
+        getattr(getattr(c, "must", [None])[0], "key", None) == "map_title"
+        for c in combined.must
+        if getattr(c, "must", None)
+    )

--- a/tests/unit/test_docsearch.py
+++ b/tests/unit/test_docsearch.py
@@ -329,6 +329,30 @@ def test_get_indexed_doc_ids_returns_empty_list_when_no_indexed_docs():
     mock_pg.fetch_indexed_doc_ids.assert_called_once()
 
 
+def test_build_metadata_filter_condition_multi_select_uses_match_any():
+    """A comma-joined multi-select (as sent by the UI) ORs the values, so
+    picking two document types in attribute mode no longer returns nothing."""
+    result = _build_metadata_filter_condition(
+        "document_type", "Activity,Thematic", "map_document_type"
+    )
+
+    assert isinstance(result, qmodels.Filter)
+    assert len(result.must) == 1
+    assert result.must[0].key == "map_document_type"
+    assert isinstance(result.must[0].match, qmodels.MatchAny)
+    assert result.must[0].match.any == ["Activity", "Thematic"]
+
+
+def test_build_metadata_filter_condition_list_value_uses_match_any():
+    """An expanded (list) filter value is applied as MatchAny."""
+    result = _build_metadata_filter_condition(
+        "country", ["Kenya", "Kenya; Ethiopia"], "map_country"
+    )
+
+    assert isinstance(result.must[0].match, qmodels.MatchAny)
+    assert result.must[0].match.any == ["Kenya", "Kenya; Ethiopia"]
+
+
 def test_build_metadata_filter_condition_title_uses_match_text():
     """Test _build_metadata_filter_condition uses MatchText for title field."""
     result = _build_metadata_filter_condition("title", "Education", "map_title")

--- a/tests/unit/test_docsearch.py
+++ b/tests/unit/test_docsearch.py
@@ -523,6 +523,36 @@ def test_resolve_pg_filter_fields_language_to_sys_language_doc_ids():
     assert mock_field.call_args.args[1] == "sys_language"
 
 
+def test_resolve_pg_filter_fields_region_to_doc_ids():
+    """region is resolved via the PostgreSQL containment lookup (like chunk
+    search) instead of an exact Qdrant payload match, so multi-region documents
+    and a multi-select of regions both count."""
+    pg = Mock()
+    pg.fetch_doc_ids_by_region.return_value = ["2", "5"]
+    core_filters = {"region": "Asia and the Pacific,Eastern and Southern Africa"}
+
+    _resolve_pg_filter_fields(core_filters, pg, "wfp")
+
+    assert "region" not in core_filters
+    assert set(core_filters["doc_id"].split(",")) == {"2", "5"}
+    pg.fetch_doc_ids_by_region.assert_called_once_with(
+        "Asia and the Pacific,Eastern and Southern Africa"
+    )
+
+
+def test_resolve_pg_filter_fields_region_and_language_intersect():
+    """region and language doc_id sets AND together."""
+    pg = Mock()
+    pg.fetch_doc_ids_by_region.return_value = ["2", "5", "7"]
+    core_filters = {"language": "en", "region": "Asia and the Pacific"}
+    with patch(
+        "ui.backend.routes.search.doc_ids_from_pg_field", return_value=["5", "7", "9"]
+    ):
+        _resolve_pg_filter_fields(core_filters, pg, "wfp")
+
+    assert set(core_filters["doc_id"].split(",")) == {"5", "7"}
+
+
 def test_resolve_pg_filter_fields_src_field_to_jsonb_doc_ids():
     """src_* fields are resolved via the src_doc_raw_metadata JSONB column."""
     core_filters = {"src_evaluation_category": "DE", "document_type": "Activity"}

--- a/tests/unit/test_docsearch.py
+++ b/tests/unit/test_docsearch.py
@@ -46,6 +46,10 @@ class FakeDB:
         self._scroll_calls.append({"filter": query_filter, "end_idx": end_idx})
         return self.scroll_results[:end_idx]
 
+    def facet_documents(self, key, filter_conditions=None, limit=10, exact=False):
+        """Mock facet values (no "; "-joined payload values by default)."""
+        return {}
+
 
 def create_fake_document(doc_id, title, organization, year, summary="Test summary"):
     """Helper to create fake document points."""
@@ -914,3 +918,47 @@ async def test_docsearch_title_multi_select_resolves_exact_titles(mock_pg):
         for c in combined.must
         if getattr(c, "must", None)
     )
+
+
+@pytest.mark.asyncio
+async def test_docsearch_country_filter_matches_joined_payload_values(mock_pg):
+    """A country selection also matches documents whose payload stores several
+    countries as one "; "-joined string (regression: Kenya facet 26, filter 8)."""
+    fake_db = FakeDB(scroll_results=[create_fake_document("1", "A", "WFP", "2023")])
+    fake_db.facet_documents = lambda key, **kwargs: {
+        "Kenya": 8,
+        "Kenya; Ethiopia": 3,
+        "Malawi": 5,
+    }
+    mock_pg.fetch_indexed_doc_ids.return_value = ["1"]
+
+    mock_request = Mock(spec=Request)
+    mock_request.query_params = {}
+
+    with patch("ui.backend.routes.search.get_db_for_source", return_value=fake_db):
+        with patch("ui.backend.routes.search.get_pg_for_source", return_value=mock_pg):
+            with patch("ui.backend.routes.search.run_in_threadpool") as mock_threadpool:
+                mock_threadpool.side_effect = lambda func, **kwargs: func(**kwargs)
+                result = await docsearch(
+                    request=mock_request,
+                    q="",
+                    limit=10,
+                    organization=None,
+                    title=None,
+                    published_year=None,
+                    document_type=None,
+                    country="Kenya",
+                    language=None,
+                    data_source="uneg",
+                )
+
+    assert result.filters["country"] == ["Kenya", "Kenya; Ethiopia"]
+    combined = fake_db._scroll_calls[0]["filter"]
+    country_matches = [
+        c.must[0].match
+        for c in combined.must
+        if getattr(c, "must", None) and c.must[0].key == "map_country"
+    ]
+    assert len(country_matches) == 1
+    assert isinstance(country_matches[0], qmodels.MatchAny)
+    assert country_matches[0].any == ["Kenya", "Kenya; Ethiopia"]

--- a/tests/unit/test_heatmap_integration.py
+++ b/tests/unit/test_heatmap_integration.py
@@ -44,6 +44,10 @@ class FakeDB:
         self._scroll_calls.append({"filter": query_filter, "end_idx": end_idx})
         return self.scroll_results[:end_idx]
 
+    def facet_documents(self, key, filter_conditions=None, limit=10, exact=False):
+        """Mock facet values (no "; "-joined payload values by default)."""
+        return {}
+
     def hybrid_search(self, **kwargs):
         """Mock hybrid search for chunks."""
         self._search_calls.append(kwargs)

--- a/tests/unit/test_multivalue_filters.py
+++ b/tests/unit/test_multivalue_filters.py
@@ -1,0 +1,34 @@
+"""Unit tests for multi-valued filter handling in the search routes.
+
+Covers three defects surfaced by Heatmapper:
+
+* filters on "; "-joined payload fields (country, theme, …) missed every
+  multi-valued document (facet 26, filter 8);
+* a multi-select title filter arrives comma-joined although titles contain
+  commas, so it must be resolved to exact titles rather than substring-matched;
+* the resolved title doc_ids must AND with other document-level constraints.
+"""
+
+import pytest
+from qdrant_client.http import models as qmodels
+
+from ui.backend.routes.search import _filter_match
+
+pytestmark = pytest.mark.unit
+
+
+class TestFilterMatch:
+    def test_plain_string_then_match_value(self):
+        match = _filter_match("Activity")
+        assert isinstance(match, qmodels.MatchValue)
+        assert match.value == "Activity"
+
+    def test_comma_joined_then_match_any(self):
+        match = _filter_match("Activity, Thematic")
+        assert isinstance(match, qmodels.MatchAny)
+        assert match.any == ["Activity", "Thematic"]
+
+    def test_list_then_match_any_of_strings(self):
+        match = _filter_match(["2024", 2025])
+        assert isinstance(match, qmodels.MatchAny)
+        assert match.any == ["2024", "2025"]

--- a/tests/unit/test_multivalue_filters.py
+++ b/tests/unit/test_multivalue_filters.py
@@ -21,8 +21,94 @@ from ui.backend.routes.search import (
     _resolve_title_doc_ids,
     _title_candidates,
 )
+from ui.backend.utils.filter_helpers import (
+    _is_expandable_filter,
+    expand_multivalue_filters,
+)
 
 pytestmark = pytest.mark.unit
+
+
+def _db_with_values(values):
+    db = MagicMock()
+    db.facet_documents.return_value = {v: 1 for v in values}
+    return db
+
+
+class TestExpandMultivalueFilters:
+    def test_single_value_when_joined_payloads_exist_then_expanded_to_list(self):
+        db = _db_with_values(["Kenya", "Kenya; Ethiopia", "Malawi"])
+        core = {"country": "Kenya"}
+        expand_multivalue_filters(db, core, "wfp")
+        assert core["country"] == ["Kenya", "Kenya; Ethiopia"]
+        db.facet_documents.assert_called_once()
+        assert db.facet_documents.call_args.kwargs["key"] == "map_country"
+
+    def test_multi_select_when_joined_payloads_exist_then_all_kept(self):
+        db = _db_with_values(["Kenya", "Kenya; Ethiopia", "Malawi", "Niger; Malawi"])
+        core = {"country": "Kenya,Malawi"}
+        expand_multivalue_filters(db, core, "wfp")
+        assert core["country"] == [
+            "Kenya",
+            "Kenya; Ethiopia",
+            "Malawi",
+            "Niger; Malawi",
+        ]
+
+    def test_value_when_nothing_to_add_then_left_as_string(self):
+        db = _db_with_values(["Activity", "Thematic"])
+        core = {"document_type": "Activity"}
+        expand_multivalue_filters(db, core, "wfp")
+        assert core["document_type"] == "Activity"
+
+    def test_skipped_fields_when_present_then_never_looked_up(self):
+        db = MagicMock()
+        core = {
+            "title": "A title",
+            "doc_id": "1,2",
+            "language": "en",
+            "region": "Asia",
+            "published_year": "2024",
+            "src_evaluation_category": "CE",
+            "tag_sdg": "sdg1 - SDG1",
+            "score_min": "3",
+            "country": None,
+            "theme": "",
+        }
+        before = dict(core)
+        expand_multivalue_filters(db, core, "wfp")
+        assert core == before
+        db.facet_documents.assert_not_called()
+
+    def test_list_value_when_already_expanded_then_left_untouched(self):
+        db = MagicMock()
+        core = {"country": ["Kenya", "Kenya; Ethiopia"]}
+        expand_multivalue_filters(db, core, "wfp")
+        assert core["country"] == ["Kenya", "Kenya; Ethiopia"]
+        db.facet_documents.assert_not_called()
+
+
+class TestIsExpandableFilter:
+    @pytest.mark.parametrize(
+        "field, value, expected",
+        [
+            ("country", "Kenya", True),
+            ("organization", "WFP", True),
+            ("theme", "Nutrition", True),
+            ("title", "x", False),
+            ("region", "x", False),
+            ("published_year", "2024", False),
+            ("src_quality_rating", "x", False),
+            ("tag_sdg", "x", False),
+            ("num_citations_max", "5", False),
+            ("country", "", False),
+            ("country", "   ", False),
+            ("country", ["Kenya"], False),
+            ("country", None, False),
+        ],
+    )
+    def test_field_and_value_then_expected(self, field, value, expected):
+        assert _is_expandable_filter(field, value) is expected
 
 
 class TestFilterMatch:

--- a/tests/unit/test_multivalue_filters.py
+++ b/tests/unit/test_multivalue_filters.py
@@ -9,10 +9,18 @@ Covers three defects surfaced by Heatmapper:
 * the resolved title doc_ids must AND with other document-level constraints.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 from qdrant_client.http import models as qmodels
 
-from ui.backend.routes.search import _filter_match
+from ui.backend.routes.search import (
+    _NO_MATCH_DOC_ID,
+    _filter_match,
+    _handle_title_filter,
+    _resolve_title_doc_ids,
+    _title_candidates,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -32,3 +40,77 @@ class TestFilterMatch:
         match = _filter_match(["2024", 2025])
         assert isinstance(match, qmodels.MatchAny)
         assert match.any == ["2024", "2025"]
+
+
+class TestTitleCandidates:
+    def test_single_title_then_only_itself(self):
+        assert _title_candidates("Evaluation of X") == ["Evaluation of X"]
+
+    def test_two_titles_then_each_and_joined(self):
+        candidates = _title_candidates("Title A,Title B")
+        assert "Title A" in candidates
+        assert "Title B" in candidates
+        assert "Title A,Title B" in candidates
+
+    def test_title_with_comma_then_reconstructed_with_space(self):
+        candidates = _title_candidates("Partnerships in East Africa, 2016-2020")
+        assert "Partnerships in East Africa, 2016-2020" in candidates
+
+    def test_two_titles_one_with_comma_then_both_reconstructed(self):
+        candidates = _title_candidates("Title A,Region Study, 2016-2020,Title C")
+        assert "Title A" in candidates
+        assert "Region Study, 2016-2020" in candidates
+        assert "Title C" in candidates
+
+    def test_blank_parts_then_dropped(self):
+        assert _title_candidates(" , ,A, ") == [", ,A,", "A"]
+
+    def test_many_parts_then_only_parts_and_whole(self):
+        parts = [f"T{i}" for i in range(60)]
+        candidates = _title_candidates(",".join(parts))
+        assert set(parts) <= set(candidates)
+        assert len(candidates) == len(parts) + 1
+
+
+class TestResolveTitleDocIds:
+    def test_exact_and_substring_matches_then_unioned_sorted(self):
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_exact_titles.return_value = ["d3", "d1"]
+        pg.fetch_doc_ids_by_title.return_value = ["d2", "d1"]
+        assert _resolve_title_doc_ids(pg, "Title A,Title B") == ["d1", "d2", "d3"]
+        pg.fetch_doc_ids_by_title.assert_called_once_with("Title A,Title B")
+
+
+class TestHandleTitleFilter:
+    def test_title_when_resolved_then_intersected_with_existing_doc_id(self):
+        # Regression: the title doc_ids used to overwrite a language/region
+        # constraint instead of ANDing with it.
+        core = {"title": "Title A", "doc_id": "d1,d2"}
+        with patch(
+            "ui.backend.routes.search._resolve_title_doc_ids",
+            return_value=["d2", "d9"],
+        ):
+            assert _handle_title_filter(MagicMock(), core, "q") is None
+        assert "title" not in core
+        assert core["doc_id"] == "d2"
+
+    def test_title_when_disjoint_from_existing_then_sentinel(self):
+        core = {"title": "Title A", "doc_id": "d1"}
+        with patch(
+            "ui.backend.routes.search._resolve_title_doc_ids", return_value=["d9"]
+        ):
+            _handle_title_filter(MagicMock(), core, "q")
+        assert core["doc_id"] == _NO_MATCH_DOC_ID
+
+    def test_title_when_no_match_then_empty_response(self):
+        core = {"title": "Nope"}
+        with patch("ui.backend.routes.search._resolve_title_doc_ids", return_value=[]):
+            response = _handle_title_filter(MagicMock(), core, "q")
+        assert response is not None
+        assert response.total == 0
+        assert response.filters == {"title": ["Nope"]}
+
+    def test_no_title_then_untouched(self):
+        core = {"country": "Kenya"}
+        assert _handle_title_filter(MagicMock(), core, "q") is None
+        assert core == {"country": "Kenya"}

--- a/tests/unit/test_region_filter.py
+++ b/tests/unit/test_region_filter.py
@@ -122,3 +122,29 @@ class TestFetchDocIdsByRegion:
         assert "Middle East" not in sql
         assert params[0] == "Middle East, Northern Africa, and Eastern Europe"
         assert "%s ILIKE" in sql
+
+
+class TestConvertLanguageToDocIds:
+    def test_language_when_no_docs_match_then_sentinel_doc_id(self):
+        # Regression: a language matching no document used to drop the filter
+        # and return every chunk.
+        core = {"language": "xx"}
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_language.return_value = []
+        _convert_language_to_doc_ids(core, pg)
+        assert "language" not in core
+        assert core["doc_id"] == _NO_MATCH_DOC_ID
+
+    def test_language_when_doc_id_already_set_then_intersected(self):
+        core = {"language": "en", "doc_id": "d1,d2"}
+        pg = MagicMock()
+        pg.fetch_doc_ids_by_language.return_value = ["d2", "d3"]
+        _convert_language_to_doc_ids(core, pg)
+        assert core["doc_id"] == "d2"
+
+    def test_language_when_absent_then_filters_unchanged(self):
+        core = {"organization": "WFP"}
+        pg = MagicMock()
+        _convert_language_to_doc_ids(core, pg)
+        assert core == {"organization": "WFP"}
+        pg.fetch_doc_ids_by_language.assert_not_called()

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.concurrency import run_in_threadpool
@@ -470,6 +470,18 @@ def _build_search_results(
     return filtered_results
 
 
+def _filter_match(value: Any) -> Union[qmodels.MatchAny, qmodels.MatchValue]:
+    """Qdrant match for a filter value: ``MatchAny`` when the value is a list or
+    a comma-joined multi-select (values OR within a field), else ``MatchValue``.
+    """
+    if isinstance(value, (list, tuple, set)):
+        return qmodels.MatchAny(any=[str(item) for item in value])
+    multi_values = split_filter_values(value)
+    if multi_values:
+        return qmodels.MatchAny(any=multi_values)
+    return qmodels.MatchValue(value=value)
+
+
 def _build_facet_filter(core_filters: Dict[str, Any], data_source: Optional[str]):
     """Build a Qdrant filter from core filter fields for restricting facet counts."""
     facet_conditions: List[qmodels.Condition] = []
@@ -480,16 +492,8 @@ def _build_facet_filter(core_filters: Dict[str, Any], data_source: Optional[str]
         storage_field = resolve_storage_field(core_field, data_source)
         if core_field == "published_year":
             value = str(value)
-        multi_values = split_filter_values(value)
         facet_conditions.append(
-            qmodels.FieldCondition(
-                key=storage_field,
-                match=(
-                    qmodels.MatchAny(any=multi_values)
-                    if multi_values
-                    else qmodels.MatchValue(value=value)
-                ),
-            )
+            qmodels.FieldCondition(key=storage_field, match=_filter_match(value))
         )
 
     for sf, bounds in collect_range_bounds(core_filters, data_source).items():
@@ -900,7 +904,12 @@ def _get_indexed_doc_ids(pg, source: str) -> List[str]:
 def _build_metadata_filter_condition(
     core_field: str, value: Any, storage_field: str
 ) -> qmodels.Filter:
-    """Build a Qdrant filter condition for a single metadata field."""
+    """Build a Qdrant filter condition for a single metadata field.
+
+    A multi-select (list, or the UI's comma-joined string) becomes ``MatchAny``
+    so the selected values OR within the field, exactly as in chunk search;
+    a single value is an exact ``MatchValue``.
+    """
     if core_field == "title":
         return qmodels.Filter(
             should=[
@@ -910,11 +919,7 @@ def _build_metadata_filter_condition(
             ]
         )
     return qmodels.Filter(
-        must=[
-            qmodels.FieldCondition(
-                key=storage_field, match=qmodels.MatchValue(value=value)
-            )
-        ]
+        must=[qmodels.FieldCondition(key=storage_field, match=_filter_match(value))]
     )
 
 

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -115,8 +115,12 @@ def _resolve_pg_filter_fields(core_filters: Dict[str, Any], pg, source: str) -> 
     (the ``src_doc_raw_metadata`` JSONB). Filtering those against the Qdrant
     payload returns wrong/zero counts, so resolve each to its matching doc_ids
     here — the same source the facet counts come from — and AND them together.
-    Qdrant-resident fields (document_type, published_year, organization,
-    country, region, …) are left in ``core_filters`` as payload filters.
+    ``region`` is resolved the same way as in chunk search: its payload value is
+    a ``"; "``-joined string and region names contain commas, so only the
+    PostgreSQL containment lookup handles multi-region documents and
+    multi-select correctly. Qdrant-resident fields (document_type,
+    published_year, organization, country, …) are left in ``core_filters`` as
+    payload filters.
     """
     language = core_filters.pop("language", None)
     if language:
@@ -125,6 +129,7 @@ def _resolve_pg_filter_fields(core_filters: Dict[str, Any], pg, source: str) -> 
             doc_ids_from_pg_field(pg, "sys_language", str(language).split(",")),
         )
 
+    _convert_region_to_doc_ids(core_filters, pg)
     _convert_src_fields_to_doc_ids(core_filters, pg, source)
 
 

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -565,15 +565,51 @@ async def perform_title_search(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+# Above this many comma-separated parts a title filter is matched part by part
+# only, instead of trying every contiguous run of parts.
+_MAX_TITLE_PARTS = 50
+
+
+def _title_candidates(title_filter: str) -> List[str]:
+    """Exact-title candidates encoded in a comma-joined title filter.
+
+    The UI joins multi-select filter values with commas, but display titles
+    themselves often contain commas (``"…, 2016-2021"``), so the filter cannot
+    simply be split. Every contiguous run of the comma-split parts is rejoined
+    (with and without the space after the comma) and offered as a candidate, so
+    both ``"Title A,Title B"`` and a single ``"Region, 2016-2020"`` resolve to
+    the titles the user picked.
+    """
+    parts = [part.strip() for part in title_filter.split(",") if part.strip()]
+    candidates = {title_filter.strip(), *parts}
+    if len(parts) <= _MAX_TITLE_PARTS:
+        for start in range(len(parts)):
+            for end in range(start + 2, len(parts) + 1):
+                candidates.add(", ".join(parts[start:end]))
+                candidates.add(",".join(parts[start:end]))
+    return sorted(candidate for candidate in candidates if candidate)
+
+
+def _resolve_title_doc_ids(pg, title_filter: str) -> List[str]:
+    """doc_ids for a title filter: exact display titles (one or several, as
+    picked in the UI) unioned with the partial substring match of the raw value
+    that API callers rely on."""
+    doc_ids = set(pg.fetch_doc_ids_by_exact_titles(_title_candidates(title_filter)))
+    doc_ids.update(pg.fetch_doc_ids_by_title(title_filter))
+    return sorted(doc_ids)
+
+
 def _handle_title_filter(
     pg, core_filters: Dict[str, Any], q: str
 ) -> Optional[SearchResponse]:
+    """Replace a title filter with a doc_id constraint (intersected with any
+    existing one). Returns an empty response when no document matches."""
     title_filter = core_filters.get("title")
     if not title_filter:
         return None
 
     t_title_filter_start = time.time()
-    title_doc_ids = pg.fetch_doc_ids_by_title(title_filter)
+    title_doc_ids = _resolve_title_doc_ids(pg, title_filter)
     t_title_filter_end = time.time()
     logger.info(
         "[TIMING] title_doc_id_fetch: %.3fs (%s matches)",
@@ -588,7 +624,7 @@ def _handle_title_filter(
             filters={"title": [title_filter]},
         )
     core_filters.pop("title", None)
-    core_filters["doc_id"] = title_doc_ids
+    _intersect_doc_id_filter(core_filters, title_doc_ids)
     return None
 
 
@@ -908,16 +944,9 @@ def _build_metadata_filter_condition(
 
     A multi-select (list, or the UI's comma-joined string) becomes ``MatchAny``
     so the selected values OR within the field, exactly as in chunk search;
-    a single value is an exact ``MatchValue``.
+    a single value is an exact ``MatchValue``. ``title`` never reaches here:
+    it is resolved to a doc_id constraint by ``_handle_title_filter``.
     """
-    if core_field == "title":
-        return qmodels.Filter(
-            should=[
-                qmodels.FieldCondition(
-                    key=storage_field, match=qmodels.MatchText(text=value)
-                )
-            ]
-        )
     return qmodels.Filter(
         must=[qmodels.FieldCondition(key=storage_field, match=_filter_match(value))]
     )
@@ -1050,6 +1079,11 @@ async def docsearch(
         # "evaluation category" axis returns zero/under-counted results.
         _resolve_pg_filter_fields(core_filters, pg, source)
 
+        title_filter = core_filters.get("title")
+        early_response = _handle_title_filter(pg, core_filters, q)
+        if early_response:
+            return early_response
+
         combined_filter = _build_docsearch_filters(q, core_filters, indexed_doc_ids, db)
         if combined_filter is None:
             return SearchResponse(results=[], total=0, query=q, filters={})
@@ -1075,9 +1109,7 @@ async def docsearch(
             len(documents),
         )
 
-        filters_response = _build_filters_response(
-            core_filters, core_filters.get("title")
-        )
+        filters_response = _build_filters_response(core_filters, title_filter)
         return SearchResponse(
             results=documents, total=len(documents), query=q, filters=filters_response
         )

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -39,6 +39,7 @@ from ui.backend.utils.filter_helpers import (
     build_core_filters_from_params,
     build_needed_fields,
     collect_range_bounds,
+    expand_multivalue_filters,
     normalize_language_filter,
     resolve_storage_field,
     split_filter_values,
@@ -857,6 +858,8 @@ async def search(
         _convert_language_to_doc_ids(core_filters, pg)
         _convert_region_to_doc_ids(core_filters, pg)
         _convert_src_fields_to_doc_ids(core_filters, pg, source)
+        # Country/theme/… payloads may be "; "-joined; match the joined values too.
+        expand_multivalue_filters(db, core_filters, source)
 
         title_filter = core_filters.get("title")
         early_response = _handle_title_filter(pg, core_filters, q)
@@ -1078,6 +1081,8 @@ async def docsearch(
         # Heatmapper counts match the facets. Without this a "language" or
         # "evaluation category" axis returns zero/under-counted results.
         _resolve_pg_filter_fields(core_filters, pg, source)
+        # Country/theme/… payloads may be "; "-joined; match the joined values too.
+        expand_multivalue_filters(db, core_filters, source)
 
         title_filter = core_filters.get("title")
         early_response = _handle_title_filter(pg, core_filters, q)
@@ -1191,6 +1196,8 @@ async def get_facets(
             language,
         )
         add_dynamic_filters(core_filters, request.query_params, source)
+        # Country/theme/… payloads may be "; "-joined; match the joined values too.
+        expand_multivalue_filters(db, core_filters, source)
         title_filter = core_filters.get("title")
         if title_filter and q:
             title_doc_ids = pg.fetch_doc_ids_by_title(title_filter)

--- a/ui/backend/routes/search.py
+++ b/ui/backend/routes/search.py
@@ -72,7 +72,13 @@ def _intersect_doc_id_filter(core_filters: Dict[str, Any], doc_ids: List[str]) -
 
 
 def _convert_language_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:
-    """Replace language filter with doc_id filter (language not on chunks)."""
+    """Replace language filter with a doc_id filter (language is not on chunks).
+
+    The resolved doc_ids are intersected with any existing doc_id constraint so
+    document-level filters combine with AND, and a language that matches no
+    document pins the sentinel id so the search returns nothing instead of
+    silently dropping the filter.
+    """
     lang = core_filters.pop("language", None)
     if not lang:
         return
@@ -80,8 +86,7 @@ def _convert_language_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:
     if not lang_code:
         return
     doc_ids = pg.fetch_doc_ids_by_language(lang_code.split(","))
-    if doc_ids:
-        core_filters["doc_id"] = ",".join(doc_ids)
+    _intersect_doc_id_filter(core_filters, doc_ids)
 
 
 def _convert_region_to_doc_ids(core_filters: Dict[str, Any], pg) -> None:

--- a/ui/backend/utils/filter_helpers.py
+++ b/ui/backend/utils/filter_helpers.py
@@ -11,7 +11,10 @@ from pipeline.db import (
     get_taxonomy_filter_fields,
 )
 from ui.backend.utils.document_utils import map_core_field_to_storage
-from ui.backend.utils.facet_helpers import doc_ids_from_pg_jsonb
+from ui.backend.utils.facet_helpers import (
+    doc_ids_from_pg_jsonb,
+    expand_multivalue_filter,
+)
 from ui.backend.utils.language_codes import LANGUAGE_CODES
 
 
@@ -368,3 +371,45 @@ def resolve_doc_level_filters(
     resolved_ids = set.intersection(*constraints)
     result["doc_id"] = sorted(resolved_ids) if resolved_ids else [NO_MATCH_DOC_ID]
     return result
+
+
+# Core fields whose stored values are never "; "-joined, or that are resolved
+# to a doc_id constraint elsewhere, so multi-value expansion skips them.
+_MULTIVALUE_EXPANSION_SKIP = frozenset(
+    {"title", "doc_id", "language", "region", "published_year"}
+)
+
+
+def _is_expandable_filter(core_field: str, value: Any) -> bool:
+    """True for keyword payload filters whose stored values may be "; "-joined."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    if core_field in _MULTIVALUE_EXPANSION_SKIP:
+        return False
+    if core_field.startswith(("src_", "tag_")):
+        return False
+    return not core_field.endswith(("_min", "_max"))
+
+
+def expand_multivalue_filters(
+    db, core_filters: Dict[str, Any], data_source: Optional[str]
+) -> None:
+    """Expand keyword filters in place so "; "-joined payload values match.
+
+    Multi-valued document fields (country, theme, topic, …) are stored as one
+    ``"; "``-joined string (``"Kenya; Ethiopia"``) and faceted as individual
+    values, but a payload filter matches the whole string exactly, so selecting
+    ``Kenya`` misses every multi-country document. For each keyword filter this
+    adds the raw joined values that contain a selected value (see
+    :func:`expand_multivalue_filter`), turning the filter into a list that the
+    query builders apply as ``MatchAny``. A filter that gains nothing is left
+    untouched so single values keep their exact match.
+    """
+    for core_field, value in list(core_filters.items()):
+        if not _is_expandable_filter(core_field, value):
+            continue
+        selected = split_filter_values(value) or [value.strip()]
+        storage_field = resolve_storage_field(core_field, data_source)
+        expanded = expand_multivalue_filter(db, storage_field, selected)
+        if len(expanded) > len(selected):
+            core_filters[core_field] = sorted(expanded)

--- a/ui/frontend/src/App.tsx
+++ b/ui/frontend/src/App.tsx
@@ -2756,7 +2756,6 @@ function App() {
   );
 
   const activeFiltersCount = Object.values(filters).filter(Boolean).length;
-  const heatmapActiveFiltersCount = Object.values(heatmapFilters).filter(Boolean).length;
 
   // When search results are displayed, compute facet counts directly from
   // the actual results (deduped by doc_id) so counts exactly match what the
@@ -2921,7 +2920,6 @@ function App() {
       loadingConfig={loadingConfig}
       facetsDataSource={facetsDataSource}
       filtersExpanded={heatmapFiltersExpanded}
-      activeFiltersCount={heatmapActiveFiltersCount}
       onToggleFiltersExpanded={toggleHeatmapFiltersExpanded}
       onClearFilters={handleClearHeatmapFilters}
       facets={facets}

--- a/ui/frontend/src/components/app/HeatmapTabContent.tsx
+++ b/ui/frontend/src/components/app/HeatmapTabContent.tsx
@@ -49,7 +49,6 @@ interface HeatmapTabContentProps {
   loadingConfig: boolean;
   facetsDataSource: string | null;
   filtersExpanded: boolean;
-  activeFiltersCount: number;
   onToggleFiltersExpanded: () => void;
   onClearFilters: () => void;
   facets: Facets | null;
@@ -318,6 +317,13 @@ const ThumbnailCarousel = ({ documents, selectedDomain, filteredDocId, onSelectD
     </div>
   );
 };
+
+// Identifies the query a sensitivity cutoff was computed for: the row queries
+// when rows are search queries, otherwise the grid query.
+const buildCutoffQueryKey = (rowDimension: string, rowQueries: string[], gridQuery: string) =>
+  rowDimension === 'queries'
+    ? `queries:${rowQueries.map((query) => query.trim()).join(' ')}`
+    : `grid:${gridQuery.trim()}`;
 
 const buildExcludedFilterFields = (rowDimension: string, columnDimension: string) => {
   const excludedFields = new Set<string>();
@@ -1187,7 +1193,6 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
   loadingConfig,
   facetsDataSource,
   filtersExpanded,
-  activeFiltersCount,
   onToggleFiltersExpanded,
   onClearFilters,
   facets,
@@ -1292,7 +1297,11 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
   const [heatmapReady, setHeatmapReady] = useState<boolean>(false);
   const [infoModalOpen, setInfoModalOpen] = useState(false);
   const processingHighlightsRef = useRef<Set<string>>(new Set());
-  const userAdjustedCutoffRef = useRef(false);
+  // The sensitivity cutoff is pinned once set (auto-computed for a query, moved
+  // by the user, or read from the URL) so filter-only re-runs keep comparing
+  // against the same threshold; it is re-computed only when the query changes.
+  const cutoffPinnedRef = useRef(false);
+  const cutoffQueryKeyRef = useRef<string | null>(null);
   const heatmapUrlInitRef = useRef(false);
   const heatmapUrlHadYearFilterRef = useRef(false);
   const heatmapAutoRunRef = useRef(false);
@@ -1711,6 +1720,23 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     [getFieldValues, heatmapSelectedFilters]
   );
 
+  // Filters the next run will actually send: axis fields count when narrowed
+  // below all their values, every other field when it has a selection.
+  const heatmapActiveFiltersCount = useMemo(() => {
+    const axisFields = buildExcludedFilterFields(rowDimension, columnDimension);
+    return Object.entries(heatmapSelectedFilters).filter(([field, values]) =>
+      axisFields.has(field) ? isHeatmapFieldFiltered(field) : values.length > 0
+    ).length;
+  }, [columnDimension, heatmapSelectedFilters, isHeatmapFieldFiltered, rowDimension]);
+
+  // The heatmap keeps its own filter state, so "Clear filters" must reset it
+  // here; the parent's handler only clears the parent's copy.
+  const clearHeatmapFilters = useCallback(() => {
+    setHeatmapSelectedFilters({});
+    setHeatmapFilterSearchTerms({});
+    onClearFilters();
+  }, [onClearFilters]);
+
   const updateHeatmapURL = useCallback(
     (options?: { run?: boolean }) => {
       const url = new URL(window.location.href);
@@ -1789,6 +1815,14 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     const parsedSensitivity = urlSensitivity ? Number(urlSensitivity) : NaN;
     if (!Number.isNaN(parsedSensitivity)) {
       setSimilarityCutoff(parsedSensitivity);
+      // A shared link carries its sensitivity: pin it to the link's query so
+      // the auto-run does not replace it.
+      cutoffPinnedRef.current = true;
+      cutoffQueryKeyRef.current = buildCutoffQueryKey(
+        urlRow && rowOptions.some((option) => option.value === urlRow) ? urlRow : rowDimension,
+        urlRowQueries.length > 0 ? urlRowQueries : rowQueries,
+        urlQuery ?? gridQuery
+      );
     }
     if (urlRow === 'queries' && urlRowQueries.length > 0) {
       setRowQueries(urlRowQueries);
@@ -2282,11 +2316,12 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
   }, [gridResults]);
 
   useEffect(() => {
-    if (!scoreBounds.hasScores || userAdjustedCutoffRef.current) {
+    if (!scoreBounds.hasScores || cutoffPinnedRef.current) {
       return;
     }
     const cutoff = scoreBounds.max - HEATMAP_SCORE_PERCENTILE * (scoreBounds.max - scoreBounds.min);
     setSimilarityCutoff(cutoff);
+    cutoffPinnedRef.current = true;
   }, [scoreBounds]);
 
   const maxCellCount = useMemo(() => {
@@ -2408,7 +2443,15 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     setGridError(null);
     setGridResults({});
     setCappedCells(new Set());
-    userAdjustedCutoffRef.current = false;
+    // Only a changed query gets a fresh auto-computed cutoff. A re-run that
+    // merely changes filters keeps the current one, so excluding the documents
+    // that were above the threshold really empties the cells instead of
+    // promoting the next-best chunks.
+    const cutoffQueryKey = buildCutoffQueryKey(rowDimension, rowQueries, gridQuery);
+    if (cutoffQueryKeyRef.current !== cutoffQueryKey) {
+      cutoffQueryKeyRef.current = cutoffQueryKey;
+      cutoffPinnedRef.current = false;
+    }
     const controller = new AbortController();
     gridAbortRef.current = controller;
     const tasks: Array<() => Promise<void>> = [];
@@ -2521,6 +2564,7 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     rerankEnabled,
     rerankModel,
     rowDimension,
+    rowQueries,
     searchDenseWeight,
     searchModel,
     sectionTypes,
@@ -2912,7 +2956,7 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     <div className="main-content">
       <MobileFiltersToggle
         filtersExpanded={filtersExpanded}
-        activeFiltersCount={activeFiltersCount}
+        activeFiltersCount={heatmapActiveFiltersCount}
         onToggle={onToggleFiltersExpanded}
         label="More Filters"
       />
@@ -2921,7 +2965,7 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
         <HeatmapFiltersColumn
           filtersExpanded={filtersExpanded}
           onToggleFiltersExpanded={onToggleFiltersExpanded}
-          onClearFilters={onClearFilters}
+          onClearFilters={clearHeatmapFilters}
           filtersPanelProps={filtersPanelProps}
         />
 
@@ -3000,7 +3044,7 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
                   scoreBounds={scoreBounds}
                   similarityCutoff={similarityCutoff}
                   onCutoffChange={(value: number) => {
-                    userAdjustedCutoffRef.current = true;
+                    cutoffPinnedRef.current = true;
                     setSimilarityCutoff(value);
                   }}
                 />
@@ -3013,7 +3057,7 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
                   scoreBounds={scoreBounds}
                   similarityCutoff={similarityCutoff}
                   onCutoffChange={(value: number) => {
-                    userAdjustedCutoffRef.current = true;
+                    cutoffPinnedRef.current = true;
                     setSimilarityCutoff(value);
                   }}
                 />

--- a/ui/frontend/src/components/app/HeatmapTabContent.tsx
+++ b/ui/frontend/src/components/app/HeatmapTabContent.tsx
@@ -2042,10 +2042,12 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
       return null;
     }
     const baseValues = facets.facets[heatmapFilterModal.field] || [];
-    // Transform taxonomy values to display clean names
+    // Show taxonomy values by their clean name but keep the raw value: the
+    // selection and the axis values are raw, so a renamed value would never
+    // match and the axis could not be narrowed.
     const transformedValues = baseValues.map((facetValue) => ({
       ...facetValue,
-      value: extractTaxonomyName(facetValue.value, heatmapFilterModal.field),
+      label: extractTaxonomyName(facetValue.value, heatmapFilterModal.field),
     }));
     const orderedValues = sortFacetValues(transformedValues, modalSelectedValues);
     return {
@@ -2063,10 +2065,10 @@ export const HeatmapTabContent: React.FC<HeatmapTabContentProps> = ({
     if (!results) {
       return heatmapFacetSearchResults;
     }
-    // Transform taxonomy values to display clean names
+    // Clean name for display only; the raw value stays the filter value.
     const transformedResults = results.map((facetValue) => ({
       ...facetValue,
-      value: extractTaxonomyName(facetValue.value, field),
+      label: extractTaxonomyName(facetValue.value, field),
     }));
     return {
       ...heatmapFacetSearchResults,

--- a/ui/frontend/src/components/filters/FilterComponents.tsx
+++ b/ui/frontend/src/components/filters/FilterComponents.tsx
@@ -241,7 +241,7 @@ const computeDisplayItems = (
 
   const filteredItems = orderFacetValuesForDisplay(
     coreField,
-    facetValues.filter((item) => item.value.toLowerCase().includes(searchTerm))
+    facetValues.filter((item) => (item.label ?? item.value).toLowerCase().includes(searchTerm))
   );
   const remaining = filteredItems.length - defaultDisplayCount;
   return {
@@ -263,7 +263,8 @@ const FilterCheckboxList = ({
   return (
     <React.Fragment>
       {items.map((item) => {
-        const displayValue = isTag ? stripTagPrefix(item.value) : item.value;
+        // item.value is always the raw filter value; only the text shown changes.
+        const displayValue = item.label ?? (isTag ? stripTagPrefix(item.value) : item.value);
         return (
           <label
             key={item.value}

--- a/ui/frontend/src/tests/heatmapFilters.test.tsx
+++ b/ui/frontend/src/tests/heatmapFilters.test.tsx
@@ -1,0 +1,250 @@
+import React from 'react';
+import axios from 'axios';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { HeatmapTabContent } from '../components/app/HeatmapTabContent';
+import { Facets } from '../types/api';
+
+// The real FiltersPanel is rendered here: these tests exercise the side
+// filters (checkboxes, "Clear filters") that feed the heatmap's cell requests.
+jest.mock('../components/SearchResultsList', () => ({
+  SearchResultsList: () => <div>Search Results</div>,
+}));
+
+const GENERATE_HEATMAP = 'Generate Heatmap';
+const TUNE_QUERY = /Tune your heatmap using a search query/;
+const GRID_QUERY_PLACEHOLDER = 'Add a search query to filter the results for your heatmap ...';
+
+const buildFacets = (): Facets => ({
+  facets: {
+    published_year: [{ value: '2024', count: 5 }],
+    document_type: [{ value: 'IAHE', count: 2 }, { value: 'Activity', count: 3 }],
+    country: [{ value: 'Kenya', count: 4 }],
+  },
+  filter_fields: {
+    published_year: 'Year Published',
+    document_type: 'Document Type',
+    country: 'Country',
+  },
+});
+
+const noop = () => undefined;
+const baseProps = {
+  selectedDomain: 'wfp',
+  loadingConfig: false,
+  facetsDataSource: 'wfp',
+  filtersExpanded: true,
+  onToggleFiltersExpanded: noop,
+  onClearFilters: jest.fn(),
+  facets: buildFacets(),
+  filters: {},
+  selectedFilters: {},
+  collapsedFilters: new Set<string>(),
+  expandedFilterLists: new Set<string>(),
+  filterSearchTerms: {},
+  titleSearchResults: [],
+  facetSearchResults: {},
+  onRemoveFilter: noop,
+  onToggleFilter: noop,
+  onFilterSearchTermChange: noop,
+  onToggleFilterListExpansion: noop,
+  onFilterValuesChange: noop,
+  searchModel: null,
+  searchDenseWeight: 0.8,
+  onSearchDenseWeightChange: noop,
+  keywordBoostShortQueries: true,
+  onKeywordBoostChange: noop,
+  semanticHighlighting: true,
+  onSemanticHighlightingChange: noop,
+  minScore: 0,
+  maxScore: 1,
+  onMinScoreChange: noop,
+  rerankEnabled: false,
+  onRerankToggle: noop,
+  recencyBoostEnabled: false,
+  onRecencyBoostToggle: noop,
+  recencyWeight: 0.15,
+  onRecencyWeightChange: noop,
+  recencyScaleDays: 365,
+  onRecencyScaleDaysChange: noop,
+  rerankModel: null,
+  rerankModelPageSize: null,
+  minChunkSize: 0,
+  onMinChunkSizeChange: noop,
+  sectionTypes: [],
+  onSectionTypesChange: noop,
+  autoMinScore: false,
+  onAutoMinScoreToggle: noop,
+  deduplicateEnabled: true,
+  onDeduplicateToggle: noop,
+  wideSearch: false,
+  onWideSearchToggle: noop,
+  wideGroupSize: 5,
+  onWideGroupSizeChange: noop,
+  wideLimit: 20,
+  onWideLimitChange: noop,
+  groupByDocument: false,
+  onGroupByDocumentToggle: noop,
+  summaryLimitResults: true,
+  onSummaryLimitResultsChange: noop,
+  summaryMaxResults: 20,
+  onSummaryMaxResultsChange: noop,
+  summaryTemperature: 0,
+  onSummaryTemperatureChange: noop,
+  fieldBoostEnabled: false,
+  onFieldBoostToggle: noop,
+  fieldBoostFields: {},
+  onFieldBoostFieldsChange: noop,
+  selectedModelCombo: 'Azure Foundry',
+  dataSource: 'wfp',
+  selectedDoc: null,
+  onResultClick: noop,
+  onOpenMetadata: noop,
+  onLanguageChange: noop,
+};
+
+const cellRequestParams = (getSpy: jest.SpyInstance) =>
+  getSpy.mock.calls
+    .map(([url]) => String(url))
+    .filter((url) => /\/(doc)?search\?/.test(url))
+    .map((url) => new URLSearchParams(url.split('?')[1]));
+
+const openCountryFilter = () => {
+  // Filter sections start collapsed; the header toggles the checkbox list.
+  const header = screen.getAllByText('Country').find((el) => el.classList.contains('filter-section-title'));
+  fireEvent.click(header!.parentElement as HTMLElement);
+};
+
+const setGridQuery = (value: string) => {
+  fireEvent.click(screen.getByRole('button', { name: TUNE_QUERY }));
+  fireEvent.change(screen.getByPlaceholderText(GRID_QUERY_PLACEHOLDER), { target: { value } });
+};
+
+const cellTexts = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll('td.heatmap-cell')).map((cell) => cell.textContent);
+
+const resultsWithScores = (scores: number[]) => ({
+  data: {
+    results: scores.map((score, index) => ({
+      chunk_id: `c${index}`,
+      doc_id: `d${index}`,
+      text: '',
+      page_num: 1,
+      headings: [],
+      score,
+      title: `Doc ${index}`,
+      year: '2024',
+      organization: 'WFP',
+    })),
+  },
+});
+
+describe('Heatmap side filters', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/heatmap');
+  });
+
+  test('a side-panel selection is sent with every cell request and "Clear filters" removes it', async () => {
+    const getSpy = jest.spyOn(axios, 'get').mockResolvedValue({ data: { results: [] } });
+    const postSpy = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} });
+    try {
+      render(<HeatmapTabContent {...baseProps} />);
+      await waitFor(() => expect(screen.getByText('2024')).toBeInTheDocument());
+
+      openCountryFilter();
+      const kenya = screen.getByLabelText(/Kenya/) as HTMLInputElement;
+      fireEvent.click(kenya);
+      expect(kenya.checked).toBe(true);
+
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(cellRequestParams(getSpy).length).toBeGreaterThan(0));
+      await waitFor(() => expect(screen.getByRole('button', { name: GENERATE_HEATMAP })).toBeEnabled());
+      for (const params of cellRequestParams(getSpy)) {
+        expect(params.get('country')).toBe('Kenya');
+      }
+      getSpy.mockClear();
+
+      // Regression: the button used to clear only the parent's copy of the
+      // filters, so the next run still sent country=Kenya.
+      fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }));
+      expect(baseProps.onClearFilters).toHaveBeenCalled();
+      expect((screen.getByLabelText(/Kenya/) as HTMLInputElement).checked).toBe(false);
+
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(cellRequestParams(getSpy).length).toBeGreaterThan(0));
+      for (const params of cellRequestParams(getSpy)) {
+        expect(params.get('country')).toBeNull();
+      }
+    } finally {
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+    }
+  });
+
+  test('the sensitivity cutoff survives a filter-only re-run and resets when the query changes', async () => {
+    // Run 1: scores 0.9/0.5/0.1 → auto cutoff 0.74 → one document per cell.
+    // Run 2 (filter only): scores 0.5/0.4 → nothing above 0.74 → empty cells.
+    // Run 3 (new query): same scores → cutoff recomputed (0.48) → one document.
+    let scores = [0.9, 0.5, 0.1];
+    const getSpy = jest.spyOn(axios, 'get').mockImplementation((url) =>
+      /\/search\?/.test(String(url))
+        ? Promise.resolve(resultsWithScores(scores))
+        : Promise.resolve({ data: [] })
+    );
+    const postSpy = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} });
+    try {
+      const { container } = render(<HeatmapTabContent {...baseProps} />);
+      await waitFor(() => expect(screen.getByText('2024')).toBeInTheDocument());
+      setGridQuery('girls education');
+
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(cellTexts(container)).toEqual(['1', '1']));
+
+      scores = [0.5, 0.4];
+      openCountryFilter();
+      fireEvent.click(screen.getByLabelText(/Kenya/));
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(screen.getByRole('button', { name: GENERATE_HEATMAP })).toBeEnabled());
+      await waitFor(() => expect(cellTexts(container)).toEqual(['0', '0']));
+
+      scores = [0.5, 0.4];
+      fireEvent.change(screen.getByPlaceholderText(GRID_QUERY_PLACEHOLDER), { target: { value: 'school feeding' } });
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(cellTexts(container)).toEqual(['1', '1']));
+    } finally {
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+    }
+  });
+
+  test('the sensitivity moved by hand is kept for a filter-only re-run', async () => {
+    const getSpy = jest.spyOn(axios, 'get').mockImplementation((url) =>
+      /\/search\?/.test(String(url))
+        ? Promise.resolve(resultsWithScores([0.9, 0.5, 0.1]))
+        : Promise.resolve({ data: [] })
+    );
+    const postSpy = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} });
+    try {
+      const { container } = render(<HeatmapTabContent {...baseProps} />);
+      await waitFor(() => expect(screen.getByText('2024')).toBeInTheDocument());
+      setGridQuery('girls education');
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(cellTexts(container)).toEqual(['1', '1']));
+
+      // The slider is inverted (right = more results); its value maps to a
+      // cutoff of min + max - value. Move it to include every result.
+      const slider = container.querySelector('#heatmap-cutoff') as HTMLInputElement;
+      fireEvent.change(slider, { target: { value: String(0.9 + 0.1 - 0.05) } });
+      await waitFor(() => expect(cellTexts(container)).toEqual(['3', '3']));
+
+      openCountryFilter();
+      fireEvent.click(screen.getByLabelText(/Kenya/));
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(screen.getByRole('button', { name: GENERATE_HEATMAP })).toBeEnabled());
+      expect(cellTexts(container)).toEqual(['3', '3']);
+    } finally {
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+    }
+  });
+});

--- a/ui/frontend/src/tests/heatmapFilters.test.tsx
+++ b/ui/frontend/src/tests/heatmapFilters.test.tsx
@@ -20,11 +20,19 @@ const buildFacets = (): Facets => ({
     published_year: [{ value: '2024', count: 5 }],
     document_type: [{ value: 'IAHE', count: 2 }, { value: 'Activity', count: 3 }],
     country: [{ value: 'Kenya', count: 4 }],
+    region: [{ value: 'Asia and the Pacific', count: 3 }, { value: 'Eastern and Southern Africa', count: 2 }],
+    tag_sdg: [
+      { value: 'sdg1 - SDG1 - No Poverty', count: 3 },
+      { value: 'sdg2 - SDG2 - Zero Hunger', count: 2 },
+      { value: 'sdg4 - SDG4 - Quality Education', count: 1 },
+    ],
   },
   filter_fields: {
     published_year: 'Year Published',
     document_type: 'Document Type',
     country: 'Country',
+    region: 'Region',
+    tag_sdg: 'United Nations Sustainable Development Goals',
   },
 });
 
@@ -242,6 +250,42 @@ describe('Heatmap side filters', () => {
       fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
       await waitFor(() => expect(screen.getByRole('button', { name: GENERATE_HEATMAP })).toBeEnabled());
       expect(cellTexts(container)).toEqual(['3', '3']);
+    } finally {
+      getSpy.mockRestore();
+      postSpy.mockRestore();
+    }
+  });
+
+  test('narrowing a taxonomy axis in the row/column filter keeps only the picked values', async () => {
+    // Regression: the modal listed SDGs by their clean name while the axis and
+    // the selection used the raw "sdg1 - SDG1 - …" value, so ticking a goal
+    // appended a name that never matched and every column stayed.
+    const getSpy = jest.spyOn(axios, 'get').mockResolvedValue({ data: { results: [] } });
+    const postSpy = jest.spyOn(axios, 'post').mockResolvedValue({ data: {} });
+    try {
+      render(<HeatmapTabContent {...baseProps} />);
+      await waitFor(() => expect(screen.getByText('2024')).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('Rows'), { target: { value: 'region' } });
+      fireEvent.change(screen.getByLabelText('Columns'), { target: { value: 'tag_sdg' } });
+      await waitFor(() => expect(screen.getAllByText('SDG1 - No Poverty').length).toBeGreaterThan(0));
+
+      fireEvent.click(screen.getByRole('button', { name: 'Filter United Nations Sustainable Development Goals' }));
+      // Everything starts selected; clear, then keep a single goal.
+      fireEvent.click(screen.getByLabelText('Select all'));
+      const noPoverty = screen.getByLabelText(/SDG1 - No Poverty/) as HTMLInputElement;
+      fireEvent.click(noPoverty);
+      expect(noPoverty.checked).toBe(true);
+      expect((screen.getByLabelText(/SDG2 - Zero Hunger/) as HTMLInputElement).checked).toBe(false);
+      fireEvent.click(screen.getByRole('button', { name: 'Done' }));
+
+      fireEvent.click(screen.getByRole('button', { name: GENERATE_HEATMAP }));
+      await waitFor(() => expect(screen.getByRole('button', { name: GENERATE_HEATMAP })).toBeEnabled());
+      const params = cellRequestParams(getSpy);
+      // Two regions × the one remaining SDG column, sent as the raw value.
+      expect(params).toHaveLength(2);
+      for (const cell of params) {
+        expect(cell.get('tag_sdg')).toBe('sdg1 - SDG1 - No Poverty');
+      }
     } finally {
       getSpy.mockRestore();
       postSpy.mockRestore();

--- a/ui/frontend/src/tests/heatmapTabContent.test.tsx
+++ b/ui/frontend/src/tests/heatmapTabContent.test.tsx
@@ -32,7 +32,6 @@ const baseProps = {
   loadingConfig: false,
   facetsDataSource: 'wfp',
   filtersExpanded: false,
-  activeFiltersCount: 0,
   onToggleFiltersExpanded: jest.fn(),
   onClearFilters: jest.fn(),
   facets: buildFacets(),

--- a/ui/frontend/src/types/api.ts
+++ b/ui/frontend/src/types/api.ts
@@ -221,6 +221,7 @@ export interface SearchResponse {
 export interface FacetValue {
   value: string;
   count: number;
+  label?: string;  // Display text when it differs from the raw filter value (e.g. taxonomy names)
   organization?: string;  // For title facets - associated org
   published_year?: string;  // For title facets - associated year
 }


### PR DESCRIPTION
## Description

Heatmapper filters did not behave as the filter panel suggested. The reported case (query "barriers to girls education", rows = Evaluation Category, columns = Year, then excluding the IAHE document type) still showed a hit because the search sensitivity cutoff was recomputed from the score range of every run, so removing the winning document just promoted the next-best chunks. Investigating the filter path surfaced five further defects in the search routes, most of which also affect the Search tab. One commit per fix:

1. **Language filter with no matching documents** returned every chunk instead of nothing (`_convert_language_to_doc_ids` dropped the filter). It now intersects and pins the no-match sentinel like region does.
2. **Region in attribute mode** (`/docsearch`) matched the Qdrant payload exactly, missing `"; "`-joined multi-region documents and returning 0 for a multi-select. It is now resolved through the PostgreSQL containment lookup used by chunk search.
3. **Multi-select in attribute mode** sent a comma-joined string that `/docsearch` matched exactly, so picking two document types or years returned 0. Multi-selects become `MatchAny`, shared with the facet filter via `_filter_match`.
4. **Title multi-select** arrived comma-joined although titles contain commas, so it matched nothing in both modes. `_title_candidates` reconstructs every contiguous run of the parts as an exact-title candidate (unioned with the existing substring match), and the resolved ids now AND with other document-level constraints instead of replacing them.
5. **Multi-valued country/theme payloads** (`"Kenya; Ethiopia"`) were only matched exactly, so a Kenya filter found 8 of the 26 documents the facet counted. The previously unused `expand_multivalue_filter` helper is wired into `/search`, `/docsearch` and `/facets` through `expand_multivalue_filters`.
6. **Frontend**: "Clear filters" in the Heatmapper side panel cleared the parent's unused copy of the filter state, and the mobile badge counted that same copy; both now use the heatmap's own state. The sensitivity cutoff is pinned once set (auto, by hand, or from a shared link) and recomputed only when the query changes, so filter-only re-runs keep the same threshold and excluded documents really empty their cells.

7. **Taxonomy axis narrowing** (rows or columns set to an AI-generated tag field such as SDGs): the row/column filter modal listed the goals by their clean name while the selection and axis values used the raw `sdg1 - SDG1 - …` strings, so ticking a couple of goals never reduced the axis. The modal now keeps the raw value and shows the clean name via a new optional `FacetValue.label`.

Docs: `docs/using-evidence-lab/heatmapper.md` describes the sensitivity behaviour and multi-valued filters.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other: ___

## Testing
- [x] Tests pass locally (`pytest tests/unit/`: 1954 passed; frontend suite: 780 passed)
- [x] New tests added for new functionality (`tests/unit/test_multivalue_filters.py`, additions to `test_docsearch.py` / `test_region_filter.py`, `ui/frontend/src/tests/heatmapFilters.test.tsx` incl. the taxonomy-axis case)
- [x] Manual testing completed (each fix verified against the local WFP stack via the API and the UI; facet counts and heatmap cell counts now agree for document type, year, region, country, language and title filters, the reported IAHE case goes to 0 after excluding the type, and narrowing an SDG axis to a couple of goals now reduces the grid to those goals)

## Checklist
- [x] Code follows project style guidelines (pre-commit passes on every commit; ESLint warning count unchanged)
- [x] Self-review of code completed
- [x] Documentation updated
- [x] No breaking changes (or clearly documented) — behaviour change: the Heatmapper sensitivity slider no longer resets on every run, see docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
