### PR TITLE
feat(brief): show each cited document's year in the Word export references

### DIFF
--- a/docs/using-evidence-lab/brief.md
+++ b/docs/using-evidence-lab/brief.md
@@ -100,11 +100,11 @@ From a card you can **open**, **share** or **delete** a brief. **New brief** sta
 
 When your brief is ready, click **Export to Word** at the top right.
 
-The exported document mirrors what you see on screen: inline `[n]` citation numbers in the prose and a compiled **References** list at the end, laid out according to the **Group by document** checkboxes above that list (tick at most one):
+The exported document mirrors what you see on screen: inline `[n]` citation numbers in the prose and a compiled **References** list at the end, laid out according to the **Group by document** checkboxes above that list (tick at most one). Each reference adds the document's publication year after its title; a document with no recorded year shows its title alone.
 
-- **Neither ticked** — one line per citation, with its page: `[1] Title, p.32`.
-- **Group by document (multiple per document)** — one line per document listing each of its citation numbers with the page it points at: `Title, [1] p. 32, [2] p. 56`. The numbering is unchanged, so this is more compact when a brief leans on a handful of reports.
-- **Group by document (single per document)** — one number per document and no page numbers: `[1] Title`. Every passage cited from the same document shares that number, so the prose is renumbered too — `A fact happened. [1][3]` becomes `A fact happened. [1]` when both citations came from the same report. Clicking an inline number still opens the document at the passage it was cited from.
+- **Neither ticked** — one line per citation, with its page: `[1] Title, 2021, p.32`.
+- **Group by document (multiple per document)** — one line per document listing each of its citation numbers with the page it points at: `Title, 2021, [1] p. 32, [2] p. 56`. The numbering is unchanged, so this is more compact when a brief leans on a handful of reports.
+- **Group by document (single per document)** — one number per document and no page numbers: `[1] Title, 2021`. Every passage cited from the same document shares that number, so the prose is renumbered too — `A fact happened. [1][3]` becomes `A fact happened. [1]` when both citations came from the same report. Clicking an inline number still opens the document at the passage it was cited from.
 
 ![Export to Word button](/docs/images/brief/brief-export-button.png)
 

--- a/ui/frontend/src/components/brief/BriefTab.tsx
+++ b/ui/frontend/src/components/brief/BriefTab.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../hooks/useAuth';
 import { SearchResult, SourceReference, SummaryModelConfig } from '../../types/api';
 import { SearchSettings } from '../../types/auth';
 import { buildExportFilename, exportResultsToDocxBlob, ReferenceListLayout } from '../../utils/exportResultsToDocx';
+import { withDocumentYears } from '../../utils/briefExportYears';
 import { buildGlobalCitations } from './briefCitations';
 import { ReferenceGrouping } from './briefTypes';
 import { BriefCentral } from './BriefCentral';
@@ -400,10 +401,14 @@ export const BriefTab: React.FC<BriefTabProps> = ({
       setExportBusy(true);
       try {
         const { summary, results } = assembleBriefForExport(brief, dataSource);
+        // The exported References list shows each document's year after its
+        // title. Brief sources don't carry it, so look it up per cited document
+        // in the data source the brief was researched in (a saved brief records
+        // it; a new brief's sources are in the app's selected data source).
         const blob = await exportResultsToDocxBlob({
           query: brief.briefTitle || DEFAULT_BRIEF_TITLE,
           aiSummary: summary,
-          results,
+          results: await withDocumentYears(results, brief.briefDataSource ?? dataSource),
           dataSource,
           documentTitle: 'AI-generated Research Brief',
           summaryHeading: brief.briefTitle || DEFAULT_BRIEF_TITLE,

--- a/ui/frontend/src/components/brief/useBrief.ts
+++ b/ui/frontend/src/components/brief/useBrief.ts
@@ -208,6 +208,10 @@ export const useBrief = ({
   // False when the open brief was shared with (not owned by) this user.
   const [canEdit, setCanEdit] = useState(true);
   const [ownerName, setOwnerName] = useState<string | null>(null);
+  // The data source a saved brief was researched in, from its server record.
+  // Null for a new or local brief, whose sources are in the app's selected
+  // data source. The Word export looks cited documents up in this source.
+  const [briefDataSource, setBriefDataSource] = useState<string | null>(null);
 
   const briefIdRef = useRef<string | null>(null);
   // Stable Activity-log id for the current brief (one row per brief).
@@ -651,6 +655,7 @@ export const useBrief = ({
       briefIdRef.current = uid();
       briefActivityIdRef.current = activityId;
       remoteSavedRef.current = false;
+      setBriefDataSource(null);
       setCanEdit(true);
       setOwnerName(null);
       setBriefTitle(toTitleCase(topic));
@@ -673,6 +678,7 @@ export const useBrief = ({
     briefIdRef.current = uid();
     briefActivityIdRef.current = newActivityId();
     remoteSavedRef.current = false;
+    setBriefDataSource(null);
     setCanEdit(true);
     setOwnerName(null);
     setBriefTitle(DEFAULT_BRIEF_TITLE);
@@ -694,6 +700,7 @@ export const useBrief = ({
       briefIdRef.current = uid();
       briefActivityIdRef.current = newActivityId();
       remoteSavedRef.current = false;
+      setBriefDataSource(null);
       setCanEdit(true);
       setOwnerName(null);
       setBriefTitle(title.trim() || DEFAULT_BRIEF_TITLE);
@@ -1248,11 +1255,17 @@ export const useBrief = ({
   const applyLoadedBrief = useCallback(
     (
       entry: SavedBrief,
-      access: { canEdit: boolean; ownerName: string | null; saved: boolean },
+      access: {
+        canEdit: boolean;
+        ownerName: string | null;
+        saved: boolean;
+        dataSource: string | null;
+      },
     ) => {
       abortRef.current?.abort();
       briefIdRef.current = entry.id;
       remoteSavedRef.current = access.saved;
+      setBriefDataSource(access.dataSource);
       briefActivityIdRef.current = entry.activityId || newActivityId();
       setBriefTitle(entry.title);
       setQuery(entry.query);
@@ -1352,6 +1365,7 @@ export const useBrief = ({
               canEdit: full.can_edit,
               ownerName: full.owner_name,
               saved: true,
+              dataSource: full.data_source,
             }),
           )
           .catch((e) =>
@@ -1359,7 +1373,7 @@ export const useBrief = ({
           );
         return;
       }
-      applyLoadedBrief(entry, { canEdit: true, ownerName: null, saved: false });
+      applyLoadedBrief(entry, { canEdit: true, ownerName: null, saved: false, dataSource: null });
     },
     [remote, applyLoadedBrief],
   );
@@ -1394,6 +1408,7 @@ export const useBrief = ({
               canEdit: true,
               ownerName: null,
               saved: true,
+              dataSource: created.data_source,
             });
           })
           .catch((e) =>
@@ -1419,6 +1434,7 @@ export const useBrief = ({
     briefIdRef.current = null;
     briefActivityIdRef.current = null;
     remoteSavedRef.current = false;
+    setBriefDataSource(null);
     setStage('seed');
     setSections([]);
     setRegenFor(null);
@@ -1477,6 +1493,7 @@ export const useBrief = ({
     briefVoiceId,
     canEdit,
     ownerName,
+    briefDataSource,
     remote,
     voices: voices || [],
     // setters / actions

--- a/ui/frontend/src/tests/briefExportYears.test.ts
+++ b/ui/frontend/src/tests/briefExportYears.test.ts
@@ -1,0 +1,72 @@
+import axios from 'axios';
+import { withDocumentYears } from '../utils/briefExportYears';
+import type { SearchResult } from '../types/api';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+const result = (over: Partial<SearchResult>): SearchResult =>
+  ({
+    chunk_id: 'c1',
+    doc_id: 'd1',
+    title: 'A report',
+    text: 'excerpt',
+    score: 0.5,
+    page_num: 3,
+    headings: [],
+    metadata: {},
+    ...over,
+  }) as SearchResult;
+
+describe('withDocumentYears', () => {
+  beforeEach(() => {
+    mockedAxios.get.mockReset();
+  });
+
+  test('attaches each document year as a string and fetches every document once', async () => {
+    mockedAxios.get.mockImplementation(async (url: string) => {
+      if (url.endsWith('/document/d1')) return { data: { published_year: 2021 } };
+      if (url.endsWith('/document/d2')) return { data: { published_year: '2019' } };
+      throw new Error(`unexpected url ${url}`);
+    });
+    const results = [
+      result({ chunk_id: 'c1', doc_id: 'd1' }),
+      result({ chunk_id: 'c2', doc_id: 'd1', page_num: 9 }),
+      result({ chunk_id: 'c3', doc_id: 'd2' }),
+    ];
+
+    const out = await withDocumentYears(results, 'wfp');
+
+    expect(out.map((r) => r.year)).toEqual(['2021', '2021', '2019']);
+    expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringMatching(/\/document\/d1$/),
+      { params: { data_source: 'wfp' } },
+    );
+    // The input results are left untouched.
+    expect(results[0].year).toBeUndefined();
+  });
+
+  test('leaves results without a recorded year unchanged', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { published_year: null } });
+    const out = await withDocumentYears([result({})], 'wfp');
+    expect(out[0].year).toBeUndefined();
+  });
+
+  test('a failed lookup leaves that document without a year, warns, and keeps the others', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockedAxios.get.mockImplementation(async (url: string) => {
+      if (url.endsWith('/document/d9')) throw new Error('Request failed with status code 500');
+      return { data: { published_year: '2020' } };
+    });
+    const out = await withDocumentYears(
+      [result({ chunk_id: 'c1', doc_id: 'd9' }), result({ chunk_id: 'c2', doc_id: 'd1' })],
+      'wfp',
+    );
+    expect(out.map((r) => r.year)).toEqual([undefined, '2020']);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(/cited document d9: Request failed with status code 500/),
+    );
+    warn.mockRestore();
+  });
+});

--- a/ui/frontend/src/tests/exportBriefDocx.test.ts
+++ b/ui/frontend/src/tests/exportBriefDocx.test.ts
@@ -250,6 +250,56 @@ describe('brief Word export — references list layouts', () => {
   });
 });
 
+describe('brief Word export — document year in the references list', () => {
+  const YEAR = '2021';
+  const dated = [
+    result({ chunk_id: 'c1', doc_id: 'd1', page_num: 26, year: YEAR }),
+    result({ chunk_id: 'c2', doc_id: 'd1', page_num: 40, year: YEAR }),
+  ];
+  const withList = (
+    referenceList: 'flat' | 'grouped' | 'document',
+    results: SearchResult[],
+  ) => ({
+    ...BRIEF_OPTS,
+    aiSummary: '# Access\n\nEnrolment has risen [1] and stayed up [2].\n',
+    results,
+    resultsSectionTitle: REFERENCES,
+    referenceList,
+  });
+  const referencesText = async (opts: ReturnType<typeof withList>): Promise<string> => {
+    const xml = await documentXml(opts);
+    return xml.slice(xml.lastIndexOf(REFERENCES)).replace(/<[^>]+>/g, '');
+  };
+
+  test('flat: the year follows the title, before the page — "Title, 2021, p.26"', async () => {
+    const text = await referencesText(withList('flat', dated));
+    expect(text).toContain(`1. ${DOC_TITLE}, ${YEAR}, p.26`);
+    expect(text).toContain(`2. ${DOC_TITLE}, ${YEAR}, p.40`);
+  });
+
+  test('grouped: the year follows the title, before the citations', async () => {
+    const text = await referencesText(withList('grouped', dated));
+    expect(text).toContain(`${DOC_TITLE}, ${YEAR}, [1] p. 26, [2] p. 40`);
+  });
+
+  test('document: the year follows the title and there is still no page', async () => {
+    const text = await referencesText(withList('document', [dated[0]]));
+    expect(text).toContain(`1. ${DOC_TITLE}, ${YEAR}`);
+    expect(text).not.toContain('p.26');
+  });
+
+  test.each(['flat', 'grouped', 'document'] as const)(
+    '%s: a result without a year keeps the title alone',
+    async (referenceList) => {
+      const text = await referencesText(
+        withList(referenceList, [result({ chunk_id: 'c1', doc_id: 'd1', page_num: 26 })]),
+      );
+      expect(text).toContain(DOC_TITLE);
+      expect(text).not.toMatch(new RegExp(`${DOC_TITLE}, \\d{4}`));
+    },
+  );
+});
+
 describe('brief Word export — a single References section', () => {
   // Count "References" heading paragraphs (w:pStyle Heading1/Heading2) in the
   // document body.

--- a/ui/frontend/src/tests/useBriefDataSource.test.ts
+++ b/ui/frontend/src/tests/useBriefDataSource.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { RemoteBrief } from '../components/brief/briefTypes';
+import { useBrief } from '../components/brief/useBrief';
+
+jest.mock('../config', () => ({
+  __esModule: true,
+  default: '/api',
+  API_KEY: undefined,
+  USER_MODULE: true,
+}));
+
+jest.mock('../utils/briefStream', () => ({
+  __esModule: true,
+  requestBriefOutline: jest.fn(),
+  researchBriefSection: jest.fn(),
+  runDeepResearch: jest.fn(),
+}));
+
+const mockGetBrief = jest.fn();
+jest.mock('../components/brief/briefCentralApi', () => ({
+  __esModule: true,
+  createBrief: jest.fn(),
+  deleteBriefRemote: jest.fn(),
+  getBrief: (...args: unknown[]) => mockGetBrief(...args),
+  listMyBriefs: jest.fn(async () => []),
+  updateBrief: jest.fn(),
+}));
+
+const TITLE = 'School feeding';
+
+const remoteBrief = (dataSource: string | null): RemoteBrief => ({
+  id: 'b-1',
+  user_id: 'u-1',
+  title: TITLE,
+  query: 'school feeding',
+  data_source: dataSource,
+  voice_profile_id: null,
+  content: {
+    id: 'b-1',
+    title: TITLE,
+    query: 'school feeding',
+    date: Date.now(),
+    sectionCount: 0,
+    sourceCount: 0,
+    sections: [],
+  },
+  owner_name: null,
+  can_edit: true,
+  shared_with: [],
+  created_at: '2026-09-01T10:00:00Z',
+  updated_at: '2026-09-01T10:00:00Z',
+});
+
+const renderBrief = () =>
+  renderHook(() =>
+    useBrief({ apiBaseUrl: '/api', dataSource: 'uneg', userKey: 'u-1', remote: true }),
+  );
+
+describe('useBrief briefDataSource', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  test('is null until a saved brief is opened, then the data source it was saved under', async () => {
+    mockGetBrief.mockResolvedValue(remoteBrief('wfp'));
+    const { result } = renderBrief();
+    expect(result.current.briefDataSource).toBeNull();
+
+    await act(async () => {
+      result.current.openBriefById('b-1');
+    });
+    await waitFor(() => expect(result.current.briefDataSource).toBe('wfp'));
+  });
+
+  test('stays null for a saved brief with no recorded data source', async () => {
+    mockGetBrief.mockResolvedValue(remoteBrief(null));
+    const { result } = renderBrief();
+    await act(async () => {
+      result.current.openBriefById('b-1');
+    });
+    await waitFor(() => expect(result.current.briefTitle).toBe(TITLE));
+    expect(result.current.briefDataSource).toBeNull();
+  });
+
+  test('clears when a new brief is started', async () => {
+    mockGetBrief.mockResolvedValue(remoteBrief('wfp'));
+    const { result } = renderBrief();
+    await act(async () => {
+      result.current.openBriefById('b-1');
+    });
+    await waitFor(() => expect(result.current.briefDataSource).toBe('wfp'));
+
+    act(() => {
+      result.current.startManual();
+    });
+    expect(result.current.briefDataSource).toBeNull();
+  });
+});

--- a/ui/frontend/src/utils/briefExportYears.ts
+++ b/ui/frontend/src/utils/briefExportYears.ts
@@ -1,0 +1,53 @@
+/**
+ * Attach each cited document's publication year to a brief's export results.
+ *
+ * Brief citations carry a document's title, page and links but not its year,
+ * which lives on the documents table. The Word export shows the year in its
+ * References list (as the search export does), so before the document is built
+ * the export looks the year up once per cited document through the document
+ * metadata endpoint. The year is decoration on the reference, so a document
+ * whose lookup fails (for example one no longer in the library) is exported
+ * without a year and the failure is logged, rather than blocking the export.
+ */
+import axios from 'axios';
+import API_BASE_URL from '../config';
+import type { SearchResult } from '../types/api';
+
+const yearOf = (payload: unknown): string => {
+  const raw = (payload as { published_year?: string | number | null } | null)?.published_year;
+  return raw === undefined || raw === null ? '' : String(raw).trim();
+};
+
+const fetchDocumentYear = async (docId: string, dataSource: string): Promise<string> => {
+  try {
+    const response = await axios.get(`${API_BASE_URL}/document/${encodeURIComponent(docId)}`, {
+      params: { data_source: dataSource },
+    });
+    return yearOf(response.data);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    console.warn(`Brief export: no publication year for cited document ${docId}: ${detail}`);
+    return '';
+  }
+};
+
+/** Return a copy of `results` with `year` set from each document's metadata.
+ *  Each distinct `doc_id` is fetched once; a document without a recorded year,
+ *  or whose lookup fails, leaves its results unchanged. */
+export const withDocumentYears = async (
+  results: SearchResult[],
+  dataSource: string,
+): Promise<SearchResult[]> => {
+  const docIds = Array.from(new Set(results.map((r) => r.doc_id).filter(Boolean)));
+  const years = new Map<string, string>();
+  await Promise.all(
+    docIds.map(async (docId) => {
+      const year = await fetchDocumentYear(docId, dataSource);
+      if (year) years.set(docId, year);
+    }),
+  );
+  return results.map((r) => {
+    const year = years.get(r.doc_id);
+    return year ? { ...r, year } : r;
+  });
+};

--- a/ui/frontend/src/utils/exportResultsToDocx.ts
+++ b/ui/frontend/src/utils/exportResultsToDocx.ts
@@ -1096,10 +1096,18 @@ const referenceTitleOf = (r: SearchResult): string =>
   (typeof r.document_title === 'string' && r.document_title.trim()) ||
   '(untitled document)';
 
+/** The document's publication year as a title suffix — ", 2021" — so a
+ *  reference reads "Title, 2021". Empty when the result carries no year, so
+ *  the row reads as before. */
+const referenceYearOf = (r: SearchResult): string => {
+  const year = r.year ? String(r.year).trim() : '';
+  return year ? `, ${year}` : '';
+};
+
 /**
- * One row per document, exactly as the Brief shows it on screen with
- * "Group by document (multiple per document)":
- *   Title, [1] p. 32, [2] p. 56
+ * One row per document, as the Brief shows it on screen with "Group by
+ * document (multiple per document)", plus the document's year:
+ *   Title, 2021, [1] p. 32, [2] p. 56
  * The title links to the document; each [n] and its page link to that
  * citation's page. As on screen, a number is shown once per run of the same
  * citation, so a document cited from many pages reads "[1] p. 9, p. 11".
@@ -1128,6 +1136,8 @@ const buildGroupedReferenceRows = (
         children: [new TextRun({ text: referenceTitleOf(result), style: 'Hyperlink' })],
       }),
     ];
+    const year = referenceYearOf(result);
+    if (year) children.push(new TextRun({ text: year }));
     cites.forEach((cite, i) => {
       const link = resolveResultLink(cite.result, siteOrigin, dataSource);
       children.push(new TextRun({ text: ', ' }));
@@ -1153,8 +1163,8 @@ const buildGroupedReferenceRows = (
   return rows;
 };
 
-/** One row per citation — "1. Title, p.26" — or, for document-level
- *  citations, "1. Title" with no page. */
+/** One row per citation — "1. Title, 2021, p.26" — or, for document-level
+ *  citations, "1. Title, 2021" with no page. */
 const buildNumberedReferenceRows = (
   results: SearchResult[],
   siteOrigin: string,
@@ -1163,13 +1173,14 @@ const buildNumberedReferenceRows = (
 ): Paragraph[] =>
   results.map((result, idx) => {
     const page = withPages && result.page_num ? `, p.${result.page_num}` : '';
+    const label = `${referenceTitleOf(result)}${referenceYearOf(result)}${page}`;
     return new Paragraph({
       spacing: { after: 60 },
       children: [
         new TextRun({ text: `${idx + 1}. `, bold: true }),
         new ExternalHyperlink({
           link: resolveResultLink(result, siteOrigin, dataSource),
-          children: [new TextRun({ text: `${referenceTitleOf(result)}${page}`, style: 'Hyperlink' })],
+          children: [new TextRun({ text: label, style: 'Hyperlink' })],
         }),
       ],
     });
@@ -1180,7 +1191,8 @@ const buildNumberedReferenceRows = (
  * one line per citation with its page ('flat'), one line per document listing
  * each of its citation numbers with their pages ('grouped'), or one line per
  * document-level citation with no page ('document'). Mirrors what the Brief
- * shows on screen so the export matches the reader's view.
+ * shows on screen so the export matches the reader's view, adding each
+ * document's publication year after its title as the search export does.
  */
 const buildReferenceList = (
   results: SearchResult[],


### PR DESCRIPTION
## Description

The brief's **Export to Word** now adds the publication year after each document title in the References list, in all three layouts:

- Neither grouping ticked: `1. Title, 2021, p.26`
- Group by document (multiple): `Title, 2021, [1] p. 26, [2] p. 40`
- Group by document (single): `1. Title, 2021`

A document with no recorded year keeps its title alone.

Brief sources carry no year, so the export looks it up once per cited document from the existing `/document/{doc_id}` endpoint before building the file. Saved briefs record the data source they were researched in; `useBrief` now exposes it as `briefDataSource` and the lookup uses it, falling back to the app's selected data source only for briefs without one. A document that cannot be resolved (for example one no longer in the library) is exported without a year and logged, so it never blocks the export.

Scope: Word export only. On-screen citations, numbering, the brief stream payload and the backend are unchanged.

## Type of Change
- [x] New feature

## Testing
- [x] Tests pass locally (frontend suite in the `ui` container: 837 passed)
- [x] New tests added: year rendering in all three layouts and the no-year case (`exportBriefDocx.test.ts`), the year lookup incl. deduplication and failure tolerance (`briefExportYears.test.ts`), and the hook's `briefDataSource` lifecycle (`useBriefDataSource.test.ts`)
- [x] Manual testing completed: exported briefs locally with the app on a different data source than the brief's

Note: `src/tests/app.test.tsx › loads config and navigates tabs` fails intermittently in the local `ui` container on a clean `rc/v1.6.2` tree as well (3/3 runs), so it is unrelated to this change.

## Checklist
- [x] Code follows project style guidelines (pre-commit, eslint, tsc, code metrics pass on changed files)
- [x] Self-review of code completed
- [x] Documentation updated (`docs/using-evidence-lab/brief.md`)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
